### PR TITLE
fix(rpc): Add Missing Safe Head Endpoint

### DIFF
--- a/crates/rpc-jsonrpsee/src/traits.rs
+++ b/crates/rpc-jsonrpsee/src/traits.rs
@@ -25,6 +25,10 @@ pub trait RollupNode {
     async fn op_output_at_block(&self, block_number: BlockNumberOrTag)
         -> RpcResult<OutputResponse>;
 
+    /// Gets the safe head at an L1 block height.
+    #[method(name = "safeHeadAtL1Block")]
+    async fn op_safe_head_at_l1_block(&self, block_number: BlockNumberOrTag) -> RpcResult<B256>;
+
     /// Get the synchronization status.
     #[method(name = "syncStatus")]
     async fn op_sync_status(&self) -> RpcResult<SyncStatus>;

--- a/crates/rpc-jsonrpsee/src/traits.rs
+++ b/crates/rpc-jsonrpsee/src/traits.rs
@@ -9,6 +9,7 @@ use op_alloy_rpc_types::{
     config::RollupConfig,
     net::{PeerDump, PeerInfo, PeerStats},
     output::OutputResponse,
+    safe_head::SafeHeadResponse,
     sync::SyncStatus,
 };
 use std::net::IpAddr;
@@ -27,7 +28,10 @@ pub trait RollupNode {
 
     /// Gets the safe head at an L1 block height.
     #[method(name = "safeHeadAtL1Block")]
-    async fn op_safe_head_at_l1_block(&self, block_number: BlockNumberOrTag) -> RpcResult<B256>;
+    async fn op_safe_head_at_l1_block(
+        &self,
+        block_number: BlockNumberOrTag,
+    ) -> RpcResult<SafeHeadResponse>;
 
     /// Get the synchronization status.
     #[method(name = "syncStatus")]

--- a/crates/rpc-types/src/lib.rs
+++ b/crates/rpc-types/src/lib.rs
@@ -20,6 +20,7 @@ pub mod genesis;
 pub mod net;
 pub mod output;
 pub mod receipt;
+pub mod safe_head;
 pub mod sync;
 pub mod transaction;
 

--- a/crates/rpc-types/src/safe_head.rs
+++ b/crates/rpc-types/src/safe_head.rs
@@ -1,0 +1,14 @@
+//! Contains the response for a safe head request.
+
+use alloy_rpc_types_eth::BlockId;
+use serde::{Deserialize, Serialize};
+
+/// The safe head response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SafeHeadResponse {
+    /// The L1 block.
+    pub l1_block: BlockId,
+    /// The safe head.
+    pub safe_head: BlockId,
+}


### PR DESCRIPTION
### Description

The `RollupNode` trait was missing the `optimism_safeHeadAtL1Block` endpoint.

See reference: https://github.com/ethereum-optimism/optimism/blob/137207200ea23ae0f7d438b8cd96815e79ffb1ed/op-node/node/api.go#L144-L157