### PR TITLE
fix(docs): l1 gas used deprecated since Fjord not Ecotone

### DIFF
--- a/crates/rpc-types/src/receipt.rs
+++ b/crates/rpc-types/src/receipt.rs
@@ -107,7 +107,7 @@ pub struct L1BlockInfo {
     pub l1_gas_price: Option<u128>,
     /// L1 gas used.
     ///
-    /// Present from pre-bedrock to Ecotone. Null after Ecotone.
+    /// Present from pre-bedrock to Ecotone. Null after Fjord.
     #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub l1_gas_used: Option<u128>,
     /// L1 fee for the transaction.

--- a/crates/rpc-types/src/receipt.rs
+++ b/crates/rpc-types/src/receipt.rs
@@ -107,7 +107,7 @@ pub struct L1BlockInfo {
     pub l1_gas_price: Option<u128>,
     /// L1 gas used.
     ///
-    /// Present from pre-bedrock to Ecotone. Null after Fjord.
+    /// Present from pre-bedrock, deprecated as of Fjord.
     #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub l1_gas_used: Option<u128>,
     /// L1 fee for the transaction.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Docs bug: l1 gas used is deprecated since Fjord not Ecotone
https://github.com/ethereum-optimism/op-geth/blob/f2e69450c6eec9c35d56af91389a1c47737206ca/core/types/receipt.go#L90

## Solution

Update docs

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
