### PR TITLE
feat: Workflow to validate no_std Compatibility

### DIFF
--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crates: ["op-alloy-consensus"]
+        crate: ["op-alloy-consensus"]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -1,0 +1,20 @@
+name: no_std
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check-no-std:
+    name: check no_std ${{ matrix.features }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        crates: ["op-alloy-consensus"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: riscv32imac-unknown-none-elf
+      - run: cargo check --target riscv32imac-unknown-none-elf --no-default-features -p ${{ matrix.crate }}

--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -1,5 +1,10 @@
 name: no_std
 
+on:
+  push:
+    branches: [main]
+  pull_request:
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
### Description

Adds a workflow to validate no_std compatibility for a matrix of crates, including only `op-alloy-consensus` for now.