### PR TITLE
feat(protocol): Core Protocol Types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ alloy-eips = { version = "0.3", default-features = false }
 alloy-serde = { version = "0.3", default-features = false }
 alloy-signer = { version = "0.3", default-features = false }
 
+# Superchain
+superchain-primitives = { version = "0.3.2", default-features = false }
+
 # Serde
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
@@ -60,6 +63,7 @@ jsonrpsee-types = "0.24"
 derive_more = { version = "1.0", features = ["full"] }
 
 ## misc-testing
+hashbrown = "0.14.5"
 arbitrary = { version = "1.3", features = ["derive"] }
 rand = "0.8"
 thiserror = "1.0"

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -24,6 +24,9 @@ hashbrown.workspace = true
 # `serde` feature dependencies
 serde = { workspace = true, optional = true }
 
+[dev-dependencies]
+serde_json = "1.0"
+
 [features]
 default = ["serde", "std"]
 std = []

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "op-alloy-protocol"
+description = "Optimism protocol-specific types"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[dependencies]
+# Alloy
+alloy-primitives.workspace = true
+
+# Superchain
+superchain-primitives.workspace = true
+
+# Misc
+hashbrown.workspace = true
+
+# `serde` feature dependencies
+serde = { workspace = true, optional = true }
+
+[features]
+default = ["serde", "std"]
+std = []
+serde = [
+  "dep:serde",
+  "superchain-primitives/serde",
+]

--- a/crates/protocol/README.md
+++ b/crates/protocol/README.md
@@ -1,0 +1,11 @@
+# op-alloy-protocol
+
+Core protocol types for Optimism.
+
+These include types, constants, and methods for derivation as well as batch-submission.
+
+## Provenance
+
+This code was initially ported from [kona-primitives] as part of ongoing op-alloy migrations.
+
+[kona-primitives]: https://github.com/ethereum-optimism/kona/tree/main/crates/kona-primitives

--- a/crates/protocol/src/block.rs
+++ b/crates/protocol/src/block.rs
@@ -1,6 +1,6 @@
 //! Block Types for Optimism.
 
-use alloy_primitives::B256;
+use alloy_primitives::{U64, B256};
 use superchain_primitives::BlockID;
 
 #[cfg(feature = "serde")]
