### PR TITLE
fix(consensus): Re-export Traits

### DIFF
--- a/crates/op-consensus/src/lib.rs
+++ b/crates/op-consensus/src/lib.rs
@@ -19,6 +19,15 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+// Re-export EIP2718 Types and Traits
+pub use alloy_eips::eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718};
+
+// Re-export Alloy RLP Traits
+pub use alloy_rlp::{Decodable, Encodable};
+
+// Re-export Alloy Consensus Types
+pub use alloy_consensus::{Eip658Value, Receipt, ReceiptWithBloom, Transaction, TxReceipt};
+
 mod receipt;
 pub use receipt::{OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptEnvelope, OpTxReceipt};
 


### PR DESCRIPTION
**Description**

Since alloy dependencies are imported by github, versioning dependencies can get ugly downstream if a specific revision is imported.

To avoid dependency clashes, re-export necessary traits for downstream use. This allows crates and workspaces like kona to specify external dependency revisions (e.g. importing `alloy_eips` with a specific revision) while also importing the `op-alloy-consensus` on `main` branch along with it's EIP-2718 Encoding and Decoding traits, avoiding a dependency clash with  the `alloy_eips` crate.

Example: https://github.com/ethereum-optimism/kona/pull/267