### PR TITLE
fix(protocol): Native u64

### DIFF
--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -23,7 +23,7 @@ hashbrown.workspace = true
 
 # `serde` feature dependencies
 serde = { workspace = true, optional = true }
-serde_json = { workspace = true, optional = true }
+alloy-serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json.workspace = true
@@ -33,6 +33,6 @@ default = ["serde", "std"]
 std = []
 serde = [
   "dep:serde",
-  "dep:serde_json",
+  "dep:alloy-serde",
   "superchain-primitives/serde",
 ]

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -23,14 +23,16 @@ hashbrown.workspace = true
 
 # `serde` feature dependencies
 serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json.workspace = true
 
 [features]
 default = ["serde", "std"]
 std = []
 serde = [
   "dep:serde",
+  "dep:serde_json",
   "superchain-primitives/serde",
 ]

--- a/crates/protocol/src/block.rs
+++ b/crates/protocol/src/block.rs
@@ -1,6 +1,6 @@
 //! Block Types for Optimism.
 
-use alloy_primitives::{B256, U64};
+use alloy_primitives::B256;
 use superchain_primitives::BlockID;
 
 #[cfg(feature = "serde")]
@@ -14,22 +14,24 @@ pub struct BlockInfo {
     /// The block hash
     pub hash: B256,
     /// The block number
-    pub number: U64,
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_u64_hex"))]
+    pub number: u64,
     /// The parent block hash
     pub parent_hash: B256,
     /// The block timestamp
-    pub timestamp: U64,
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_u64_hex"))]
+    pub timestamp: u64,
 }
 
 impl BlockInfo {
     /// Instantiates a new [BlockInfo].
-    pub const fn new(hash: B256, number: U64, parent_hash: B256, timestamp: U64) -> Self {
+    pub const fn new(hash: B256, number: u64, parent_hash: B256, timestamp: u64) -> Self {
         Self { hash, number, parent_hash, timestamp }
     }
 
     /// Returns the block ID.
-    pub fn id(&self) -> BlockID {
-        BlockID { hash: self.hash, number: self.number.try_into().expect("U64 conversion to u64") }
+    pub const fn id(&self) -> BlockID {
+        BlockID { hash: self.hash, number: self.number }
     }
 }
 
@@ -53,12 +55,39 @@ pub struct L2BlockInfo {
     /// The L1 origin [BlockID]
     pub l1_origin: BlockID,
     /// The sequence number of the L2 block
-    pub seq_num: U64,
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_u64_hex"))]
+    pub seq_num: u64,
+}
+
+#[cfg(feature = "serde")]
+fn deserialize_u64_hex<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    fn deserialize_u64_hex_string<'de, D>(s: String) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = s.replace("\"", "");
+        if let Some(s) = s.strip_prefix("0x") {
+            u64::from_str_radix(s, 16).map_err(serde::de::Error::custom)
+        } else {
+            s.parse().map_err(serde::de::Error::custom)
+        }
+    }
+    let value = serde_json::Value::deserialize(deserializer)?;
+    match value {
+        serde_json::Value::String(s) => deserialize_u64_hex_string::<D>(s),
+        serde_json::Value::Number(n) => {
+            n.as_u64().ok_or_else(|| serde::de::Error::custom("invalid u64"))
+        }
+        _ => Err(serde::de::Error::custom("invalid u64")),
+    }
 }
 
 impl L2BlockInfo {
     /// Instantiates a new [L2BlockInfo].
-    pub const fn new(block_info: BlockInfo, l1_origin: BlockID, seq_num: U64) -> Self {
+    pub const fn new(block_info: BlockInfo, l1_origin: BlockID, seq_num: u64) -> Self {
         Self { block_info, l1_origin, seq_num }
     }
 }
@@ -72,18 +101,18 @@ mod tests {
     fn test_block_id_bounds() {
         let block_info = BlockInfo {
             hash: B256::from([1; 32]),
-            number: U64::from(0),
+            number: 0,
             parent_hash: B256::from([2; 32]),
-            timestamp: U64::from(1),
+            timestamp: 1,
         };
         let expected = BlockID { hash: B256::from([1; 32]), number: 0 };
         assert_eq!(block_info.id(), expected);
 
         let block_info = BlockInfo {
             hash: B256::from([1; 32]),
-            number: U64::MAX,
+            number: u64::MAX,
             parent_hash: B256::from([2; 32]),
-            timestamp: U64::from(1),
+            timestamp: 1,
         };
         let expected = BlockID { hash: B256::from([1; 32]), number: u64::MAX };
         assert_eq!(block_info.id(), expected);
@@ -93,9 +122,9 @@ mod tests {
     fn test_deserialize_block_info() {
         let block_info = BlockInfo {
             hash: B256::from([1; 32]),
-            number: U64::from(1),
+            number: 1,
             parent_hash: B256::from([2; 32]),
-            timestamp: U64::from(1),
+            timestamp: 1,
         };
 
         let json = r#"{
@@ -113,9 +142,9 @@ mod tests {
     fn test_deserialize_block_info_with_hex() {
         let block_info = BlockInfo {
             hash: B256::from([1; 32]),
-            number: U64::from(1),
+            number: 1,
             parent_hash: B256::from([2; 32]),
-            timestamp: U64::from(1),
+            timestamp: 1,
         };
 
         let json = r#"{
@@ -134,12 +163,12 @@ mod tests {
         let l2_block_info = L2BlockInfo {
             block_info: BlockInfo {
                 hash: B256::from([1; 32]),
-                number: U64::from(1),
+                number: 1,
                 parent_hash: B256::from([2; 32]),
-                timestamp: U64::from(1),
+                timestamp: 1,
             },
             l1_origin: BlockID { hash: B256::from([3; 32]), number: 2 },
-            seq_num: U64::from(3),
+            seq_num: 3,
         };
 
         let json = r#"{
@@ -165,12 +194,12 @@ mod tests {
         let l2_block_info = L2BlockInfo {
             block_info: BlockInfo {
                 hash: B256::from([1; 32]),
-                number: U64::from(1),
+                number: 1,
                 parent_hash: B256::from([2; 32]),
-                timestamp: U64::from(1),
+                timestamp: 1,
             },
             l1_origin: BlockID { hash: B256::from([3; 32]), number: 2 },
-            seq_num: U64::from(3),
+            seq_num: 3,
         };
 
         let json = r#"{

--- a/crates/protocol/src/block.rs
+++ b/crates/protocol/src/block.rs
@@ -14,12 +14,12 @@ pub struct BlockInfo {
     /// The block hash
     pub hash: B256,
     /// The block number
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_u64_hex"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub number: u64,
     /// The parent block hash
     pub parent_hash: B256,
     /// The block timestamp
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_u64_hex"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub timestamp: u64,
 }
 
@@ -55,34 +55,8 @@ pub struct L2BlockInfo {
     /// The L1 origin [BlockID]
     pub l1_origin: BlockID,
     /// The sequence number of the L2 block
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_u64_hex"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub seq_num: u64,
-}
-
-#[cfg(feature = "serde")]
-fn deserialize_u64_hex<'de, D>(deserializer: D) -> Result<u64, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    fn deserialize_u64_hex_string<'de, D>(s: String) -> Result<u64, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = s.replace("\"", "");
-        if let Some(s) = s.strip_prefix("0x") {
-            u64::from_str_radix(s, 16).map_err(serde::de::Error::custom)
-        } else {
-            s.parse().map_err(serde::de::Error::custom)
-        }
-    }
-    let value = serde_json::Value::deserialize(deserializer)?;
-    match value {
-        serde_json::Value::String(s) => deserialize_u64_hex_string::<D>(s),
-        serde_json::Value::Number(n) => {
-            n.as_u64().ok_or_else(|| serde::de::Error::custom("invalid u64"))
-        }
-        _ => Err(serde::de::Error::custom("invalid u64")),
-    }
 }
 
 impl L2BlockInfo {

--- a/crates/protocol/src/channel.rs
+++ b/crates/protocol/src/channel.rs
@@ -3,7 +3,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use alloy_primitives::{Bytes, U64};
+use alloy_primitives::Bytes;
 use hashbrown::HashMap;
 
 use crate::block::BlockInfo;
@@ -150,7 +150,7 @@ impl Channel {
     }
 
     /// Returns the block number of the L1 block that contained the first [Frame] in this channel.
-    pub const fn open_block_number(&self) -> U64 {
+    pub const fn open_block_number(&self) -> u64 {
         self.open_block.number
     }
 


### PR DESCRIPTION
### Description

Uses the native `u64` type - this prevents a lot of type conversions in kona.

See https://github.com/anton-rs/kona/pull/495