### PR TITLE
Add granite_time to OptimismGenesisInfo

### DIFF
--- a/crates/rpc-types/src/genesis.rs
+++ b/crates/rpc-types/src/genesis.rs
@@ -222,7 +222,7 @@ mod tests {
           "regolithTime": 12,
           "canyonTime": 0,
           "ecotoneTime": 0,
-          "fjordTime": 0
+          "fjordTime": 0,
           "graniteTime": 0
         }
         "#;

--- a/crates/rpc-types/src/genesis.rs
+++ b/crates/rpc-types/src/genesis.rs
@@ -46,6 +46,8 @@ pub struct OptimismGenesisInfo {
     pub ecotone_time: Option<u64>,
     /// fjord hardfork timestamp
     pub fjord_time: Option<u64>,
+    /// granite hardfork timestamp
+    pub granite_time: Option<u64>,
 }
 
 impl OptimismGenesisInfo {
@@ -123,6 +125,7 @@ mod tests {
                 canyon_time: Some(0),
                 ecotone_time: Some(0),
                 fjord_time: None,
+                granite_time: None,
             }
         );
     }
@@ -179,6 +182,7 @@ mod tests {
                     canyon_time: Some(0),
                     ecotone_time: Some(0),
                     fjord_time: None,
+                    granite_time: None,
                 }),
                 base_fee_info: Some(OptimismBaseFeeInfo {
                     eip1559_elasticity: None,
@@ -199,6 +203,7 @@ mod tests {
                     canyon_time: Some(0),
                     ecotone_time: Some(0),
                     fjord_time: None,
+                    granite_time: None,
                 }),
                 base_fee_info: Some(OptimismBaseFeeInfo {
                     eip1559_elasticity: None,
@@ -218,6 +223,7 @@ mod tests {
           "canyonTime": 0,
           "ecotoneTime": 0,
           "fjordTime": 0
+          "graniteTime": 0
         }
         "#;
 
@@ -233,6 +239,7 @@ mod tests {
                     canyon_time: Some(0),
                     ecotone_time: Some(0),
                     fjord_time: Some(0),
+                    granite_time: Some(0),
                 }),
                 base_fee_info: None,
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Support the upcoming Optimism Granite hardfork.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adds a `granite_time` config value to the `OptimismGenesisInfo` struct

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
