### PR TITLE
Set `op_alloy_rpc_types::Transaction` as `Optimism::TransactionResponse`

### DIFF
--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -32,7 +32,7 @@ impl Network for Optimism {
 
     type TransactionRequest = alloy_rpc_types_eth::transaction::TransactionRequest;
 
-    type TransactionResponse = alloy_rpc_types_eth::Transaction;
+    type TransactionResponse = op_alloy_rpc_types::Transaction;
 
     type ReceiptResponse = op_alloy_rpc_types::OpTransactionReceipt;
 

--- a/crates/rpc-types/src/transaction.rs
+++ b/crates/rpc-types/src/transaction.rs
@@ -1,5 +1,6 @@
 //! Optimism specific types related to transactions.
 
+use alloy_network::TransactionResponse;
 use alloy_primitives::B256;
 use serde::{Deserialize, Serialize};
 
@@ -24,4 +25,30 @@ pub struct Transaction {
     /// Deposit receipt version for deposit transactions post-canyon
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deposit_receipt_version: Option<u64>,
+}
+
+impl TransactionResponse for Transaction {
+    fn from(&self) -> alloy_primitives::Address {
+        self.inner.from()
+    }
+
+    fn to(&self) -> Option<alloy_primitives::Address> {
+        self.inner.to()
+    }
+
+    fn tx_hash(&self) -> alloy_primitives::TxHash {
+        self.inner.tx_hash()
+    }
+
+    fn value(&self) -> alloy_primitives::U256 {
+        self.inner.value()
+    }
+
+    fn gas(&self) -> u128 {
+        self.inner.gas()
+    }
+
+    fn input(&self) -> &alloy_primitives::Bytes {
+        self.inner.input()
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`alloy_network::Network` impl for `Optimism` needs to have unique types as associated types for integration in reth rpc

## Solution

Replace `alloy_rpc_types_eth::Transaction` with `op_alloy_rpc_types::Transaction` for `Optimism::TransactionResponse`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
