### PR TITLE
feat(rpc-types): OP Error Types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,11 @@ alloy-eips = { version = "0.2", default-features = false }
 alloy-serde = { version = "0.2", default-features = false }
 alloy-signer = { version = "0.2", default-features = false }
 
+# Revm
+revm-primitives = { version = "8.0.0", features = [
+    "std",
+], default-features = false }
+
 # Serde
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -12,15 +12,28 @@ repository.workspace = true
 exclude.workspace = true
 
 [dependencies]
+# op-alloy
 op-alloy-consensus = { workspace = true, features = ["serde"] }
 
+# alloy
 alloy-primitives = { workspace = true, features = ["rlp", "serde", "std"] }
 alloy-rpc-types-eth.workspace = true
 alloy-network.workspace = true
 alloy-serde.workspace = true
 
+# revm
+revm-primitives = { workspace = true, features = ["serde", "optimism"] }
+
+# serde
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+
+# rpc
+jsonrpsee-types = "0.24"
+jsonrpsee-core = "0.24"
+
+# misc
+thiserror.workspace = true
 
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -6,7 +6,7 @@ use std::fmt::Display;
 
 /// Optimism specific errors.
 #[derive(Debug, thiserror::Error)]
-pub enum OpEthApiError<EthApiError: Display> {
+pub enum OpEthApiError<EthApiError: Error> {
     /// L1 ethereum error.
     #[error(transparent)]
     Eth(#[from] EthApiError),

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -1,0 +1,98 @@
+//! RPC errors specific to OP.
+
+use alloy_rpc_types_eth::error::EthRpcErrorCode;
+use revm_primitives::{InvalidTransaction, OptimismInvalidTransaction};
+use std::fmt::Display;
+
+/// Optimism specific errors, that extend [`EthApiError`].
+#[derive(Debug, thiserror::Error)]
+pub enum OpEthApiError<EthApiError: Display> {
+    /// L1 ethereum error.
+    #[error(transparent)]
+    Eth(#[from] EthApiError),
+    /// Thrown when calculating L1 gas fee.
+    #[error("failed to calculate l1 gas fee")]
+    L1BlockFeeError,
+    /// Thrown when calculating L1 gas used
+    #[error("failed to calculate l1 gas used")]
+    L1BlockGasError,
+    /// Wrapper for [`revm_primitives::InvalidTransaction`](InvalidTransaction).
+    #[error(transparent)]
+    InvalidTransaction(OptimismInvalidTransactionError),
+}
+
+/// Constructs an internal JSON-RPC error.
+fn internal_rpc_err(msg: impl Into<String>) -> jsonrpsee_types::error::ErrorObject<'static> {
+    rpc_err(jsonrpsee_types::error::INTERNAL_ERROR_CODE, msg, None)
+}
+
+/// Constructs a JSON-RPC error, consisting of `code`, `message` and optional `data`.
+fn rpc_err(
+    code: i32,
+    msg: impl Into<String>,
+    data: Option<&[u8]>,
+) -> jsonrpsee_types::error::ErrorObject<'static> {
+    jsonrpsee_types::error::ErrorObject::owned(
+        code,
+        msg.into(),
+        data.map(|data| {
+            jsonrpsee_core::to_json_raw_value(&alloy_primitives::hex::encode_prefixed(data))
+                .expect("serializing String can't fail")
+        }),
+    )
+}
+
+impl<EthApiError> From<OpEthApiError<EthApiError>> for jsonrpsee_types::error::ErrorObject<'static>
+where
+    EthApiError: Into<jsonrpsee_types::error::ErrorObject<'static>> + Display,
+{
+    fn from(err: OpEthApiError<EthApiError>) -> Self {
+        match err {
+            OpEthApiError::Eth(err) => err.into(),
+            OpEthApiError::L1BlockFeeError | OpEthApiError::L1BlockGasError => {
+                internal_rpc_err(err.to_string())
+            }
+            OpEthApiError::InvalidTransaction(err) => err.into(),
+        }
+    }
+}
+
+/// Optimism specific invalid transaction errors
+#[derive(thiserror::Error, Copy, Clone, Debug)]
+pub enum OptimismInvalidTransactionError {
+    /// A deposit transaction was submitted as a system transaction post-regolith.
+    #[error("no system transactions allowed after regolith")]
+    DepositSystemTxPostRegolith,
+    /// A deposit transaction halted post-regolith
+    #[error("deposit transaction halted after regolith")]
+    HaltedDepositPostRegolith,
+}
+
+impl From<OptimismInvalidTransactionError> for jsonrpsee_types::error::ErrorObject<'static> {
+    fn from(err: OptimismInvalidTransactionError) -> Self {
+        match err {
+            OptimismInvalidTransactionError::DepositSystemTxPostRegolith
+            | OptimismInvalidTransactionError::HaltedDepositPostRegolith => {
+                rpc_err(EthRpcErrorCode::TransactionRejected.code(), err.to_string(), None)
+            }
+        }
+    }
+}
+
+impl TryFrom<InvalidTransaction> for OptimismInvalidTransactionError {
+    type Error = InvalidTransaction;
+
+    fn try_from(err: InvalidTransaction) -> Result<Self, Self::Error> {
+        match err {
+            InvalidTransaction::OptimismError(err) => match err {
+                OptimismInvalidTransaction::DepositSystemTxPostRegolith => {
+                    Ok(Self::DepositSystemTxPostRegolith)
+                }
+                OptimismInvalidTransaction::HaltedDepositPostRegolith => {
+                    Ok(Self::HaltedDepositPostRegolith)
+                }
+            },
+            _ => Err(err),
+        }
+    }
+}

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -4,7 +4,7 @@ use alloy_rpc_types_eth::error::EthRpcErrorCode;
 use revm_primitives::{InvalidTransaction, OptimismInvalidTransaction};
 use std::fmt::Display;
 
-/// Optimism specific errors, that extend [`EthApiError`].
+/// Optimism specific errors.
 #[derive(Debug, thiserror::Error)]
 pub enum OpEthApiError<EthApiError: Display> {
     /// L1 ethereum error.
@@ -16,7 +16,7 @@ pub enum OpEthApiError<EthApiError: Display> {
     /// Thrown when calculating L1 gas used
     #[error("failed to calculate l1 gas used")]
     L1BlockGasError,
-    /// Wrapper for [`revm_primitives::InvalidTransaction`](InvalidTransaction).
+    /// Wrapper for [`revm_primitives::InvalidTransaction`].
     #[error(transparent)]
     InvalidTransaction(OptimismInvalidTransactionError),
 }

--- a/crates/rpc-types/src/lib.rs
+++ b/crates/rpc-types/src/lib.rs
@@ -15,6 +15,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+pub mod error;
 pub mod genesis;
 pub mod receipt;
 pub mod transaction;

--- a/crates/rpc-types/src/lib.rs
+++ b/crates/rpc-types/src/lib.rs
@@ -15,8 +15,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-pub mod error;
 pub mod config;
+pub mod error;
 pub mod genesis;
 pub mod net;
 pub mod receipt;


### PR DESCRIPTION
**Description**

Upstream error types from `reth/optimism` to `rpc-types`.

Not a huge fan of the generic `EthApiError` on the `OpEthApiError` type.

Also unfortunate we need to copy over `internal_rpc_err` and `rpc_err` functions since they're custom reth utils.

Close #40.