@@ -9,26 +9,27 @@ use serde::{Deserialize, Serialize};
 /// Block Header Info
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, Default)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct BlockInfo {
     /// The block hash
     pub hash: B256,
     /// The block number
-    pub number: u64,
+    pub number: U64,
     /// The parent block hash
     pub parent_hash: B256,
     /// The block timestamp
-    pub timestamp: u64,
+    pub timestamp: U64,
 }
 
 impl BlockInfo {
     /// Instantiates a new [BlockInfo].
-    pub const fn new(hash: B256, number: u64, parent_hash: B256, timestamp: u64) -> Self {
+    pub const fn new(hash: B256, number: U64, parent_hash: B256, timestamp: U64) -> Self {
         Self { hash, number, parent_hash, timestamp }
     }
 
     /// Returns the block ID.
-    pub const fn id(&self) -> BlockID {
-        BlockID { hash: self.hash, number: self.number }
+    pub fn id(&self) -> BlockID {
+        BlockID { hash: self.hash, number: self.number.try_into().expect("U64 conversion to u64") }
     }
 }
 
@@ -45,18 +46,147 @@ impl core::fmt::Display for BlockInfo {
 /// L2 Block Header Info
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct L2BlockInfo {
     /// The base [BlockInfo]
     pub block_info: BlockInfo,
     /// The L1 origin [BlockID]
     pub l1_origin: BlockID,
     /// The sequence number of the L2 block
-    pub seq_num: u64,
+    pub seq_num: U64,
 }
 
 impl L2BlockInfo {
     /// Instantiates a new [L2BlockInfo].
-    pub const fn new(block_info: BlockInfo, l1_origin: BlockID, seq_num: u64) -> Self {
+    pub const fn new(block_info: BlockInfo, l1_origin: BlockID, seq_num: U64) -> Self {
         Self { block_info, l1_origin, seq_num }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_block_id_bounds() {
+        let block_info = BlockInfo {
+            hash: B256::from([1; 32]),
+            number: U64::from(0),
+            parent_hash: B256::from([2; 32]),
+            timestamp: U64::from(1),
+        };
+        let expected = BlockID { hash: B256::from([1; 32]), number: 0 };
+        assert_eq!(block_info.id(), expected);
+
+        let block_info = BlockInfo {
+            hash: B256::from([1; 32]),
+            number: U64::MAX,
+            parent_hash: B256::from([2; 32]),
+            timestamp: U64::from(1),
+        };
+        let expected = BlockID { hash: B256::from([1; 32]), number: u64::MAX };
+        assert_eq!(block_info.id(), expected);
+    }
+
+    #[test]
+    fn test_deserialize_block_info() {
+        let block_info = BlockInfo {
+            hash: B256::from([1; 32]),
+            number: U64::from(1),
+            parent_hash: B256::from([2; 32]),
+            timestamp: U64::from(1),
+        };
+
+        let json = r#"{
+            "hash": "0x0101010101010101010101010101010101010101010101010101010101010101",
+            "number": 1,
+            "parentHash": "0x0202020202020202020202020202020202020202020202020202020202020202",
+            "timestamp": 1
+        }"#;
+
+        let deserialized: BlockInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, block_info);
+    }
+
+    #[test]
+    fn test_deserialize_block_info_with_hex() {
+        let block_info = BlockInfo {
+            hash: B256::from([1; 32]),
+            number: U64::from(1),
+            parent_hash: B256::from([2; 32]),
+            timestamp: U64::from(1),
+        };
+
+        let json = r#"{
+            "hash": "0x0101010101010101010101010101010101010101010101010101010101010101",
+            "number": "0x1",
+            "parentHash": "0x0202020202020202020202020202020202020202020202020202020202020202",
+            "timestamp": "0x1"
+        }"#;
+
+        let deserialized: BlockInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, block_info);
+    }
+
+    #[test]
+    fn test_deserialize_l2_block_info() {
+        let l2_block_info = L2BlockInfo {
+            block_info: BlockInfo {
+                hash: B256::from([1; 32]),
+                number: U64::from(1),
+                parent_hash: B256::from([2; 32]),
+                timestamp: U64::from(1),
+            },
+            l1_origin: BlockID { hash: B256::from([3; 32]), number: 2 },
+            seq_num: U64::from(3),
+        };
+
+        let json = r#"{
+            "blockInfo": {
+                "hash": "0x0101010101010101010101010101010101010101010101010101010101010101",
+                "number": 1,
+                "parentHash": "0x0202020202020202020202020202020202020202020202020202020202020202",
+                "timestamp": 1
+            },
+            "l1Origin": {
+                "hash": "0x0303030303030303030303030303030303030303030303030303030303030303",
+                "number": 2
+            },
+            "seqNum": 3
+        }"#;
+
+        let deserialized: L2BlockInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, l2_block_info);
+    }
+
+    #[test]
+    fn test_deserialize_l2_block_info_hex() {
+        let l2_block_info = L2BlockInfo {
+            block_info: BlockInfo {
+                hash: B256::from([1; 32]),
+                number: U64::from(1),
+                parent_hash: B256::from([2; 32]),
+                timestamp: U64::from(1),
+            },
+            l1_origin: BlockID { hash: B256::from([3; 32]), number: 2 },
+            seq_num: U64::from(3),
+        };
+
+        let json = r#"{
+            "blockInfo": {
+                "hash": "0x0101010101010101010101010101010101010101010101010101010101010101",
+                "number": "0x1",
+                "parentHash": "0x0202020202020202020202020202020202020202020202020202020202020202",
+                "timestamp": "0x1"
+            },
+            "l1Origin": {
+                "hash": "0x0303030303030303030303030303030303030303030303030303030303030303",
+                "number": 2
+            },
+            "seqNum": "0x3"
+        }"#;
+
+        let deserialized: L2BlockInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, l2_block_info);
     }
 }

--- a/crates/protocol/src/block.rs
+++ b/crates/protocol/src/block.rs
@@ -1,6 +1,6 @@
 //! Block Types for Optimism.
 
-use alloy_primitives::{U64, B256};
+use alloy_primitives::{B256, U64};
 use superchain_primitives::BlockID;
 
 #[cfg(feature = "serde")]
@@ -64,6 +64,7 @@ impl L2BlockInfo {
 }
 
 #[cfg(test)]
