### PR TITLE
fix(rpc): Add l1 block info to OpTransactionReceipt

### DIFF
--- a/crates/rpc-types/src/receipt.rs
+++ b/crates/rpc-types/src/receipt.rs
@@ -14,6 +14,8 @@ pub struct OpTransactionReceipt {
     /// Regular eth transaction receipt including deposit receipts
     #[serde(flatten)]
     pub inner: alloy_rpc_types_eth::TransactionReceipt<OpReceiptEnvelope<alloy_rpc_types_eth::Log>>,
+    //// L1 block info of the transaction.
+    pub l1_block_info: L1BlockInfo,
 }
 
 impl ReceiptResponse for OpTransactionReceipt {
@@ -121,6 +123,54 @@ impl From<OptimismTransactionReceiptFields> for OtherFields {
         serde_json::to_value(value).unwrap().try_into().unwrap()
     }
 }
+
+/// L1 block info extracted from inout of first transaction in every block.
+///
+/// The subset of [`OptimismTransactionReceiptFields`], that encompasses L1 block
+/// info:
+/// <https://github.com/ethereum-optimism/op-geth/blob/f2e69450c6eec9c35d56af91389a1c47737206ca/core/types/receipt.go#L87-L87>
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct L1BlockInfo {
+    /// L1 base fee is the minimum price per unit of gas.
+    ///
+    /// Present from pre-bedrock as de facto L1 price per unit of gas. L1 base fee after Bedrock.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub l1_gas_price: Option<u128>,
+    /// L1 gas used.
+    ///
+    /// Present from pre-bedrock to Ecotone. Null after Ecotone.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub l1_gas_used: Option<u128>,
+    /// L1 fee for the transaction.
+    ///
+    /// Present from pre-bedrock.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub l1_fee: Option<u128>,
+    /// L1 fee scalar for the transaction
+    ///
+    /// Present from pre-bedrock to Ecotone. Null after Ecotone.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "l1_fee_scalar_serde")]
+    pub l1_fee_scalar: Option<f64>,
+    /* ---------------------------------------- Ecotone ---------------------------------------- */
+    /// L1 base fee scalar. Applied to base fee to compute weighted gas price multiplier.
+    ///
+    /// Always null prior to the Ecotone hardfork.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub l1_base_fee_scalar: Option<u128>,
+    /// L1 blob base fee.
+    ///
+    /// Always null prior to the Ecotone hardfork.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub l1_blob_base_fee: Option<u128>,
+    /// L1 blob base fee scalar. Applied to blob base fee to compute weighted gas price multiplier.
+    ///
+    /// Always null prior to the Ecotone hardfork.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub l1_blob_base_fee_scalar: Option<u128>,
+}
+
+impl Eq for L1BlockInfo {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/rpc-types/src/receipt.rs
+++ b/crates/rpc-types/src/receipt.rs
@@ -41,26 +41,9 @@ impl ReceiptResponse for OpTransactionReceipt {
 #[serde(rename_all = "camelCase")]
 #[doc(alias = "OptimismTxReceiptFields")]
 pub struct OptimismTransactionReceiptFields {
-    /// L1 base fee is the minimum price per unit of gas.
-    ///
-    /// Present from pre-bedrock as de facto L1 price per unit of gas. L1 base fee after Bedrock.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
-    pub l1_gas_price: Option<u128>,
-    /// L1 gas used.
-    ///
-    /// Present from pre-bedrock to Ecotone. Null after Ecotone.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
-    pub l1_gas_used: Option<u128>,
-    /// L1 fee for the transaction.
-    ///
-    /// Present from pre-bedrock.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
-    pub l1_fee: Option<u128>,
-    /// L1 fee scalar for the transaction
-    ///
-    /// Present from pre-bedrock to Ecotone. Null after Ecotone.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "l1_fee_scalar_serde")]
-    pub l1_fee_scalar: Option<f64>,
+    /// L1 block info.
+    #[serde(flatten)]
+    pub l1_block_info: L1BlockInfo,
     /* --------------------------------------- Regolith --------------------------------------- */
     /// Deposit nonce for deposit transactions.
     ///
@@ -73,22 +56,6 @@ pub struct OptimismTransactionReceiptFields {
     /// Always null prior to the Canyon hardfork.
     #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub deposit_receipt_version: Option<u64>,
-    /* ---------------------------------------- Ecotone ---------------------------------------- */
-    /// L1 base fee scalar. Applied to base fee to compute weighted gas price multiplier.
-    ///
-    /// Always null prior to the Ecotone hardfork.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
-    pub l1_base_fee_scalar: Option<u128>,
-    /// L1 blob base fee.
-    ///
-    /// Always null prior to the Ecotone hardfork.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
-    pub l1_blob_base_fee: Option<u128>,
-    /// L1 blob base fee scalar. Applied to blob base fee to compute weighted gas price multiplier.
-    ///
-    /// Always null prior to the Ecotone hardfork.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
-    pub l1_blob_base_fee_scalar: Option<u128>,
 }
 
 /// Serialize/Deserialize l1FeeScalar to/from string

--- a/crates/rpc-types/src/receipt.rs
+++ b/crates/rpc-types/src/receipt.rs
@@ -14,7 +14,7 @@ pub struct OpTransactionReceipt {
     /// Regular eth transaction receipt including deposit receipts
     #[serde(flatten)]
     pub inner: alloy_rpc_types_eth::TransactionReceipt<OpReceiptEnvelope<alloy_rpc_types_eth::Log>>,
-    //// L1 block info of the transaction.
+    /// L1 block info of the transaction.
     #[serde(flatten)]
     pub l1_block_info: L1BlockInfo,
 }

--- a/crates/rpc-types/src/receipt.rs
+++ b/crates/rpc-types/src/receipt.rs
@@ -15,6 +15,7 @@ pub struct OpTransactionReceipt {
     #[serde(flatten)]
     pub inner: alloy_rpc_types_eth::TransactionReceipt<OpReceiptEnvelope<alloy_rpc_types_eth::Log>>,
     //// L1 block info of the transaction.
+    #[serde(flatten)]
     pub l1_block_info: L1BlockInfo,
 }
 
@@ -182,8 +183,8 @@ mod tests {
     #[test]
     fn serialize_l1_fee_scalar() {
         let op_fields = OptimismTransactionReceiptFields {
-            l1_fee_scalar: Some(0.678),
-            ..OptimismTransactionReceiptFields::default()
+            l1_block_info: L1BlockInfo { l1_fee_scalar: Some(0.678), ..Default::default() },
+            ..Default::default()
         };
 
         let json = serde_json::to_value(op_fields).unwrap();
@@ -198,18 +199,18 @@ mod tests {
         });
 
         let op_fields: OptimismTransactionReceiptFields = serde_json::from_value(json).unwrap();
-        assert_eq!(op_fields.l1_fee_scalar, Some(0.678f64));
+        assert_eq!(op_fields.l1_block_info.l1_fee_scalar, Some(0.678f64));
 
         let json = json!({
             "l1FeeScalar": Value::Null
         });
 
         let op_fields: OptimismTransactionReceiptFields = serde_json::from_value(json).unwrap();
-        assert_eq!(op_fields.l1_fee_scalar, None);
+        assert_eq!(op_fields.l1_block_info.l1_fee_scalar, None);
 
         let json = json!({});
 
         let op_fields: OptimismTransactionReceiptFields = serde_json::from_value(json).unwrap();
-        assert_eq!(op_fields.l1_fee_scalar, None);
+        assert_eq!(op_fields.l1_block_info.l1_fee_scalar, None);
     }
 }

--- a/crates/rpc-types/src/receipt.rs
+++ b/crates/rpc-types/src/receipt.rs
@@ -163,7 +163,13 @@ mod tests {
         "to": "0x4200000000000000000000000000000000000015",
         "transactionHash": "0xb7c74afdeb7c89fb9de2c312f49b38cb7a850ba36e064734c5223a477e83fdc9",
         "transactionIndex": "0x0",
-        "type": "0x7e"
+        "type": "0x7e",
+        "l1GasPrice": "0x3ef12787",
+        "l1GasUsed": "0x1177",
+        "l1Fee": "0x5bf1ab43d",
+        "l1BaseFeeScalar": "0x1",
+        "l1BlobBaseFee": "0x600ab8f05e64",
+        "l1BlobBaseFeeScalar": "0x1"
     }"#;
 
         let receipt: OpTransactionReceipt = serde_json::from_str(s).unwrap();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes https://github.com/alloy-rs/op-alloy/issues/54

## Solution

- Moves L1 block info fields out of type `OptimismTransactionReceiptFields` into new type `L1BlockInfo`.
- Adds `L1BlockInfo` to `OpTransactionReceipt`

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
