### PR TITLE
Make `l1_origin` in `L2BlockRef` a struct instead of an enum

### DIFF
--- a/crates/rpc-types/src/sync.rs
+++ b/crates/rpc-types/src/sync.rs
@@ -1,17 +1,8 @@
 //! Op types related to sync.
 
+use alloy_eips::BlockNumHash;
 use alloy_primitives::{BlockNumber, B256};
 use serde::{Deserialize, Serialize};
-
-
-/// See: https://github.com/ethereum-optimism/optimism/blob/develop/op-service/eth/id.go#L10-L13
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct BlockID {
-    /// The block hash.
-    pub hash: B256,
-    /// The block number.
-    pub number: BlockNumber,
-}
 
 /// The block reference for an L2 block.
 ///
@@ -29,7 +20,7 @@ pub struct L2BlockRef {
     pub timestamp: u64,
     /// The L1 origin.
     #[serde(rename = "l1Origin")]
-    pub l1_origin: BlockID,
+    pub l1_origin: BlockNumHash,
     /// The sequence number.
     pub sequence_number: u64,
 }

--- a/crates/rpc-types/src/sync.rs
+++ b/crates/rpc-types/src/sync.rs
@@ -1,8 +1,17 @@
 //! Op types related to sync.
 
 use alloy_primitives::{BlockNumber, B256};
-use alloy_rpc_types_eth::BlockId;
 use serde::{Deserialize, Serialize};
+
+
+/// See: https://github.com/ethereum-optimism/optimism/blob/develop/op-service/eth/id.go#L10-L13
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockID {
+    /// The block hash.
+    pub hash: B256,
+    /// The block number.
+    pub number: BlockNumber,
+}
 
 /// The block reference for an L2 block.
 ///
@@ -20,7 +29,7 @@ pub struct L2BlockRef {
     pub timestamp: u64,
     /// The L1 origin.
     #[serde(rename = "l1Origin")]
-    pub l1_origin: BlockId,
+    pub l1_origin: BlockID,
     /// The sequence number.
     pub sequence_number: u64,
 }


### PR DESCRIPTION
Currently, `l1_origin` in the `L2BlockRef` struct is an enum. But from the link embedded above it, it is supposed to be a struct. 

See: https://github.com/ethereum-optimism/optimism/blob/develop/op-service/eth/id.go#L10-L13