### PR TITLE
fix(protocol): EIP 2718 Deposit Tx Utility

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -37,7 +37,7 @@ pub use frame::{
 };
 
 mod utils;
-pub use utils::starts_with_2781_deposit;
+pub use utils::starts_with_2718_deposit;
 
 mod channel;
 pub use channel::{Channel, FJORD_MAX_RLP_BYTES_PER_CHANNEL, MAX_RLP_BYTES_PER_CHANNEL};

--- a/crates/protocol/src/utils.rs
+++ b/crates/protocol/src/utils.rs
@@ -1,7 +1,7 @@
 //! Utility methods used by protocol types.
 
 /// Returns if the given `value` is a deposit transaction.
-pub fn starts_with_2781_deposit<B>(value: &B) -> bool
+pub fn starts_with_2718_deposit<B>(value: &B) -> bool
 where
     B: AsRef<[u8]>,
 {
@@ -15,15 +15,15 @@ mod tests {
 
     #[test]
     fn test_is_deposit() {
-        assert!(starts_with_2781_deposit(&[0x7E]));
-        assert!(!starts_with_2781_deposit(&[]));
-        assert!(!starts_with_2781_deposit(&[0x7F]));
+        assert!(starts_with_2718_deposit(&[0x7E]));
+        assert!(!starts_with_2718_deposit(&[]));
+        assert!(!starts_with_2718_deposit(&[0x7F]));
     }
 
     #[test]
     fn test_bytes_deposit() {
-        assert!(starts_with_2781_deposit(&Bytes::from_static(&[0x7E])));
-        assert!(!starts_with_2781_deposit(&Bytes::from_static(&[])));
-        assert!(!starts_with_2781_deposit(&Bytes::from_static(&[0x7F])));
+        assert!(starts_with_2718_deposit(&Bytes::from_static(&[0x7E])));
+        assert!(!starts_with_2718_deposit(&Bytes::from_static(&[])));
+        assert!(!starts_with_2718_deposit(&Bytes::from_static(&[0x7F])));
     }
 }


### PR DESCRIPTION
### Description

Fixes the deposit util to be for EIP 2718.

Renames:
`starts_with_2781_deposit` to
`starts_with_2718_deposit`