+#[cfg(feature = "serde")]
 mod tests {
     use super::*;
 

--- a/crates/protocol/src/block.rs
+++ b/crates/protocol/src/block.rs
@@ -1,0 +1,62 @@
+//! Block Types for Optimism.
+
+use alloy_primitives::B256;
+use superchain_primitives::BlockID;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Block Header Info
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, Default)]
+pub struct BlockInfo {
+    /// The block hash
+    pub hash: B256,
+    /// The block number
+    pub number: u64,
+    /// The parent block hash
+    pub parent_hash: B256,
+    /// The block timestamp
+    pub timestamp: u64,
+}
+
+impl BlockInfo {
+    /// Instantiates a new [BlockInfo].
+    pub const fn new(hash: B256, number: u64, parent_hash: B256, timestamp: u64) -> Self {
+        Self { hash, number, parent_hash, timestamp }
+    }
+
+    /// Returns the block ID.
+    pub const fn id(&self) -> BlockID {
+        BlockID { hash: self.hash, number: self.number }
+    }
+}
+
+impl core::fmt::Display for BlockInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "BlockInfo {{ hash: {}, number: {}, parent_hash: {}, timestamp: {} }}",
+            self.hash, self.number, self.parent_hash, self.timestamp
+        )
+    }
+}
+
+/// L2 Block Header Info
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Default)]
+pub struct L2BlockInfo {
+    /// The base [BlockInfo]
+    pub block_info: BlockInfo,
+    /// The L1 origin [BlockID]
+    pub l1_origin: BlockID,
+    /// The sequence number of the L2 block
+    pub seq_num: u64,
+}
+
+impl L2BlockInfo {
+    /// Instantiates a new [L2BlockInfo].
+    pub const fn new(block_info: BlockInfo, l1_origin: BlockID, seq_num: u64) -> Self {
+        Self { block_info, l1_origin, seq_num }
+    }
+}

--- a/crates/protocol/src/channel.rs
+++ b/crates/protocol/src/channel.rs
@@ -3,7 +3,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use alloy_primitives::Bytes;
+use alloy_primitives::{U64, Bytes};
 use hashbrown::HashMap;
 
 use crate::block::BlockInfo;
@@ -137,7 +137,7 @@ impl Channel {
     }
 
     /// Returns the block number of the L1 block that contained the first [Frame] in this channel.
