### PR TITLE
feat(consensus): Recycle RPC TxType [RFC]

### DIFF
--- a/crates/op-consensus/Cargo.toml
+++ b/crates/op-consensus/Cargo.toml
@@ -13,6 +13,7 @@ exclude.workspace = true
 
 [dependencies]
 alloy-primitives = { workspace = true, features = ["rlp"] }
+alloy-op-rpc-types.workspace = true
 alloy-consensus.workspace = true
 alloy-rlp.workspace = true
 alloy-eips.workspace = true
@@ -32,8 +33,31 @@ serde_json.workspace = true
 
 [features]
 default = ["std"]
-std = ["alloy-eips/std", "alloy-consensus/std"]
+std = [
+  "alloy-eips/std",
+  "alloy-consensus/std",
+  "alloy-op-rpc-types/std",
+]
 k256 = ["alloy-primitives/k256", "alloy-consensus/k256"]
-kzg = ["alloy-eips/kzg", "alloy-consensus/kzg", "std"]
-arbitrary = ["std", "dep:arbitrary", "alloy-consensus/arbitrary", "alloy-eips/arbitrary", "alloy-primitives/rand"]
-serde = ["dep:serde", "dep:alloy-serde", "alloy-primitives/serde", "alloy-consensus/serde", "alloy-eips/serde"]
+kzg = [
+  "std",
+  "alloy-eips/kzg",
+  "alloy-consensus/kzg",
+  "alloy-op-rpc-types/kzg",
+]
+arbitrary = [
+  "std",
+  "dep:arbitrary",
+  "alloy-consensus/arbitrary",
+  "alloy-eips/arbitrary",
+  "alloy-primitives/rand",
+  "alloy-op-rpc-types/arbitrary",
+]
+serde = [
+  "dep:serde",
+  "dep:alloy-serde",
+  "alloy-primitives/serde",
+  "alloy-consensus/serde",
+  "alloy-eips/serde",
+  "alloy-op-rpc-types/serde",
+]

--- a/crates/op-consensus/src/lib.rs
+++ b/crates/op-consensus/src/lib.rs
@@ -23,4 +23,4 @@ mod receipt;
 pub use receipt::{OpDepositReceipt, OpReceiptEnvelope, OpReceiptWithBloom, OpTxReceipt};
 
 mod transaction;
-pub use transaction::{OpTxEnvelope, OpTxType, OpTypedTransaction, TxDeposit};
+pub use transaction::{OpTxEnvelope, OpTypedTransaction, TxDeposit};

