### PR TITLE
feat(engine): Attributes and Optional Serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,16 @@ option_if_let_else = "warn"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[patch.crates-io]
+alloy-rpc-types-engine = { git = "https://github.com/refcell/alloy", branch = "rf/engine/opt-serde" }
+
 [workspace.dependencies]
 # Alloy
 op-alloy-rpc-jsonrpsee = { version = "0.2.9", path = "crates/rpc-jsonrpsee" }
 op-alloy-rpc-types = { version = "0.2.9", path = "crates/rpc-types" }
 op-alloy-rpc-types-engine = { version = "0.2.9", path = "crates/rpc-types-engine" }
 op-alloy-consensus = { version = "0.2.9", path = "crates/consensus", default-features = false }
+op-alloy-protocol = { version = "0.2.9", path = "crates/protocol", default-features = false }
 
 alloy-rlp = { version = "0.3", default-features = false }
 alloy-primitives = { version = "0.8", default-features = false }
@@ -41,7 +45,7 @@ alloy = { version = "0.3.2" }
 alloy-consensus = { version = "0.3.2", default-features = false }
 alloy-network = { version = "0.3.2", default-features = false }
 alloy-rpc-types = { version = "0.3.2" }
-alloy-rpc-types-engine = { version = "0.3.2" }
+alloy-rpc-types-engine = { version = "0.3.2", default-features = false }
 alloy-rpc-types-eth = { version = "0.3.2" }
 alloy-eips = { version = "0.3.2", default-features = false }
 alloy-serde = { version = "0.3.2", default-features = false }

--- a/crates/rpc-types-engine/Cargo.toml
+++ b/crates/rpc-types-engine/Cargo.toml
@@ -14,9 +14,15 @@ exclude.workspace = true
 [dependencies]
 alloy-primitives.workspace = true
 alloy-rpc-types-engine.workspace = true
-alloy-serde.workspace = true
+op-alloy-protocol.workspace = true
 
-serde.workspace = true
+# serde
+serde = { workspace = true, optional = true }
+alloy-serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json.workspace = true
+
+[features]
+default = ["serde"]
+serde = ["dep:serde", "dep:alloy-serde", "alloy-rpc-types-engine/serde", "op-alloy-protocol/serde"]


### PR DESCRIPTION
### Description

> [!WARNING]
>
> Depends on optional serde support in `alloy-rpc-types-engine` https://github.com/alloy-rs/alloy/pull/1283.

Adds an attributes with parent object that's [needed by `kona`](https://github.com/anton-rs/kona/issues/510).