### PR TITLE
fix(consensus): no_std Compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ jsonrpsee-types = "0.24"
 
 # misc
 spin = { version = "0.9.8", features = ["mutex"] }
-derive_more = { version = "1.0", features = ["full"] }
+derive_more = { version = "1.0", default-features = false }
 
 ## misc-testing
 hashbrown = "0.14.5"

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -37,7 +37,7 @@ serde_json.workspace = true
 
 [features]
 default = ["std"]
-std = ["alloy-eips/std", "alloy-consensus/std"]
+std = ["alloy-eips/std", "alloy-consensus/std", "derive_more/std"]
 k256 = ["alloy-primitives/k256", "alloy-consensus/k256"]
 kzg = ["alloy-eips/kzg", "alloy-consensus/kzg", "std"]
 arbitrary = ["std", "dep:arbitrary", "alloy-consensus/arbitrary", "alloy-eips/arbitrary", "alloy-primitives/rand"]


### PR DESCRIPTION
### Description

`derive_more` dependency with `full` default features includes `std`, breaking `no_std` compatibility. This PR fixes `no_std` compat by toggling `default-features = false`.