### PR TITLE
Include deposit tx type in `alloy_network::Network` impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ alloy-signer = { version = "0.2", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 
+# misc
+derive_more = { version = "0.99", default-features = false }
+
 ## misc-testing
 arbitrary = { version = "1.3", features = ["derive"] }
 rand = "0.8"

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -24,6 +24,9 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 # serde
 serde = { workspace = true, features = ["derive"], optional = true }
 
+# misc
+derive_more = { workspace = true, features = ["display"] }
+
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["rand"] }
 alloy-signer.workspace = true

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -52,6 +52,12 @@ impl<'a> arbitrary::Arbitrary<'a> for OpTxType {
     }
 }
 
+impl From<OpTxType> for u8 {
+    fn from(v: OpTxType) -> u8 {
+        v as u8
+    }
+}
+
 impl TryFrom<u8> for OpTxType {
     type Error = Eip2718Error;
 

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1,9 +1,11 @@
-use crate::TxDeposit;
 use alloy_consensus::{
     Signed, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip4844WithSidecar, TxLegacy,
 };
 use alloy_eips::eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718};
 use alloy_rlp::{Decodable, Encodable, Header};
+use derive_more::Display;
+
+use crate::TxDeposit;
 
 /// Identifier for an Optimism deposit transaction
 pub const DEPOSIT_TX_TYPE_ID: u8 = 126; // 0x7E
@@ -17,17 +19,22 @@ pub const DEPOSIT_TX_TYPE_ID: u8 = 126; // 0x7E
 /// [4844]: https://eips.ethereum.org/EIPS/eip-4844
 /// [deposit-spec]: https://specs.optimism.io/protocol/deposits.html
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, Display)]
 pub enum OpTxType {
     /// Legacy transaction type.
+    #[display(fmt = "legacy")]
     Legacy = 0,
     /// EIP-2930 transaction type.
+    #[display(fmt = "eip2930")]
     Eip2930 = 1,
     /// EIP-1559 transaction type.
+    #[display(fmt = "eip1559")]
     Eip1559 = 2,
     /// EIP-4844 transaction type.
+    #[display(fmt = "eip4844")]
     Eip4844 = 3,
     /// Optimism Deposit transaction type.
+    #[display(fmt = "deposit")]
     Deposit = 126,
 }
 


### PR DESCRIPTION
<!--

-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes https://github.com/alloy-rs/op-alloy/issues/22

## Solution

Replaces `alloy_consensus::TxType` with `op_alloy_consensus::TxType` for `<Optimism as Network>::TxType`.

Some methods, are yet to be implemented for deposit tx, and hence will only work for l1 tx types atm, but is out of scope of this pr:

- [ ] `TransactionBuilder::complete_type`
- [ ] `TransactionRequest::preferred_type`
- [ ] `TransactionRequest::buildable_type`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