--- a/crates/op-consensus/src/receipt/envelope.rs
+++ b/crates/op-consensus/src/receipt/envelope.rs
@@ -1,4 +1,5 @@
-use crate::{OpDepositReceipt, OpReceiptWithBloom, OpTxType};
+use crate::{OpDepositReceipt, OpReceiptWithBloom};
+use alloy_op_rpc_types::transaction::TxType;
 use alloy_eips::eip2718::{Decodable2718, Encodable2718};
 use alloy_primitives::{Bloom, Log};
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable};
@@ -45,13 +46,13 @@ pub enum OpReceiptEnvelope<T = Log> {
 
 impl<T> OpReceiptEnvelope<T> {
     /// Return the [`OpTxType`] of the inner receipt.
-    pub const fn tx_type(&self) -> OpTxType {
+    pub const fn tx_type(&self) -> TxType {
         match self {
-            Self::Legacy(_) => OpTxType::Legacy,
-            Self::Eip2930(_) => OpTxType::Eip2930,
-            Self::Eip1559(_) => OpTxType::Eip1559,
-            Self::Eip4844(_) => OpTxType::Eip4844,
-            Self::Deposit(_) => OpTxType::Deposit,
+            Self::Legacy(_) => TxType::Legacy,
+            Self::Eip2930(_) => TxType::Eip2930,
+            Self::Eip1559(_) => TxType::Eip1559,
+            Self::Eip4844(_) => TxType::Eip4844,
+            Self::Deposit(_) => TxType::Deposit,
         }
     }
 
@@ -158,10 +159,10 @@ impl Encodable2718 for OpReceiptEnvelope {
     fn type_flag(&self) -> Option<u8> {
         match self {
             Self::Legacy(_) => None,
-            Self::Eip2930(_) => Some(OpTxType::Eip2930 as u8),
-            Self::Eip1559(_) => Some(OpTxType::Eip1559 as u8),
-            Self::Eip4844(_) => Some(OpTxType::Eip4844 as u8),
-            Self::Deposit(_) => Some(OpTxType::Deposit as u8),
+            Self::Eip2930(_) => Some(TxType::Eip2930 as u8),
+            Self::Eip1559(_) => Some(TxType::Eip1559 as u8),
+            Self::Eip4844(_) => Some(TxType::Eip4844 as u8),
+            Self::Deposit(_) => Some(TxType::Deposit as u8),
         }
     }
 
@@ -182,13 +183,13 @@ impl Decodable2718 for OpReceiptEnvelope {
     fn typed_decode(ty: u8, buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         let receipt = Decodable::decode(buf)?;
         match ty.try_into().map_err(|_| alloy_rlp::Error::Custom("Unexpected type"))? {
-            OpTxType::Legacy => {
+            TxType::Legacy => {
                 Err(alloy_rlp::Error::Custom("type-0 eip2718 transactions are not supported"))
             }
-            OpTxType::Eip2930 => Ok(Self::Eip2930(receipt)),
-            OpTxType::Eip1559 => Ok(Self::Eip1559(receipt)),
-            OpTxType::Eip4844 => Ok(Self::Eip4844(receipt)),
-            OpTxType::Deposit => Ok(Self::Deposit(receipt)),
+            TxType::Eip2930 => Ok(Self::Eip2930(receipt)),
+            TxType::Eip1559 => Ok(Self::Eip1559(receipt)),
+            TxType::Eip4844 => Ok(Self::Eip4844(receipt)),
+            TxType::Deposit => Ok(Self::Deposit(receipt)),
         }
     }
 
@@ -197,7 +198,7 @@ impl Decodable2718 for OpReceiptEnvelope {
     }
 }
 
-#[cfg(all(test, feature = "arbitrary"))]
+#[cfg(any(test, feature = "arbitrary"))]
 impl<'a, T> arbitrary::Arbitrary<'a> for OpReceiptEnvelope<T>
 where
     T: arbitrary::Arbitrary<'a>,

--- a/crates/op-consensus/src/receipt/receipts.rs
+++ b/crates/op-consensus/src/receipt/receipts.rs
@@ -231,7 +231,7 @@ impl alloy_rlp::Decodable for OpReceiptWithBloom {
     }
 }
 
-#[cfg(all(test, feature = "arbitrary"))]
+#[cfg(any(test, feature = "arbitrary"))]
 impl<'a, T> arbitrary::Arbitrary<'a> for OpDepositReceipt<T>
 where
     T: arbitrary::Arbitrary<'a>,
@@ -252,7 +252,7 @@ where
     }
 }
 
-#[cfg(all(test, feature = "arbitrary"))]
+#[cfg(any(test, feature = "arbitrary"))]
 impl<'a, T> arbitrary::Arbitrary<'a> for OpReceiptWithBloom<T>
 where
     T: arbitrary::Arbitrary<'a>,

--- a/crates/op-consensus/src/transaction/mod.rs
+++ b/crates/op-consensus/src/transaction/mod.rs
@@ -2,7 +2,7 @@ mod optimism;
 pub use optimism::TxDeposit;
 
 mod envelope;
-pub use envelope::{OpTxEnvelope, OpTxType};
+pub use envelope::OpTxEnvelope;
 
 mod typed;
 pub use typed::OpTypedTransaction;

--- a/crates/op-consensus/src/transaction/typed.rs
+++ b/crates/op-consensus/src/transaction/typed.rs
@@ -1,4 +1,5 @@
-use crate::{OpTxEnvelope, OpTxType, TxDeposit};
+use crate::{OpTxEnvelope, TxDeposit};
+use alloy_op_rpc_types::transaction::TxType;
 use alloy_consensus::{Transaction, TxEip1559, TxEip2930, TxEip4844Variant, TxLegacy};
 use alloy_primitives::TxKind;
 
@@ -76,13 +77,13 @@ impl From<OpTxEnvelope> for OpTypedTransaction {
 
 impl OpTypedTransaction {
     /// Return the [`OpTxType`] of the inner txn.
-    pub const fn tx_type(&self) -> OpTxType {
+    pub const fn tx_type(&self) -> TxType {
         match self {
-            Self::Legacy(_) => OpTxType::Legacy,
-            Self::Eip2930(_) => OpTxType::Eip2930,
-            Self::Eip1559(_) => OpTxType::Eip1559,
-            Self::Eip4844(_) => OpTxType::Eip4844,
-            Self::Deposit(_) => OpTxType::Deposit,
+            Self::Legacy(_) => TxType::Legacy,
+            Self::Eip2930(_) => TxType::Eip2930,
+            Self::Eip1559(_) => TxType::Eip1559,
+            Self::Eip4844(_) => TxType::Eip4844,
+            Self::Deposit(_) => TxType::Deposit,
         }
     }
 

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -13,27 +13,34 @@ exclude.workspace = true
 
 [dependencies]
 alloy-primitives = { workspace = true, features = ["rlp", "serde", "std"] }
-alloy-consensus = { workspace = true, features = ["std", "serde"] }
 alloy-rpc-types.workspace = true
+alloy-eips.workspace = true
 
-serde = { workspace = true, features = ["derive"] }
-serde_json.workspace = true
-
-# arbitrary
+serde_json = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["arbitrary"] }
-alloy-consensus = { workspace = true, features = ["arbitrary"] }
 alloy-rpc-types = { workspace = true, features = ["arbitrary"] }
 
 arbitrary = { workspace = true, features = ["derive"] }
 rand.workspace = true
 
 [features]
+default = ["std"]
+std = ["alloy-eips/std"]
+kzg = ["std", "alloy-eips/kzg"]
 arbitrary = [
+    "std",
     "dep:arbitrary",
+    "alloy-eips/arbitrary",
     "alloy-primitives/arbitrary",
-    "alloy-consensus/arbitrary",
     "alloy-rpc-types/arbitrary",
+]
+serde = [
+  "dep:serde",
+  "dep:serde_json",
+  "alloy-eips/serde",
+  "alloy-primitives/serde",
 ]

--- a/crates/rpc-types/src/lib.rs
+++ b/crates/rpc-types/src/lib.rs
@@ -13,5 +13,9 @@
 )]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 pub mod transaction;

--- a/crates/rpc-types/src/transaction/mod.rs
+++ b/crates/rpc-types/src/transaction/mod.rs
@@ -1,31 +1,30 @@
 //! Optimism specific types related to transactions.
 
 use alloy_primitives::B256;
-use serde::{Deserialize, Serialize};
-
-pub use self::tx_type::TxType;
 
 pub mod tx_type;
+pub use tx_type::TxType;
 
 /// OP Transaction type
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Transaction {
     /// Ethereum Transaction Types
-    #[serde(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub inner: alloy_rpc_types::Transaction,
     /// The ETH value to mint on L2
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub mint: Option<u128>,
     /// Hash that uniquely identifies the source of the deposit.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub source_hash: Option<B256>,
     /// Field indicating whether the transaction is a system transaction, and therefore
     /// exempt from the L2 gas limit.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub is_system_tx: Option<bool>,
     /// Deposit receipt version for deposit transactions post-canyon
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub deposit_receipt_version: Option<u64>,
 }

--- a/crates/rpc-types/src/transaction/tx_type.rs
+++ b/crates/rpc-types/src/transaction/tx_type.rs
@@ -1,6 +1,7 @@
 //! OP transaction identifiers.
 
-use serde::{Deserialize, Serialize};
+use alloy_eips::eip2718::Eip2718Error;
+use core::mem;
 
 /// Identifier for legacy transaction, however a legacy tx is technically not
 /// typed.
@@ -18,10 +19,16 @@ pub const EIP4844_TX_TYPE_ID: u8 = 3;
 /// Identifier for an Optimism deposit transaction
 pub const DEPOSIT_TX_TYPE_ID: u8 = 126;
 
-/// Transaction Type
-#[derive(
-    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Default, Serialize, Deserialize, Hash,
-)]
+/// Optimism `TransactionType` as specified in EIPs [2718], [1559], and
+/// [2930], as well as the [deposit transaction spec][deposit-spec]
+///
+/// [2718]: https://eips.ethereum.org/EIPS/eip-2718
+/// [1559]: https://eips.ethereum.org/EIPS/eip-1559
+/// [2930]: https://eips.ethereum.org/EIPS/eip-2930
+/// [4844]: https://eips.ethereum.org/EIPS/eip-4844
+/// [deposit-spec]: https://specs.optimism.io/protocol/deposits.html
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TxType {
     /// Legacy transaction pre EIP-2929
     #[default]
@@ -36,6 +43,20 @@ pub enum TxType {
     Deposit = 126_isize,
 }
 
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for TxType {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        Ok(match u.int_in_range(0..=3)? {
+            0 => TxType::Legacy,
+            1 => TxType::Eip2930,
+            2 => TxType::Eip1559,
+            3 => TxType::Eip4844,
+            0x7E => TxType::Deposit,
+            _ => unreachable!(),
+        })
+    }
+}
+
 impl From<TxType> for u8 {
     fn from(value: TxType) -> Self {
         match value {
@@ -47,3 +68,16 @@ impl From<TxType> for u8 {
         }
     }
 }
+
+impl TryFrom<u8> for TxType {
+    type Error = Eip2718Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            // SAFETY: repr(u8) with explicit discriminant
+            0..=3 | 0x7E => Ok(unsafe { mem::transmute::<u8, TxType>(value) }),
+            _ => Err(Eip2718Error::UnexpectedType(value)),
+        }
+    }
+}
+


### PR DESCRIPTION
**Description**

Recycles the `alloy-op-rpc-types` `TxType`. Curious to hear if this makes sense to folks.