### PR TITLE
fix: Remove Block ID

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ option_if_let_else = "warn"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[patch.crates-io]
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+
 [workspace.dependencies]
 # Alloy
 op-alloy-rpc-jsonrpsee = { version = "0.2.9", path = "crates/rpc-jsonrpsee" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,6 @@ option_if_let_else = "warn"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
-[patch.crates-io]
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-
 [workspace.dependencies]
 # Alloy
 op-alloy-rpc-jsonrpsee = { version = "0.2.10", path = "crates/rpc-jsonrpsee" }

--- a/crates/protocol/src/block.rs
+++ b/crates/protocol/src/block.rs
@@ -1,7 +1,7 @@
 //! Block Types for Optimism.
 
 use alloy_primitives::B256;
-use superchain_primitives::BlockID;
+use alloy_eips::BlockNumHash;
 
 /// Block Header Info
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -27,8 +27,8 @@ impl BlockInfo {
     }
 
     /// Returns the block ID.
-    pub const fn id(&self) -> BlockID {
-        BlockID { hash: self.hash, number: self.number }
+    pub const fn id(&self) -> BlockNumHash {
+        BlockNumHash { hash: self.hash, number: self.number }
     }
 }
 
@@ -50,7 +50,7 @@ pub struct L2BlockInfo {
     /// The base [BlockInfo]
     pub block_info: BlockInfo,
     /// The L1 origin [BlockID]
-    pub l1_origin: BlockID,
+    pub l1_origin: BlockNumHash,
     /// The sequence number of the L2 block
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub seq_num: u64,
@@ -58,7 +58,7 @@ pub struct L2BlockInfo {
 
 impl L2BlockInfo {
     /// Instantiates a new [L2BlockInfo].
-    pub const fn new(block_info: BlockInfo, l1_origin: BlockID, seq_num: u64) -> Self {
+    pub const fn new(block_info: BlockInfo, l1_origin: BlockNumHash, seq_num: u64) -> Self {
         Self { block_info, l1_origin, seq_num }
     }
 }
@@ -76,7 +76,7 @@ mod tests {
             parent_hash: B256::from([2; 32]),
             timestamp: 1,
         };
-        let expected = BlockID { hash: B256::from([1; 32]), number: 0 };
+        let expected = BlockNumHash { hash: B256::from([1; 32]), number: 0 };
         assert_eq!(block_info.id(), expected);
 
         let block_info = BlockInfo {
@@ -85,7 +85,7 @@ mod tests {
             parent_hash: B256::from([2; 32]),
             timestamp: 1,
         };
-        let expected = BlockID { hash: B256::from([1; 32]), number: u64::MAX };
+        let expected = BlockNumHash { hash: B256::from([1; 32]), number: u64::MAX };
         assert_eq!(block_info.id(), expected);
     }
 
@@ -138,7 +138,7 @@ mod tests {
                 parent_hash: B256::from([2; 32]),
                 timestamp: 1,
             },
-            l1_origin: BlockID { hash: B256::from([3; 32]), number: 2 },
+            l1_origin: BlockNumHash { hash: B256::from([3; 32]), number: 2 },
             seq_num: 3,
         };
 
@@ -169,7 +169,7 @@ mod tests {
                 parent_hash: B256::from([2; 32]),
                 timestamp: 1,
             },
-            l1_origin: BlockID { hash: B256::from([3; 32]), number: 2 },
+            l1_origin: BlockNumHash { hash: B256::from([3; 32]), number: 2 },
             seq_num: 3,
         };
 

--- a/crates/protocol/src/block.rs
+++ b/crates/protocol/src/block.rs
@@ -49,7 +49,7 @@ impl core::fmt::Display for BlockInfo {
 pub struct L2BlockInfo {
     /// The base [BlockInfo]
     pub block_info: BlockInfo,
-    /// The L1 origin [BlockID]
+    /// The L1 origin [BlockNumHash]
     pub l1_origin: BlockNumHash,
     /// The sequence number of the L2 block
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]

--- a/crates/protocol/src/block.rs
+++ b/crates/protocol/src/block.rs
@@ -1,7 +1,7 @@
 //! Block Types for Optimism.
 
-use alloy_primitives::B256;
 use alloy_eips::BlockNumHash;
+use alloy_primitives::B256;
 
 /// Block Header Info
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/protocol/src/block_info.rs
+++ b/crates/protocol/src/block_info.rs
@@ -8,6 +8,7 @@ use alloc::{
     vec::Vec,
 };
 use alloy_consensus::Header;
+use alloy_eips::BlockNumHash;
 use alloy_primitives::{address, Address, Bytes, TxKind, B256, U256};
 use op_alloy_consensus::{OpTxEnvelope, TxDeposit};
 use superchain_primitives::{RollupConfig, SystemConfig};
@@ -288,13 +289,13 @@ impl L1BlockInfoTx {
     }
 
     /// Returns the L1 [BlockID] for the info transaction.
-    pub const fn id(&self) -> BlockID {
+    pub const fn id(&self) -> BlockNumHash {
         match self {
             Self::Ecotone(L1BlockInfoEcotone { number, block_hash, .. }) => {
-                BlockID { number: *number, hash: *block_hash }
+                BlockNumHash { number: *number, hash: *block_hash }
             }
             Self::Bedrock(L1BlockInfoBedrock { number, block_hash, .. }) => {
-                BlockID { number: *number, hash: *block_hash }
+                BlockNumHash { number: *number, hash: *block_hash }
             }
         }
     }

--- a/crates/protocol/src/block_info.rs
+++ b/crates/protocol/src/block_info.rs
@@ -288,7 +288,7 @@ impl L1BlockInfoTx {
         }
     }
 
-    /// Returns the L1 [BlockID] for the info transaction.
+    /// Returns the L1 [BlockNumHash] for the info transaction.
     pub const fn id(&self) -> BlockNumHash {
         match self {
             Self::Ecotone(L1BlockInfoEcotone { number, block_hash, .. }) => {

--- a/crates/protocol/src/block_info.rs
+++ b/crates/protocol/src/block_info.rs
@@ -10,7 +10,7 @@ use alloc::{
 use alloy_consensus::Header;
 use alloy_primitives::{address, Address, Bytes, TxKind, B256, U256};
 use op_alloy_consensus::{OpTxEnvelope, TxDeposit};
-use superchain_primitives::{BlockID, RollupConfig, SystemConfig};
+use superchain_primitives::{RollupConfig, SystemConfig};
 
 /// The system transaction gas limit post-Regolith
 const REGOLITH_SYSTEM_TX_GAS: u128 = 1_000_000;


### PR DESCRIPTION
### Description

Re-uses [`alloy_eips::BlockNumHash`](https://docs.rs/alloy-eips/latest/alloy_eips/eip1898/type.BlockNumHash.html) instead of a custom `BlockID` type in `superchain-primitives`.

This follows #91 