### PR TITLE
feat: Added sync file with types from reth

### DIFF
--- a/crates/rpc-types/src/lib.rs
+++ b/crates/rpc-types/src/lib.rs
@@ -16,6 +16,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub mod genesis;
+pub mod sync;
 pub mod receipt;
 pub mod transaction;
 

--- a/crates/rpc-types/src/lib.rs
+++ b/crates/rpc-types/src/lib.rs
@@ -16,8 +16,8 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub mod genesis;
-pub mod sync;
 pub mod receipt;
+pub mod sync;
 pub mod transaction;
 
 pub use receipt::OpTransactionReceipt;

--- a/crates/rpc-types/src/sync.rs
+++ b/crates/rpc-types/src/sync.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 /// The block reference for an L2 block.
 ///
 /// See: <https://github.com/ethereum-optimism/optimism/blob/develop/op-service/eth/id.go#L33>
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct L2BlockRef {
     /// The block hash.
@@ -28,7 +28,7 @@ pub struct L2BlockRef {
 /// The block reference for an L1 block.
 ///
 /// See: <https://github.com/ethereum-optimism/optimism/blob/develop/op-service/eth/id.go#L52>
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct L1BlockRef {
     /// The block hash.

--- a/crates/rpc-types/src/sync.rs
+++ b/crates/rpc-types/src/sync.rs
@@ -1,37 +1,67 @@
 //! Op types related to sync.
-use serde::{Deserialize, Serialize};
+
 use alloy_primitives::{BlockNumber, B256};
 use alloy_rpc_types_eth::BlockId;
+use serde::{Deserialize, Serialize};
 
+/// The block reference for an L2 block.
+///
+/// See: <https://github.com/ethereum-optimism/optimism/blob/develop/op-service/eth/id.go#L33>
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct L2BlockRef {
-    pub hash: Option<B256>,
-    pub number: Option<BlockNumber>,
-    pub parent_hash: Option<B256>,
-    pub timestamp: Option<u64>,
-    pub l1_origin: Option<BlockId>,
-    pub sequence_number: Option<u64>,
+    /// The block hash.
+    pub hash: B256,
+    /// The block number.
+    pub number: BlockNumber,
+    /// The parent hash.
+    pub parent_hash: B256,
+    /// The timestamp.
+    pub timestamp: u64,
+    /// The L1 origin.
+    #[serde(rename = "l1Origin")]
+    pub l1_origin: BlockId,
+    /// The sequence number.
+    pub sequence_number: u64,
 }
 
+/// The block reference for an L1 block.
+///
+/// See: <https://github.com/ethereum-optimism/optimism/blob/develop/op-service/eth/id.go#L52>
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct L1BlockRef {
-    pub hash: Option<B256>,
-    pub number: Option<BlockNumber>,
-    pub parent_hash: Option<B256>,
-    pub timestamp: Option<u64>,
+    /// The block hash.
+    pub hash: B256,
+    /// The block number.
+    pub number: BlockNumber,
+    /// The parent hash.
+    pub parent_hash: B256,
+    /// The timestamp.
+    pub timestamp: u64,
 }
 
+/// The [`SyncStatus`][ss] of an Optimism Rollup Node.
+///
+/// [ss]: https://github.com/ethereum-optimism/optimism/blob/develop/op-service/eth/sync_status.go#L5
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SyncStatus {
+    /// The current L1 block.
     pub current_l1: L1BlockRef,
+    /// The current L1 finalized block.
     pub current_l1_finalized: L1BlockRef,
+    /// The L1 head block ref.
     pub head_l1: L1BlockRef,
+    /// The L1 safe head block ref.
     pub safe_l1: L1BlockRef,
+    /// The finalized L1 block ref.
     pub finalized_l1: L1BlockRef,
+    /// The unsafe L2 block ref.
     pub unsafe_l2: L2BlockRef,
+    /// The safe L2 block ref.
     pub safe_l2: L2BlockRef,
+    /// The finalized L2 block ref.
     pub finalized_l2: L2BlockRef,
+    /// The pending safe L2 block ref.
     pub pending_safe_l2: L2BlockRef,
 }

--- a/crates/rpc-types/src/sync.rs
+++ b/crates/rpc-types/src/sync.rs
@@ -10,7 +10,7 @@ pub struct L2BlockRef {
     pub number: Option<BlockNumber>,
     pub parent_hash: Option<B256>,
     pub timestamp: Option<u64>,
-    pub l1origin: Option<BlockId>,
+    pub l1_origin: Option<BlockId>,
     pub sequence_number: Option<u64>,
 }
 

--- a/crates/rpc-types/src/sync.rs
+++ b/crates/rpc-types/src/sync.rs
@@ -1,0 +1,50 @@
+//! Op types related to sync.
+use serde::{Deserialize, Serialize};
+use alloy::{
+    primitives::{BlockNumber, B256},
+    rpc::types::BlockId,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct L2BlockRef {
+    pub hash: B256,
+    pub number: BlockNumber,
+    pub parent_hash: B256,
+    pub timestamp: u64,
+    pub l1origin: BlockId,
+    pub sequence_number: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct L1BlockRef {
+    pub hash: B256,
+    pub number: BlockNumber,
+    pub parent_hash: B256,
+    pub timestamp: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SyncStatus {
+    pub current_l1: L1BlockRef,
+    pub current_l1_finalized: L1BlockRef,
+    pub head_l1: L1BlockRef,
+    pub safe_l1: L1BlockRef,
+    pub finalized_l1: L1BlockRef,
+    pub unsafe_l2: L2BlockRef,
+    pub safe_l2: L2BlockRef,
+    pub finalized_l2: L2BlockRef,
+    pub pending_safe_l2: L2BlockRef,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OutputResponse {
+    pub version: B256,
+    pub output_root: B256,
+    pub block_ref: L2BlockRef,
+    pub withdrawal_storage_root: B256,
+    pub state_root: B256,
+    pub sync_status: SyncStatus,
+}

--- a/crates/rpc-types/src/sync.rs
+++ b/crates/rpc-types/src/sync.rs
@@ -6,21 +6,21 @@ use alloy_rpc_types_eth::BlockId;
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct L2BlockRef {
-    pub hash: B256,
-    pub number: BlockNumber,
-    pub parent_hash: B256,
-    pub timestamp: u64,
-    pub l1origin: BlockId,
-    pub sequence_number: u64,
+    pub hash: Option<B256>,
+    pub number: Option<BlockNumber>,
+    pub parent_hash: Option<B256>,
+    pub timestamp: Option<u64>,
+    pub l1origin: Option<BlockId>,
+    pub sequence_number: Option<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct L1BlockRef {
-    pub hash: B256,
-    pub number: BlockNumber,
-    pub parent_hash: B256,
-    pub timestamp: u64,
+    pub hash: Option<B256>,
+    pub number: Option<BlockNumber>,
+    pub parent_hash: Option<B256>,
+    pub timestamp: Option<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -34,15 +34,4 @@ pub struct SyncStatus {
     pub safe_l2: L2BlockRef,
     pub finalized_l2: L2BlockRef,
     pub pending_safe_l2: L2BlockRef,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OutputResponse {
-    pub version: B256,
-    pub output_root: B256,
-    pub block_ref: L2BlockRef,
-    pub withdrawal_storage_root: B256,
-    pub state_root: B256,
-    pub sync_status: SyncStatus,
 }

--- a/crates/rpc-types/src/sync.rs
+++ b/crates/rpc-types/src/sync.rs
@@ -1,9 +1,7 @@
 //! Op types related to sync.
 use serde::{Deserialize, Serialize};
-use alloy::{
-    primitives::{BlockNumber, B256},
-    rpc::types::BlockId,
-};
+use alloy_primitives::{BlockNumber, B256};
+use alloy_rpc_types_eth::BlockId;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Motivation
Issue [reth Issue by matsee ](https://github.com/paradigmxyz/reth/issues/10509)
[Pr comments](https://github.com/paradigmxyz/op-rs/pull/25)
In the pr matsee suggested we should add types here and import there for usage 

 Solution
So as mentioned in issue and pr I moved the types here.
Basically added three types here L1/L2blockref and syncstatus 
## PR Checklist

- [x] Added Types 