-    pub const fn open_block_number(&self) -> u64 {
+    pub const fn open_block_number(&self) -> U64 {
         self.open_block.number
     }
 

--- a/crates/protocol/src/channel.rs
+++ b/crates/protocol/src/channel.rs
@@ -1,0 +1,299 @@
+//! Channel Types
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use alloy_primitives::Bytes;
+use hashbrown::HashMap;
+
+use crate::block::BlockInfo;
+
+use crate::{frame::Frame, ChannelId};
+
+/// [MAX_RLP_BYTES_PER_CHANNEL] is the maximum amount of bytes that will be read from
+/// a channel. This limit is set when decoding the RLP.
+pub const MAX_RLP_BYTES_PER_CHANNEL: u64 = 10_000_000;
+
+/// [FJORD_MAX_RLP_BYTES_PER_CHANNEL] is the maximum amount of bytes that will be read from
+/// a channel when the Fjord Hardfork is activated. This limit is set when decoding the RLP.
+pub const FJORD_MAX_RLP_BYTES_PER_CHANNEL: u64 = 100_000_000;
+
+/// An error returned when adding a frame to a channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ChannelError {
+    /// The frame id does not match the channel id.
+    FrameIdMismatch,
+    /// The channel is closed.
+    ChannelClosed,
+    /// The frame number is already in the channel.
+    FrameNumberExists(usize),
+    /// The frame number is beyond the end frame.
+    FrameBeyondEndFrame(usize),
+}
+
+/// A Channel is a set of batches that are split into at least one, but possibly multiple frames.
+///
+/// Frames are allowed to be ingested out of order.
+/// Each frame is ingested one by one. Once a frame with `closed` is added to the channel, the
+/// channel may mark itself as ready for reading once all intervening frames have been added
+#[derive(Debug, Clone, Default)]
+pub struct Channel {
+    /// The unique identifier for this channel
+    id: ChannelId,
+    /// The block that the channel is currently open at
+    open_block: BlockInfo,
+    /// Estimated memory size, used to drop the channel if we have too much data
+    estimated_size: usize,
+    /// True if the last frame has been buffered
+    closed: bool,
+    /// The highest frame number that has been ingested
+    highest_frame_number: u16,
+    /// The frame number of the frame where `is_last` is true
+    /// No other frame number may be higher than this
+    last_frame_number: u16,
+    /// Store a map of frame number to frame for constant time ordering
+    inputs: HashMap<u16, Frame>,
+    /// The highest L1 inclusion block that a frame was included in
+    highest_l1_inclusion_block: BlockInfo,
+}
+
+impl Channel {
+    /// Create a new [Channel] with the given [ChannelId] and [BlockInfo].
+    pub fn new(id: ChannelId, open_block: BlockInfo) -> Self {
+        Self { id, open_block, inputs: HashMap::new(), ..Default::default() }
+    }
+
+    /// Returns the current [ChannelId] for the channel.
+    pub const fn id(&self) -> ChannelId {
+        self.id
+    }
+
+    /// Returns the number of frames ingested.
+    pub fn len(&self) -> usize {
+        self.inputs.len()
+    }
+
+    /// Returns if the channel is empty.
+    pub fn is_empty(&self) -> bool {
+        self.inputs.is_empty()
+    }
+
+    /// Add a frame to the channel.
+    ///
+    /// ## Takes
+    /// - `frame`: The frame to add to the channel
+    /// - `l1_inclusion_block`: The block that the frame was included in
+    ///
+    /// ## Returns
+    /// - `Ok(()):` If the frame was successfully buffered
+    /// - `Err(_):` If the frame was invalid
+    pub fn add_frame(
+        &mut self,
+        frame: Frame,
+        l1_inclusion_block: BlockInfo,
+    ) -> Result<(), ChannelError> {
+        // Ensure that the frame ID is equal to the channel ID.
+        if frame.id != self.id {
+            return Err(ChannelError::FrameIdMismatch);
+        }
+        if frame.is_last && self.closed {
+            return Err(ChannelError::ChannelClosed);
+        }
+        if self.inputs.contains_key(&frame.number) {
+            return Err(ChannelError::FrameNumberExists(frame.number as usize));
+        }
+        if self.closed && frame.number >= self.last_frame_number {
+            return Err(ChannelError::FrameBeyondEndFrame(frame.number as usize));
+        }
+
+        // Guaranteed to succeed at this point. Update the channel state.
+        if frame.is_last {
+            self.last_frame_number = frame.number;
+            self.closed = true;
+
+            // Prune frames with a higher number than the last frame number when we receive a
+            // closing frame.
+            if self.last_frame_number < self.highest_frame_number {
+                self.inputs.retain(|id, frame| {
+                    self.estimated_size -= frame.size();
+                    *id < self.last_frame_number
+                });
+                self.highest_frame_number = self.last_frame_number;
+            }
+        }
+
+        // Update the highest frame number.
+        if frame.number > self.highest_frame_number {
+            self.highest_frame_number = frame.number;
+        }
+
+        if self.highest_l1_inclusion_block.number < l1_inclusion_block.number {
+            self.highest_l1_inclusion_block = l1_inclusion_block;
+        }
+
+        self.estimated_size += frame.size();
+        self.inputs.insert(frame.number, frame);
+        Ok(())
+    }
+
+    /// Returns the block number of the L1 block that contained the first [Frame] in this channel.
+    pub const fn open_block_number(&self) -> u64 {
+        self.open_block.number
+    }
+
+    /// Returns the estimated size of the channel including [Frame] overhead.
+    pub const fn size(&self) -> usize {
+        self.estimated_size
+    }
+
+    /// Returns `true` if the channel is ready to be read.
+    pub fn is_ready(&self) -> bool {
+        // Must have buffered the last frame before the channel is ready.
+        if !self.closed {
+            return false;
+        }
+
+        // Must have the possibility of contiguous frames.
+        if self.inputs.len() != (self.last_frame_number + 1) as usize {
+            return false;
+        }
+
+        // Check for contiguous frames.
+        for i in 0..=self.last_frame_number {
+            if !self.inputs.contains_key(&i) {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// Returns all of the channel's [Frame]s concatenated together.
+    ///
+    /// ## Returns
+    ///
+    /// - `Some(Bytes)`: The concatenated frame data
+    /// - `None`: If the channel is missing frames
+    pub fn frame_data(&self) -> Option<Bytes> {
+        let mut data = Vec::with_capacity(self.size());
+        (0..=self.last_frame_number).try_for_each(|i| {
+            let frame = self.inputs.get(&i)?;
+            data.extend_from_slice(&frame.data);
+            Some(())
+        })?;
+        Some(data.into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[cfg(not(feature = "std"))]
+    use alloc::string::String;
+    #[cfg(not(feature = "std"))]
+    use alloc::string::ToString;
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
+
+    struct FrameValidityTestCase {
+        #[allow(dead_code)]
+        name: String,
+        frames: Vec<Frame>,
+        should_error: Vec<bool>,
+        sizes: Vec<u64>,
+    }
+
+    fn run_frame_validity_test(test_case: FrameValidityTestCase) {
+        #[cfg(feature = "std")]
+        println!("Running test: {}", test_case.name);
+
+        let id = [0xFF; 16];
+        let block = BlockInfo::default();
+        let mut channel = Channel::new(id, block);
+
+        if test_case.frames.len() != test_case.should_error.len()
+            || test_case.frames.len() != test_case.sizes.len()
+        {
+            panic!("Test case length mismatch");
+        }
+
+        for (i, frame) in test_case.frames.iter().enumerate() {
+            let result = channel.add_frame(frame.clone(), block);
+            if test_case.should_error[i] {
+                assert!(result.is_err());
+            } else {
+                assert!(result.is_ok());
+            }
+            assert_eq!(channel.size(), test_case.sizes[i] as usize);
+        }
+    }
+
+    #[test]
+    fn test_frame_validity() {
+        let id = [0xFF; 16];
+        let test_cases = [
+            FrameValidityTestCase {
+                name: "wrong channel".to_string(),
+                frames: vec![Frame { id: [0xEE; 16], ..Default::default() }],
+                should_error: vec![true],
+                sizes: vec![0],
+            },
+            FrameValidityTestCase {
+                name: "double close".to_string(),
+                frames: vec![
+                    Frame { id, is_last: true, number: 2, data: b"four".to_vec() },
+                    Frame { id, is_last: true, number: 1, ..Default::default() },
+                ],
+                should_error: vec![false, true],
+                sizes: vec![204, 204],
+            },
+            FrameValidityTestCase {
+                name: "duplicate frame".to_string(),
+                frames: vec![
+                    Frame { id, number: 2, data: b"four".to_vec(), ..Default::default() },
+                    Frame { id, number: 2, data: b"seven".to_vec(), ..Default::default() },
+                ],
+                should_error: vec![false, true],
+                sizes: vec![204, 204],
+            },
+            FrameValidityTestCase {
+                name: "duplicate closing frames".to_string(),
+                frames: vec![
+                    Frame { id, number: 2, is_last: true, data: b"four".to_vec() },
+                    Frame { id, number: 2, is_last: true, data: b"seven".to_vec() },
+                ],
+                should_error: vec![false, true],
+                sizes: vec![204, 204],
+            },
+            FrameValidityTestCase {
+                name: "frame past closing".to_string(),
+                frames: vec![
+                    Frame { id, number: 2, is_last: true, data: b"four".to_vec() },
+                    Frame { id, number: 10, data: b"seven".to_vec(), ..Default::default() },
+                ],
+                should_error: vec![false, true],
+                sizes: vec![204, 204],
+            },
+            FrameValidityTestCase {
+                name: "prune after close frame".to_string(),
+                frames: vec![
+                    Frame { id, number: 10, is_last: false, data: b"seven".to_vec() },
+                    Frame { id, number: 2, is_last: true, data: b"four".to_vec() },
+                ],
+                should_error: vec![false, false],
+                sizes: vec![205, 204],
+            },
+            FrameValidityTestCase {
+                name: "multiple valid frames".to_string(),
+                frames: vec![
+                    Frame { id, number: 10, data: b"seven__".to_vec(), ..Default::default() },
+                    Frame { id, number: 2, data: b"four".to_vec(), ..Default::default() },
+                ],
+                should_error: vec![false, false],
+                sizes: vec![207, 411],
+            },
+        ];
+
+        test_cases.into_iter().for_each(run_frame_validity_test);
+    }
+}

--- a/crates/protocol/src/channel.rs
+++ b/crates/protocol/src/channel.rs
@@ -3,7 +3,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use alloy_primitives::{U64, Bytes};
+use alloy_primitives::{Bytes, U64};
 use hashbrown::HashMap;
 
 use crate::block::BlockInfo;

--- a/crates/protocol/src/frame.rs
+++ b/crates/protocol/src/frame.rs
@@ -1,0 +1,181 @@
+//! Frame Types
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use crate::ChannelId;
+
+/// The version of the derivation pipeline.
+pub(crate) const DERIVATION_VERSION_0: u8 = 0;
+
+/// Count the tagging info as 200 in terms of buffer size.
+pub(crate) const FRAME_OVERHEAD: usize = 200;
+
+/// Frames cannot be larger than 1MB.
+///
+/// Data transactions that carry frames are generally not larger than 128 KB due to L1 network
+/// conditions, but we leave space to grow larger anyway (gas limit allows for more data).
+pub(crate) const MAX_FRAME_LEN: usize = 1_000_000;
+
+/// A frame decoding error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FrameDecodingError {
+    /// The frame data is too large.
+    DataTooLarge(usize),
+    /// The frame data is too short.
+    DataTooShort(usize),
+    /// Error decoding the frame id.
+    InvalidId,
+    /// Error decoding the frame number.
+    InvalidNumber,
+    /// Error decoding the frame data length.
+    InvalidDataLength,
+}
+
+/// Frame parsing error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FrameParseError {
+    /// Error parsing the frame data.
+    FrameDecodingError(FrameDecodingError),
+    /// No frames to parse.
+    NoFrames,
+    /// Unsupported derivation version.
+    UnsupportedVersion,
+    /// Frame data length mismatch.
+    DataLengthMismatch,
+    /// No frames decoded.
+    NoFramesDecoded,
+}
+
+/// A channel frame is a segment of a channel's data.
+///
+/// *Encoding*
+/// frame = `channel_id ++ frame_number ++ frame_data_length ++ frame_data ++ is_last`
+/// * channel_id        = bytes16
+/// * frame_number      = uint16
+/// * frame_data_length = uint32
+/// * frame_data        = bytes
+/// * is_last           = bool
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Frame {
+    /// The unique idetifier for the frame.
+    pub id: ChannelId,
+    /// The number of the frame.
+    pub number: u16,
+    /// The data within the frame.
+    pub data: Vec<u8>,
+    /// Whether or not the frame is the last in the sequence.
+    pub is_last: bool,
+}
+
+impl Frame {
+    /// Encode the frame into a byte vector.
+    pub fn encode(&self) -> Vec<u8> {
+        let mut encoded = Vec::with_capacity(16 + 2 + 4 + self.data.len() + 1);
+        encoded.extend_from_slice(&self.id);
+        encoded.extend_from_slice(&self.number.to_be_bytes());
+        encoded.extend_from_slice(&(self.data.len() as u32).to_be_bytes());
+        encoded.extend_from_slice(&self.data);
+        encoded.push(self.is_last as u8);
+        encoded
+    }
+
+    /// Decode a frame from a byte vector.
+    pub fn decode(encoded: &[u8]) -> Result<(usize, Self), FrameDecodingError> {
+        const BASE_FRAME_LEN: usize = 16 + 2 + 4 + 1;
+
+        if encoded.len() < BASE_FRAME_LEN {
+            return Err(FrameDecodingError::DataTooShort(encoded.len()));
+        }
+
+        let id = encoded[..16].try_into().map_err(|_| FrameDecodingError::InvalidId)?;
+        let number = u16::from_be_bytes(
+            encoded[16..18].try_into().map_err(|_| FrameDecodingError::InvalidNumber)?,
+        );
+        let data_len = u32::from_be_bytes(
+            encoded[18..22].try_into().map_err(|_| FrameDecodingError::InvalidDataLength)?,
+        ) as usize;
+
+        if data_len > MAX_FRAME_LEN {
+            return Err(FrameDecodingError::DataTooLarge(data_len));
+        }
+
+        let data = encoded[22..22 + data_len].to_vec();
+        let is_last = encoded[22 + data_len] == 1;
+        Ok((BASE_FRAME_LEN + data_len, Self { id, number, data, is_last }))
+    }
+
+    /// Parse the on chain serialization of frame(s) in an L1 transaction. Currently
+    /// only version 0 of the serialization format is supported. All frames must be parsed
+    /// without error and there must not be any left over data and there must be at least one
+    /// frame.
+    ///
+    /// Frames are stored in L1 transactions with the following format:
+    /// * `data = DerivationVersion0 ++ Frame(s)` Where there is one or more frames concatenated
+    ///   together.
+    pub fn parse_frames(encoded: &[u8]) -> Result<Vec<Self>, FrameParseError> {
+        if encoded.is_empty() {
+            return Err(FrameParseError::NoFrames);
+        }
+        if encoded[0] != DERIVATION_VERSION_0 {
+            return Err(FrameParseError::UnsupportedVersion);
+        }
+
+        let data = &encoded[1..];
+        let mut frames = Vec::new();
+        let mut offset = 0;
+        while offset < data.len() {
+            let (frame_length, frame) =
+                Self::decode(&data[offset..]).map_err(FrameParseError::FrameDecodingError)?;
+            frames.push(frame);
+            offset += frame_length;
+        }
+
+        if offset != data.len() {
+            return Err(FrameParseError::DataLengthMismatch);
+        }
+        if frames.is_empty() {
+            return Err(FrameParseError::NoFramesDecoded);
+        }
+
+        Ok(frames)
+    }
+
+    /// Calculates the size of the frame + overhead for storing the frame. The sum of the frame size
+    /// of each frame in a channel determines the channel's size. The sum of the channel sizes
+    /// is used for pruning & compared against the max channel bank size.
+    pub fn size(&self) -> usize {
+        self.data.len() + FRAME_OVERHEAD
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
+
+    #[test]
+    fn test_encode_frame_roundtrip() {
+        let frame = Frame { id: [0xFF; 16], number: 0xEE, data: vec![0xDD; 50], is_last: true };
+
+        let (_, frame_decoded) = Frame::decode(&frame.encode()).unwrap();
+        assert_eq!(frame, frame_decoded);
+    }
+
+    #[test]
+    fn test_decode_many() {
+        let frame = Frame { id: [0xFF; 16], number: 0xEE, data: vec![0xDD; 50], is_last: true };
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&[DERIVATION_VERSION_0]);
+        (0..5).for_each(|_| {
+            bytes.extend_from_slice(&frame.encode());
+        });
+
+        let frames = Frame::parse_frames(bytes.as_slice()).unwrap();
+        assert_eq!(frames.len(), 5);
+        (0..5).for_each(|i| {
+            assert_eq!(frames[i], frame);
+        });
+    }
+}

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -1,0 +1,35 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/alloy.jpg",
+    html_favicon_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/favicon.ico"
+)]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    unreachable_pub,
+    clippy::missing_const_for_fn,
+    rustdoc::all
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![deny(unused_must_use, rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+/// [CHANNEL_ID_LENGTH] is the length of the channel ID.
+pub const CHANNEL_ID_LENGTH: usize = 16;
+
+/// [ChannelId] is an opaque identifier for a channel.
+pub type ChannelId = [u8; CHANNEL_ID_LENGTH];
+
+mod block;
+pub use block::{BlockInfo, L2BlockInfo};
+
+mod frame;
+pub use frame::{Frame, FrameDecodingError, FrameParseError};
+
+mod channel;
+pub use channel::{Channel, FJORD_MAX_RLP_BYTES_PER_CHANNEL, MAX_RLP_BYTES_PER_CHANNEL};


### PR DESCRIPTION
### Description

Introduce core protocol types to a new `op-alloy` crate called `op-alloy-protocol`.

Nomenclature: `protocol` as opposed to `derive` since these types will be used beyond derivation. They exist as core types used for data transformation between source and destination chains.

This migrates [channel types](https://github.com/ethereum-optimism/kona/blob/main/crates/primitives/src/channel.rs) and [frame types](https://github.com/ethereum-optimism/kona/blob/main/crates/primitives/src/frame.rs) to op-alloy.

> [!NOTE]
>
> This PR will not include batch types.
> Before these can be ported from the `kona-derive::batch` module, batch validity must be trait abstracted in order to avoid pulling in `kona-derive` types.