### PR TITLE
feat: Genesis Types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,15 +27,20 @@ option_if_let_else = "warn"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[patch.crates-io]
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+
 [workspace.dependencies]
 # Alloy
 op-alloy-rpc-jsonrpsee = { version = "0.2.9", path = "crates/rpc-jsonrpsee" }
 op-alloy-rpc-types = { version = "0.2.9", path = "crates/rpc-types" }
 op-alloy-rpc-types-engine = { version = "0.2.9", path = "crates/rpc-types-engine" }
 op-alloy-consensus = { version = "0.2.9", path = "crates/consensus", default-features = false }
+op-alloy-genesis = { version = "0.2.9", path = "crates/genesis" }
 
 alloy-rlp = { version = "0.3", default-features = false }
 alloy-primitives = { version = "0.8", default-features = false }
+alloy-sol-types = { version = "0.8", default-features = false }
 
 alloy = { version = "0.3.2" }
 alloy-consensus = { version = "0.3.2", default-features = false }
@@ -51,6 +56,7 @@ alloy-signer = { version = "0.3.2", default-features = false }
 superchain-primitives = { version = "0.4", default-features = false }
 
 # Serde
+serde_repr = "0.1"
 serde = { version = "1.0", default-features = false, features = [
     "derive",
     "alloc",

--- a/crates/genesis/Cargo.toml
+++ b/crates/genesis/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "op-alloy-genesis"
+description = "Optimism genesis types"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[dependencies]
+# Alloy
+alloy-sol-types.workspace = true
+alloy-primitives.workspace = true
+alloy-consensus.workspace = true
+alloy-eips.workspace = true
+
+# `serde` feature dependencies
+serde = { workspace = true, optional = true }
+serde_repr = { workspace = true, optional = true }
+
+[dev-dependencies]
+serde_json.workspace = true
+
+[features]
+default = ["serde", "std"]
+std = []
+serde = ["dep:serde", "dep:serde_repr", "alloy-primitives/serde", "alloy-eips/serde", "alloy-consensus/serde"]

--- a/crates/genesis/README.md
+++ b/crates/genesis/README.md
@@ -1,0 +1,9 @@
+# op-alloy-protocol
+
+Genesis types for Optimism.
+
+## Provenance
+
+This is based off of [alloy-genesis].
+
+[alloy-genesis]: https://github.com/alloy-rs

--- a/crates/genesis/src/addresses.rs
+++ b/crates/genesis/src/addresses.rs
@@ -1,0 +1,117 @@
+//! Address Types
+
+use alloy_primitives::Address;
+
+/// The set of network-specific contracts for a given chain.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "PascalCase"))]
+pub struct AddressList {
+    /// The address manager
+    pub address_manager: Address,
+    /// L1 Cross Domain Messenger proxy address
+    pub l1_cross_domain_messenger_proxy: Address,
+    /// L1 ERC721 Bridge proxy address
+    #[cfg_attr(feature = "serde", serde(alias = "L1ERC721BridgeProxy"))]
+    pub l1_erc721_bridge_proxy: Address,
+    /// L1 Standard Bridge proxy address
+    pub l1_standard_bridge_proxy: Address,
+    /// L2 Output Oracle Proxy address
+    pub l2_output_oracle_proxy: Option<Address>,
+    /// Optimism Mintable ERC20 Factory Proxy address
+    #[cfg_attr(feature = "serde", serde(alias = "OptimismMintableERC20FactoryProxy"))]
+    pub optimism_mintable_erc20_factory_proxy: Address,
+    /// Optimism Portal Proxy address
+    pub optimism_portal_proxy: Address,
+    /// System Config Proxy address
+    pub system_config_proxy: Address,
+    /// The system config owner
+    pub system_config_owner: Address,
+    /// Proxy Admin address
+    pub proxy_admin: Address,
+    /// The owner of the Proxy Admin
+    pub proxy_admin_owner: Address,
+    /// The guardian address
+    pub guardian: Address,
+
+    // Fault Proof Contract Addresses
+    /// Anchor State Registry Proxy address
+    pub anchor_state_registry_proxy: Option<Address>,
+    /// Delayed WETH Proxy address
+    #[cfg_attr(feature = "serde", serde(alias = "DelayedWETHProxy"))]
+    pub delayed_weth_proxy: Option<Address>,
+    /// Dispute Game Factory Proxy address
+    pub dispute_game_factory_proxy: Option<Address>,
+    /// Fault Dispute Game Proxy address
+    pub fault_dispute_game: Option<Address>,
+    /// MIPS Proxy address
+    #[cfg_attr(feature = "serde", serde(alias = "MIPS"))]
+    pub mips: Option<Address>,
+    /// Permissioned Dispute Game Proxy address
+    pub permissioned_dispute_game: Option<Address>,
+    /// Preimage Oracle Proxy address
+    pub preimage_oracle: Option<Address>,
+    /// The challenger's address
+    pub challenger: Option<Address>,
+}
+
+impl AddressList {
+    /// Sets zeroed addresses to [`Option::None`].
+    pub fn zero_proof_addresses(&mut self) {
+        if self.anchor_state_registry_proxy == Some(Address::ZERO) {
+            self.anchor_state_registry_proxy = None;
+        }
+        if self.delayed_weth_proxy == Some(Address::ZERO) {
+            self.delayed_weth_proxy = None;
+        }
+        if self.dispute_game_factory_proxy == Some(Address::ZERO) {
+            self.dispute_game_factory_proxy = None;
+        }
+        if self.fault_dispute_game == Some(Address::ZERO) {
+            self.fault_dispute_game = None;
+        }
+        if self.mips == Some(Address::ZERO) {
+            self.mips = None;
+        }
+        if self.permissioned_dispute_game == Some(Address::ZERO) {
+            self.permissioned_dispute_game = None;
+        }
+        if self.preimage_oracle == Some(Address::ZERO) {
+            self.preimage_oracle = None;
+        }
+        if self.challenger == Some(Address::ZERO) {
+            self.challenger = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_proof_addresses() {
+        let mut addresses = AddressList {
+            anchor_state_registry_proxy: Some(Address::ZERO),
+            delayed_weth_proxy: Some(Address::ZERO),
+            dispute_game_factory_proxy: Some(Address::ZERO),
+            fault_dispute_game: Some(Address::ZERO),
+            mips: Some(Address::ZERO),
+            permissioned_dispute_game: Some(Address::ZERO),
+            preimage_oracle: Some(Address::ZERO),
+            challenger: Some(Address::ZERO),
+            ..Default::default()
+        };
+
+        addresses.zero_proof_addresses();
+
+        assert_eq!(addresses.anchor_state_registry_proxy, None);
+        assert_eq!(addresses.delayed_weth_proxy, None);
+        assert_eq!(addresses.dispute_game_factory_proxy, None);
+        assert_eq!(addresses.fault_dispute_game, None);
+        assert_eq!(addresses.mips, None);
+        assert_eq!(addresses.permissioned_dispute_game, None);
+        assert_eq!(addresses.preimage_oracle, None);
+        assert_eq!(addresses.challenger, None);
+    }
+}

--- a/crates/genesis/src/chain.rs
+++ b/crates/genesis/src/chain.rs
@@ -1,0 +1,133 @@
+//! Chain Config Types
+
+use crate::{AddressList, ChainGenesis};
+use alloc::string::String;
+use alloy_primitives::Address;
+
+/// Level of integration with the superchain.
+#[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde_repr::Serialize_repr, serde_repr::Deserialize_repr))]
+#[repr(u8)]
+pub enum SuperchainLevel {
+    /// Frontier chains are chains with customizations beyond the
+    /// standard OP Stack configuration and are considered "advanced".
+    Frontier = 0,
+    /// Standard chains don't have any customizations beyond the
+    /// standard OP Stack configuration and are considered "vanilla".
+    #[default]
+    Standard = 1,
+}
+
+/// AltDA configuration.
+#[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AltDAConfig {
+    /// AltDA challenge address
+    pub da_challenge_address: Option<Address>,
+    /// AltDA challenge window time (in seconds)
+    pub da_challenge_window: Option<u64>,
+    /// AltDA resolution window time (in seconds)
+    pub da_resolve_window: Option<u64>,
+}
+
+/// Hardfork configuration.
+#[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct HardForkConfiguration {
+    /// Canyon hardfork activation time
+    pub canyon_time: Option<u64>,
+    /// Delta hardfork activation time
+    pub delta_time: Option<u64>,
+    /// Ecotone hardfork activation time
+    pub ecotone_time: Option<u64>,
+    /// Fjord hardfork activation time
+    pub fjord_time: Option<u64>,
+    /// Granite hardfork activation time
+    pub granite_time: Option<u64>,
+    /// Holocene hardfork activation time
+    pub holocene_time: Option<u64>,
+}
+
+/// A chain configuration.
+#[derive(Debug, Clone, Default, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ChainConfig {
+    /// Chain name (e.g. "Base")
+    #[cfg_attr(feature = "serde", serde(rename = "Name"))]
+    pub name: String,
+    /// Chain ID
+    #[cfg_attr(feature = "serde", serde(rename = "l2_chain_id"))]
+    pub chain_id: u64,
+    /// L1 chain ID
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub l1_chain_id: u64,
+    /// Chain public RPC endpoint
+    #[cfg_attr(feature = "serde", serde(rename = "PublicRPC"))]
+    pub public_rpc: String,
+    /// Chain sequencer RPC endpoint
+    #[cfg_attr(feature = "serde", serde(rename = "SequencerRPC"))]
+    pub sequencer_rpc: String,
+    /// Chain explorer HTTP endpoint
+    #[cfg_attr(feature = "serde", serde(rename = "Explorer"))]
+    pub explorer: String,
+    /// Level of integration with the superchain.
+    #[cfg_attr(feature = "serde", serde(rename = "SuperchainLevel"))]
+    pub superchain_level: SuperchainLevel,
+    /// Time of opt-in to the Superchain.
+    /// If superchain_time is set, hardforks times after superchain_time
+    /// will be inherited from the superchain-wide config.
+    #[cfg_attr(feature = "serde", serde(rename = "SuperchainTime"))]
+    pub superchain_time: Option<u64>,
+    /// Chain-specific batch inbox address
+    #[cfg_attr(feature = "serde", serde(rename = "batch_inbox_address"))]
+    pub batch_inbox_addr: Address,
+    /// Chain-specific genesis information
+    pub genesis: ChainGenesis,
+    /// Superchain is a simple string to identify the superchain.
+    /// This is implied by directory structure, and not encoded in the config file itself.
+    #[cfg_attr(feature = "serde", serde(rename = "Superchain"))]
+    pub superchain: String,
+    /// Chain is a simple string to identify the chain, within its superchain context.
+    /// This matches the resource filename, it is not encoded in the config file itself.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub chain: String,
+    /// Hardfork Configuration. These values may override the superchain-wide defaults.
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub hardfork_configuration: HardForkConfiguration,
+    /// Optional AltDA feature
+    pub alt_da: Option<AltDAConfig>,
+    /// Addresses
+    #[cfg_attr(feature = "serde", serde(rename = "Addresses"))]
+    pub addresses: Option<AddressList>,
+}
+
+impl ChainConfig {
+    /// Set missing hardfork configurations to the defaults, if the chain has
+    /// a superchain_time set. Defaults are only used if the chain's hardfork
+    /// activated after the superchain_time.
+    pub fn set_missing_fork_configs(&mut self, defaults: &HardForkConfiguration) {
+        let Some(super_time) = self.superchain_time else {
+            return;
+        };
+        let cfg = &mut self.hardfork_configuration;
+
+        if cfg.canyon_time.is_none() && defaults.canyon_time.is_some_and(|t| t > super_time) {
+            cfg.canyon_time = defaults.canyon_time;
+        }
+        if cfg.delta_time.is_none() && defaults.delta_time.is_some_and(|t| t > super_time) {
+            cfg.delta_time = defaults.delta_time;
+        }
+        if cfg.ecotone_time.is_none() && defaults.ecotone_time.is_some_and(|t| t > super_time) {
+            cfg.ecotone_time = defaults.ecotone_time;
+        }
+        if cfg.fjord_time.is_none() && defaults.fjord_time.is_some_and(|t| t > super_time) {
+            cfg.fjord_time = defaults.fjord_time;
+        }
+        if cfg.granite_time.is_none() && defaults.granite_time.is_some_and(|t| t > super_time) {
+            cfg.granite_time = defaults.granite_time;
+        }
+        if cfg.holocene_time.is_none() && defaults.holocene_time.is_some_and(|t| t > super_time) {
+            cfg.holocene_time = defaults.holocene_time;
+        }
+    }
+}

--- a/crates/genesis/src/genesis.rs
+++ b/crates/genesis/src/genesis.rs
@@ -22,7 +22,7 @@ mod tests {
     use super::*;
     use alloy_primitives::{address, b256, uint};
 
-    fn ref_genesis() -> ChainGenesis {
+    const fn ref_genesis() -> ChainGenesis {
         ChainGenesis {
             l1: BlockNumHash {
                 hash: b256!("438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108"),

--- a/crates/genesis/src/genesis.rs
+++ b/crates/genesis/src/genesis.rs
@@ -18,6 +18,7 @@ pub struct ChainGenesis {
 }
 
 #[cfg(test)]
+#[cfg(feature = "serde")]
 mod tests {
     use super::*;
     use alloy_primitives::{address, b256, uint};

--- a/crates/genesis/src/genesis.rs
+++ b/crates/genesis/src/genesis.rs
@@ -1,0 +1,69 @@
+//! Genesis types.
+
+use crate::SystemConfig;
+use alloy_eips::eip1898::BlockNumHash;
+
+/// Chain genesis information.
+#[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ChainGenesis {
+    /// L1 genesis block
+    pub l1: BlockNumHash,
+    /// L2 genesis block
+    pub l2: BlockNumHash,
+    /// Timestamp of the L2 genesis block
+    pub l2_time: u64,
+    /// Optional System configuration
+    pub system_config: Option<SystemConfig>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{address, b256, uint};
+
+    fn ref_genesis() -> ChainGenesis {
+        ChainGenesis {
+            l1: BlockNumHash {
+                hash: b256!("438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108"),
+                number: 17422590,
+            },
+            l2: BlockNumHash {
+                hash: b256!("dbf6a80fef073de06add9b0d14026d6e5a86c85f6d102c36d3d8e9cf89c2afd3"),
+                number: 105235063,
+            },
+            l2_time: 1686068903,
+            system_config: Some(SystemConfig {
+                batcher_address: address!("6887246668a3b87F54DeB3b94Ba47a6f63F32985"),
+                overhead: uint!(0xbc_U256),
+                scalar: uint!(0xa6fe0_U256),
+                gas_limit: 30000000,
+                base_fee_scalar: None,
+                blob_base_fee_scalar: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_genesis_serde() {
+        let genesis_str = r#"{
+            "l1": {
+              "hash": "0x438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108",
+              "number": 17422590
+            },
+            "l2": {
+              "hash": "0xdbf6a80fef073de06add9b0d14026d6e5a86c85f6d102c36d3d8e9cf89c2afd3",
+              "number": 105235063
+            },
+            "l2_time": 1686068903,
+            "system_config": {
+              "batcherAddr": "0x6887246668a3b87F54DeB3b94Ba47a6f63F32985",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          }"#;
+        let genesis: ChainGenesis = serde_json::from_str(genesis_str).unwrap();
+        assert_eq!(genesis, ref_genesis());
+    }
+}

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -41,4 +41,4 @@ pub mod genesis;
 pub use genesis::ChainGenesis;
 
 pub mod rollup;
-pub use rollup::RollupConfig;
+pub use rollup::{RollupConfig, GRANITE_CHANNEL_TIMEOUT};

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -1,0 +1,44 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/alloy.jpg",
+    html_favicon_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/favicon.ico"
+)]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    unreachable_pub,
+    clippy::missing_const_for_fn,
+    rustdoc::all
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![deny(unused_must_use, rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+pub mod params;
+pub use params::{
+    base_fee_params, canyon_base_fee_params, BASE_SEPOLIA_BASE_FEE_PARAMS,
+    BASE_SEPOLIA_CANYON_BASE_FEE_PARAMS, BASE_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER,
+    OP_BASE_FEE_PARAMS, OP_CANYON_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS,
+    OP_SEPOLIA_CANYON_BASE_FEE_PARAMS, OP_SEPOLIA_EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR_CANYON,
+    OP_SEPOLIA_EIP1559_DEFAULT_BASE_FEE_MAX_CHANGE_DENOMINATOR,
+    OP_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER,
+};
+
+pub mod addresses;
+pub use addresses::AddressList;
+
+pub mod system;
+pub use system::SystemConfig;
+
+pub mod chain;
+pub use chain::ChainConfig;
+
+pub mod genesis;
+pub use genesis::ChainGenesis;
+
+pub mod rollup;
+pub use rollup::RollupConfig;

--- a/crates/genesis/src/params.rs
+++ b/crates/genesis/src/params.rs
@@ -2,28 +2,6 @@
 
 use alloy_eips::eip1559::BaseFeeParams;
 
-/// Returns the [BaseFeeParams] for the given chain id.
-pub const fn base_fee_params(chain_id: u64) -> BaseFeeParams {
-    match chain_id {
-        10 => OP_BASE_FEE_PARAMS,
-        11155420 => OP_SEPOLIA_BASE_FEE_PARAMS,
-        8453 => OP_BASE_FEE_PARAMS,
-        84532 => BASE_SEPOLIA_BASE_FEE_PARAMS,
-        _ => OP_BASE_FEE_PARAMS,
-    }
-}
-
-/// Returns the Canyon [BaseFeeParams] for the given chain id.
-pub const fn canyon_base_fee_params(chain_id: u64) -> BaseFeeParams {
-    match chain_id {
-        10 => OP_CANYON_BASE_FEE_PARAMS,
-        11155420 => OP_SEPOLIA_CANYON_BASE_FEE_PARAMS,
-        8453 => OP_CANYON_BASE_FEE_PARAMS,
-        84532 => BASE_SEPOLIA_CANYON_BASE_FEE_PARAMS,
-        _ => OP_CANYON_BASE_FEE_PARAMS,
-    }
-}
-
 /// Base fee max change denominator for Optimism Mainnet as defined in the Optimism
 /// [transaction costs](https://community.optimism.io/docs/developers/build/differences/#transaction-costs) doc.
 pub const OP_MAINNET_EIP1559_DEFAULT_BASE_FEE_MAX_CHANGE_DENOMINATOR: u128 = 50;
@@ -87,3 +65,25 @@ pub const OP_CANYON_BASE_FEE_PARAMS: BaseFeeParams = BaseFeeParams {
     max_change_denominator: OP_MAINNET_EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR_CANYON,
     elasticity_multiplier: OP_MAINNET_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER,
 };
+
+/// Returns the [BaseFeeParams] for the given chain id.
+pub const fn base_fee_params(chain_id: u64) -> BaseFeeParams {
+    match chain_id {
+        10 => OP_BASE_FEE_PARAMS,
+        11155420 => OP_SEPOLIA_BASE_FEE_PARAMS,
+        8453 => OP_BASE_FEE_PARAMS,
+        84532 => BASE_SEPOLIA_BASE_FEE_PARAMS,
+        _ => OP_BASE_FEE_PARAMS,
+    }
+}
+
+/// Returns the Canyon [BaseFeeParams] for the given chain id.
+pub const fn canyon_base_fee_params(chain_id: u64) -> BaseFeeParams {
+    match chain_id {
+        10 => OP_CANYON_BASE_FEE_PARAMS,
+        11155420 => OP_SEPOLIA_CANYON_BASE_FEE_PARAMS,
+        8453 => OP_CANYON_BASE_FEE_PARAMS,
+        84532 => BASE_SEPOLIA_CANYON_BASE_FEE_PARAMS,
+        _ => OP_CANYON_BASE_FEE_PARAMS,
+    }
+}

--- a/crates/genesis/src/params.rs
+++ b/crates/genesis/src/params.rs
@@ -1,0 +1,89 @@
+//! Module containing fee parameters.
+
+use alloy_eips::eip1559::BaseFeeParams;
+
+/// Returns the [BaseFeeParams] for the given chain id.
+pub fn base_fee_params(chain_id: u64) -> BaseFeeParams {
+    match chain_id {
+        10 => OP_BASE_FEE_PARAMS,
+        11155420 => OP_SEPOLIA_BASE_FEE_PARAMS,
+        8453 => OP_BASE_FEE_PARAMS,
+        84532 => BASE_SEPOLIA_BASE_FEE_PARAMS,
+        _ => OP_BASE_FEE_PARAMS,
+    }
+}
+
+/// Returns the Canyon [BaseFeeParams] for the given chain id.
+pub fn canyon_base_fee_params(chain_id: u64) -> BaseFeeParams {
+    match chain_id {
+        10 => OP_CANYON_BASE_FEE_PARAMS,
+        11155420 => OP_SEPOLIA_CANYON_BASE_FEE_PARAMS,
+        8453 => OP_CANYON_BASE_FEE_PARAMS,
+        84532 => BASE_SEPOLIA_CANYON_BASE_FEE_PARAMS,
+        _ => OP_CANYON_BASE_FEE_PARAMS,
+    }
+}
+
+/// Base fee max change denominator for Optimism Mainnet as defined in the Optimism
+/// [transaction costs](https://community.optimism.io/docs/developers/build/differences/#transaction-costs) doc.
+pub const OP_MAINNET_EIP1559_DEFAULT_BASE_FEE_MAX_CHANGE_DENOMINATOR: u128 = 50;
+
+/// Base fee max change denominator for Optimism Mainnet as defined in the Optimism Canyon
+/// hardfork.
+pub const OP_MAINNET_EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR_CANYON: u128 = 250;
+
+/// Base fee max change denominator for Optimism Mainnet as defined in the Optimism
+/// [transaction costs](https://community.optimism.io/docs/developers/build/differences/#transaction-costs) doc.
+pub const OP_MAINNET_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER: u128 = 6;
+
+/// Base fee max change denominator for Optimism Sepolia as defined in the Optimism
+/// [transaction costs](https://community.optimism.io/docs/developers/build/differences/#transaction-costs) doc.
+pub const OP_SEPOLIA_EIP1559_DEFAULT_BASE_FEE_MAX_CHANGE_DENOMINATOR: u128 = 50;
+
+/// Base fee max change denominator for Optimism Sepolia as defined in the Optimism Canyon
+/// hardfork.
+pub const OP_SEPOLIA_EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR_CANYON: u128 = 250;
+
+/// Base fee max change denominator for Optimism Sepolia as defined in the Optimism
+/// [transaction costs](https://community.optimism.io/docs/developers/build/differences/#transaction-costs) doc.
+pub const OP_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER: u128 = 6;
+
+/// Base fee max change denominator for Base Sepolia as defined in the Optimism
+/// [transaction costs](https://community.optimism.io/docs/developers/build/differences/#transaction-costs) doc.
+pub const BASE_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER: u128 = 10;
+
+/// Get the base fee parameters for Optimism Sepolia.
+pub const OP_SEPOLIA_BASE_FEE_PARAMS: BaseFeeParams = BaseFeeParams {
+    max_change_denominator: OP_SEPOLIA_EIP1559_DEFAULT_BASE_FEE_MAX_CHANGE_DENOMINATOR,
+    elasticity_multiplier: OP_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER,
+};
+
+/// Get the base fee parameters for Optimism Sepolia (post Canyon).
+pub const OP_SEPOLIA_CANYON_BASE_FEE_PARAMS: BaseFeeParams = BaseFeeParams {
+    max_change_denominator: OP_SEPOLIA_EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR_CANYON,
+    elasticity_multiplier: OP_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER,
+};
+
+/// Get the base fee parameters for Base Sepolia.
+pub const BASE_SEPOLIA_BASE_FEE_PARAMS: BaseFeeParams = BaseFeeParams {
+    max_change_denominator: OP_SEPOLIA_EIP1559_DEFAULT_BASE_FEE_MAX_CHANGE_DENOMINATOR,
+    elasticity_multiplier: BASE_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER,
+};
+
+/// Get the base fee parameters for Base Sepolia (post Canyon).
+pub const BASE_SEPOLIA_CANYON_BASE_FEE_PARAMS: BaseFeeParams = BaseFeeParams {
+    max_change_denominator: OP_SEPOLIA_EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR_CANYON,
+    elasticity_multiplier: BASE_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER,
+};
+
+/// Get the base fee parameters for Optimism Mainnet.
+pub const OP_BASE_FEE_PARAMS: BaseFeeParams = BaseFeeParams {
+    max_change_denominator: OP_MAINNET_EIP1559_DEFAULT_BASE_FEE_MAX_CHANGE_DENOMINATOR,
+    elasticity_multiplier: OP_MAINNET_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER,
+};
+
+/// Get the base fee parameters for Optimism Mainnet (post Canyon).
+pub const OP_CANYON_BASE_FEE_PARAMS: BaseFeeParams = BaseFeeParams {
+    max_change_denominator: OP_MAINNET_EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR_CANYON,
+    elasticity_multiplier: OP_MAINNET_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER,
+};

--- a/crates/genesis/src/params.rs
+++ b/crates/genesis/src/params.rs
@@ -3,7 +3,7 @@
 use alloy_eips::eip1559::BaseFeeParams;
 
 /// Returns the [BaseFeeParams] for the given chain id.
-pub fn base_fee_params(chain_id: u64) -> BaseFeeParams {
+pub const fn base_fee_params(chain_id: u64) -> BaseFeeParams {
     match chain_id {
         10 => OP_BASE_FEE_PARAMS,
         11155420 => OP_SEPOLIA_BASE_FEE_PARAMS,
@@ -14,7 +14,7 @@ pub fn base_fee_params(chain_id: u64) -> BaseFeeParams {
 }
 
 /// Returns the Canyon [BaseFeeParams] for the given chain id.
-pub fn canyon_base_fee_params(chain_id: u64) -> BaseFeeParams {
+pub const fn canyon_base_fee_params(chain_id: u64) -> BaseFeeParams {
     match chain_id {
         10 => OP_CANYON_BASE_FEE_PARAMS,
         11155420 => OP_SEPOLIA_CANYON_BASE_FEE_PARAMS,

--- a/crates/genesis/src/rollup.rs
+++ b/crates/genesis/src/rollup.rs
@@ -514,9 +514,9 @@ pub const BASE_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::U256;
-
     use super::*;
+    #[cfg(feature = "serde")]
+    use alloy_primitives::U256;
 
     #[test]
     fn test_regolith_active() {
@@ -611,6 +611,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_deserialize_reference_rollup_config() {
         // Reference serialized rollup config from the `op-node`.
         let ser_cfg = r#"

--- a/crates/genesis/src/rollup.rs
+++ b/crates/genesis/src/rollup.rs
@@ -6,9 +6,9 @@ use alloy_primitives::{address, b256, uint, Address};
 use alloy_eips::eip1898::BlockNumHash;
 
 use crate::{
-    base_fee_params, canyon_base_fee_params, ChainConfig, ChainGenesis, SystemConfig,
-    BASE_SEPOLIA_BASE_FEE_PARAMS, BASE_SEPOLIA_CANYON_BASE_FEE_PARAMS, OP_BASE_FEE_PARAMS,
-    OP_CANYON_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS, OP_SEPOLIA_CANYON_BASE_FEE_PARAMS,
+    ChainGenesis, SystemConfig, BASE_SEPOLIA_BASE_FEE_PARAMS, BASE_SEPOLIA_CANYON_BASE_FEE_PARAMS,
+    OP_BASE_FEE_PARAMS, OP_CANYON_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS,
+    OP_SEPOLIA_CANYON_BASE_FEE_PARAMS,
 };
 
 /// The max rlp bytes per channel for the Bedrock hardfork.
@@ -170,57 +170,6 @@ impl Default for RollupConfig {
             blobs_enabled_l1_timestamp: None,
             da_challenge_address: None,
         }
-    }
-}
-
-/// Loads the rollup config for the OP-Stack chain given the chain config and address list.
-pub fn load_op_stack_rollup_config(chain_config: &ChainConfig) -> RollupConfig {
-    RollupConfig {
-        genesis: chain_config.genesis,
-        l1_chain_id: chain_config.l1_chain_id,
-        l2_chain_id: chain_config.chain_id,
-        base_fee_params: base_fee_params(chain_config.chain_id),
-        canyon_base_fee_params: canyon_base_fee_params(chain_config.chain_id),
-        regolith_time: Some(0),
-        canyon_time: chain_config.hardfork_configuration.canyon_time,
-        delta_time: chain_config.hardfork_configuration.delta_time,
-        ecotone_time: chain_config.hardfork_configuration.ecotone_time,
-        fjord_time: chain_config.hardfork_configuration.fjord_time,
-        granite_time: chain_config.hardfork_configuration.granite_time,
-        holocene_time: chain_config.hardfork_configuration.holocene_time,
-        batch_inbox_address: chain_config.batch_inbox_addr,
-        deposit_contract_address: chain_config
-            .addresses
-            .as_ref()
-            .map(|a| a.optimism_portal_proxy)
-            .unwrap_or_default(),
-        l1_system_config_address: chain_config
-            .addresses
-            .as_ref()
-            .map(|a| a.system_config_proxy)
-            .unwrap_or_default(),
-        protocol_versions_address: chain_config
-            .addresses
-            .as_ref()
-            .map(|a| a.address_manager)
-            .unwrap_or_default(),
-        superchain_config_address: None,
-        blobs_enabled_l1_timestamp: None,
-        da_challenge_address: chain_config
-            .alt_da
-            .as_ref()
-            .and_then(|alt_da| alt_da.da_challenge_address),
-
-        // The below chain parameters can be different per OP-Stack chain,
-        // but since none of the superchain chains differ, it's not represented in the
-        // superchain-registry yet. This restriction on superchain-chains may change in the
-        // future. Test/Alt configurations can still load custom rollup-configs when
-        // necessary.
-        block_time: 2,
-        channel_timeout: 300,
-        granite_channel_timeout: GRANITE_CHANNEL_TIMEOUT,
-        max_sequencer_drift: 600,
-        seq_window_size: 3600,
     }
 }
 

--- a/crates/genesis/src/rollup.rs
+++ b/crates/genesis/src/rollup.rs
@@ -1,0 +1,707 @@
+//! Rollup Config Types
+
+use alloy_eips::eip1559::BaseFeeParams;
+use alloy_primitives::{address, b256, uint, Address};
+
+use alloy_eips::eip1898::BlockNumHash;
+
+use crate::{
+    base_fee_params, canyon_base_fee_params, ChainConfig, ChainGenesis, SystemConfig,
+    BASE_SEPOLIA_BASE_FEE_PARAMS, BASE_SEPOLIA_CANYON_BASE_FEE_PARAMS, OP_BASE_FEE_PARAMS,
+    OP_CANYON_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS, OP_SEPOLIA_CANYON_BASE_FEE_PARAMS,
+};
+
+/// The max rlp bytes per channel for the Bedrock hardfork.
+pub const MAX_RLP_BYTES_PER_CHANNEL_BEDROCK: u64 = 10_000_000;
+
+/// The max rlp bytes per channel for the Fjord hardfork.
+pub const MAX_RLP_BYTES_PER_CHANNEL_FJORD: u64 = 100_000_000;
+
+/// The max sequencer drift when the Fjord hardfork is active.
+pub const FJORD_MAX_SEQUENCER_DRIFT: u64 = 1800;
+
+/// The channel timeout once the Granite hardfork is active.
+pub const GRANITE_CHANNEL_TIMEOUT: u64 = 50;
+
+#[cfg(feature = "serde")]
+fn default_granite_channel_timeout() -> u64 {
+    GRANITE_CHANNEL_TIMEOUT
+}
+
+/// Returns the rollup config for the given chain ID.
+pub fn rollup_config_from_chain_id(chain_id: u64) -> Result<RollupConfig, &'static str> {
+    chain_id.try_into()
+}
+
+impl TryFrom<u64> for RollupConfig {
+    type Error = &'static str;
+
+    fn try_from(chain_id: u64) -> Result<RollupConfig, &'static str> {
+        match chain_id {
+            10 => Ok(OP_MAINNET_CONFIG),
+            11155420 => Ok(OP_SEPOLIA_CONFIG),
+            8453 => Ok(BASE_MAINNET_CONFIG),
+            84532 => Ok(BASE_SEPOLIA_CONFIG),
+            _ => Err("Unknown chain ID"),
+        }
+    }
+}
+
+/// The Rollup configuration.
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RollupConfig {
+    /// The genesis state of the rollup.
+    pub genesis: ChainGenesis,
+    /// The block time of the L2, in seconds.
+    pub block_time: u64,
+    /// Sequencer batches may not be more than MaxSequencerDrift seconds after
+    /// the L1 timestamp of the sequencing window end.
+    ///
+    /// Note: When L1 has many 1 second consecutive blocks, and L2 grows at fixed 2 seconds,
+    /// the L2 time may still grow beyond this difference.
+    ///
+    /// Note: After the Fjord hardfork, this value becomes a constant of `1800`.
+    pub max_sequencer_drift: u64,
+    /// The sequencer window size.
+    pub seq_window_size: u64,
+    /// Number of L1 blocks between when a channel can be opened and when it can be closed.
+    pub channel_timeout: u64,
+    /// The channel timeout after the Granite hardfork.
+    #[cfg_attr(feature = "serde", serde(default = "default_granite_channel_timeout"))]
+    pub granite_channel_timeout: u64,
+    /// The L1 chain ID
+    pub l1_chain_id: u64,
+    /// The L2 chain ID
+    pub l2_chain_id: u64,
+    /// Base Fee Params
+    #[cfg_attr(feature = "serde", serde(default = "BaseFeeParams::optimism"))]
+    pub base_fee_params: BaseFeeParams,
+    /// Base fee params post-canyon hardfork
+    #[cfg_attr(feature = "serde", serde(default = "BaseFeeParams::optimism_canyon"))]
+    pub canyon_base_fee_params: BaseFeeParams,
+    /// `regolith_time` sets the activation time of the Regolith network-upgrade:
+    /// a pre-mainnet Bedrock change that addresses findings of the Sherlock contest related to
+    /// deposit attributes. "Regolith" is the loose deposited rock that sits on top of Bedrock.
+    /// Active if regolith_time != None && L2 block timestamp >= Some(regolith_time), inactive
+    /// otherwise.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub regolith_time: Option<u64>,
+    /// `canyon_time` sets the activation time of the Canyon network upgrade.
+    /// Active if `canyon_time` != None && L2 block timestamp >= Some(canyon_time), inactive
+    /// otherwise.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub canyon_time: Option<u64>,
+    /// `delta_time` sets the activation time of the Delta network upgrade.
+    /// Active if `delta_time` != None && L2 block timestamp >= Some(delta_time), inactive
+    /// otherwise.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub delta_time: Option<u64>,
+    /// `ecotone_time` sets the activation time of the Ecotone network upgrade.
+    /// Active if `ecotone_time` != None && L2 block timestamp >= Some(ecotone_time), inactive
+    /// otherwise.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub ecotone_time: Option<u64>,
+    /// `fjord_time` sets the activation time of the Fjord network upgrade.
+    /// Active if `fjord_time` != None && L2 block timestamp >= Some(fjord_time), inactive
+    /// otherwise.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub fjord_time: Option<u64>,
+    /// `granite_time` sets the activation time for the Granite network upgrade.
+    /// Active if `granite_time` != None && L2 block timestamp >= Some(granite_time), inactive
+    /// otherwise.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub granite_time: Option<u64>,
+    /// `holocene_time` sets the activation time for the Holocene network upgrade.
+    /// Active if `holocene_time` != None && L2 block timestamp >= Some(holocene_time), inactive
+    /// otherwise.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub holocene_time: Option<u64>,
+    /// `batch_inbox_address` is the L1 address that batches are sent to.
+    pub batch_inbox_address: Address,
+    /// `deposit_contract_address` is the L1 address that deposits are sent to.
+    pub deposit_contract_address: Address,
+    /// `l1_system_config_address` is the L1 address that the system config is stored at.
+    pub l1_system_config_address: Address,
+    /// `protocol_versions_address` is the L1 address that the protocol versions are stored at.
+    pub protocol_versions_address: Address,
+    /// The superchain config address.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub superchain_config_address: Option<Address>,
+    /// `blobs_enabled_l1_timestamp` is the timestamp to start reading blobs as a batch data
+    /// source. Optional.
+    #[cfg_attr(
+        feature = "serde",
+        serde(rename = "blobs_data", skip_serializing_if = "Option::is_none")
+    )]
+    pub blobs_enabled_l1_timestamp: Option<u64>,
+    /// `da_challenge_address` is the L1 address that the data availability challenge contract is
+    /// stored at.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub da_challenge_address: Option<Address>,
+}
+
+// Need to manually implement Default because [`BaseFeeParams`] has no Default impl.
+impl Default for RollupConfig {
+    fn default() -> Self {
+        RollupConfig {
+            genesis: ChainGenesis::default(),
+            block_time: 0,
+            max_sequencer_drift: 0,
+            seq_window_size: 0,
+            channel_timeout: 0,
+            granite_channel_timeout: GRANITE_CHANNEL_TIMEOUT,
+            l1_chain_id: 0,
+            l2_chain_id: 0,
+            base_fee_params: OP_BASE_FEE_PARAMS,
+            canyon_base_fee_params: OP_CANYON_BASE_FEE_PARAMS,
+            regolith_time: None,
+            canyon_time: None,
+            delta_time: None,
+            ecotone_time: None,
+            fjord_time: None,
+            granite_time: None,
+            holocene_time: None,
+            batch_inbox_address: Address::ZERO,
+            deposit_contract_address: Address::ZERO,
+            l1_system_config_address: Address::ZERO,
+            protocol_versions_address: Address::ZERO,
+            superchain_config_address: None,
+            blobs_enabled_l1_timestamp: None,
+            da_challenge_address: None,
+        }
+    }
+}
+
+/// Loads the rollup config for the OP-Stack chain given the chain config and address list.
+pub fn load_op_stack_rollup_config(chain_config: &ChainConfig) -> RollupConfig {
+    RollupConfig {
+        genesis: chain_config.genesis.clone(),
+        l1_chain_id: chain_config.l1_chain_id,
+        l2_chain_id: chain_config.chain_id,
+        base_fee_params: base_fee_params(chain_config.chain_id),
+        canyon_base_fee_params: canyon_base_fee_params(chain_config.chain_id),
+        regolith_time: Some(0),
+        canyon_time: chain_config.hardfork_configuration.canyon_time,
+        delta_time: chain_config.hardfork_configuration.delta_time,
+        ecotone_time: chain_config.hardfork_configuration.ecotone_time,
+        fjord_time: chain_config.hardfork_configuration.fjord_time,
+        granite_time: chain_config.hardfork_configuration.granite_time,
+        holocene_time: chain_config.hardfork_configuration.holocene_time,
+        batch_inbox_address: chain_config.batch_inbox_addr,
+        deposit_contract_address: chain_config
+            .addresses
+            .as_ref()
+            .map(|a| a.optimism_portal_proxy)
+            .unwrap_or_default(),
+        l1_system_config_address: chain_config
+            .addresses
+            .as_ref()
+            .map(|a| a.system_config_proxy)
+            .unwrap_or_default(),
+        protocol_versions_address: chain_config
+            .addresses
+            .as_ref()
+            .map(|a| a.address_manager)
+            .unwrap_or_default(),
+        superchain_config_address: None,
+        blobs_enabled_l1_timestamp: None,
+        da_challenge_address: chain_config
+            .alt_da
+            .as_ref()
+            .and_then(|alt_da| alt_da.da_challenge_address),
+
+        // The below chain parameters can be different per OP-Stack chain,
+        // but since none of the superchain chains differ, it's not represented in the
+        // superchain-registry yet. This restriction on superchain-chains may change in the
+        // future. Test/Alt configurations can still load custom rollup-configs when
+        // necessary.
+        block_time: 2,
+        channel_timeout: 300,
+        granite_channel_timeout: GRANITE_CHANNEL_TIMEOUT,
+        max_sequencer_drift: 600,
+        seq_window_size: 3600,
+    }
+}
+
+impl RollupConfig {
+    /// Returns true if Regolith is active at the given timestamp.
+    pub fn is_regolith_active(&self, timestamp: u64) -> bool {
+        self.regolith_time.map_or(false, |t| timestamp >= t)
+    }
+
+    /// Returns true if Canyon is active at the given timestamp.
+    pub fn is_canyon_active(&self, timestamp: u64) -> bool {
+        self.canyon_time.map_or(false, |t| timestamp >= t)
+    }
+
+    /// Returns true if Delta is active at the given timestamp.
+    pub fn is_delta_active(&self, timestamp: u64) -> bool {
+        self.delta_time.map_or(false, |t| timestamp >= t)
+    }
+
+    /// Returns true if Ecotone is active at the given timestamp.
+    pub fn is_ecotone_active(&self, timestamp: u64) -> bool {
+        self.ecotone_time.map_or(false, |t| timestamp >= t)
+    }
+
+    /// Returns true if Fjord is active at the given timestamp.
+    pub fn is_fjord_active(&self, timestamp: u64) -> bool {
+        self.fjord_time.map_or(false, |t| timestamp >= t)
+    }
+
+    /// Returns true if Granite is active at the given timestamp.
+    pub fn is_granite_active(&self, timestamp: u64) -> bool {
+        self.granite_time.map_or(false, |t| timestamp >= t)
+    }
+
+    /// Returns true if Holocene is active at the given timestamp.
+    pub fn is_holocene_active(&self, timestamp: u64) -> bool {
+        self.holocene_time.map_or(false, |t| timestamp >= t)
+    }
+
+    /// Returns true if a DA Challenge proxy Address is provided in the rollup config and the
+    /// address is not zero.
+    pub fn is_alt_da_enabled(&self) -> bool {
+        self.da_challenge_address.map_or(false, |addr| !addr.is_zero())
+    }
+
+    /// Returns the max sequencer drift for the given timestamp.
+    pub fn max_sequencer_drift(&self, timestamp: u64) -> u64 {
+        if self.is_fjord_active(timestamp) {
+            FJORD_MAX_SEQUENCER_DRIFT
+        } else {
+            self.max_sequencer_drift
+        }
+    }
+
+    /// Returns the max rlp bytes per channel for the given timestamp.
+    pub fn max_rlp_bytes_per_channel(&self, timestamp: u64) -> u64 {
+        if self.is_fjord_active(timestamp) {
+            MAX_RLP_BYTES_PER_CHANNEL_FJORD
+        } else {
+            MAX_RLP_BYTES_PER_CHANNEL_BEDROCK
+        }
+    }
+
+    /// Returns the channel timeout for the given timestamp.
+    pub fn channel_timeout(&self, timestamp: u64) -> u64 {
+        if self.is_granite_active(timestamp) {
+            self.granite_channel_timeout
+        } else {
+            self.channel_timeout
+        }
+    }
+
+    /// Checks the scalar value in Ecotone.
+    pub fn check_ecotone_l1_system_config_scalar(scalar: [u8; 32]) -> Result<(), &'static str> {
+        let version_byte = scalar[0];
+        match version_byte {
+            0 => {
+                if scalar[1..28] != [0; 27] {
+                    return Err("Bedrock scalar padding not empty");
+                }
+                Ok(())
+            }
+            1 => {
+                if scalar[1..24] != [0; 23] {
+                    return Err("Invalid version 1 scalar padding");
+                }
+                Ok(())
+            }
+            _ => {
+                // ignore the event if it's an unknown scalar format
+                Err("Unrecognized scalar version")
+            }
+        }
+    }
+
+    /// Returns the [RollupConfig] for the given L2 chain ID.
+    pub fn from_l2_chain_id(l2_chain_id: u64) -> Option<RollupConfig> {
+        match l2_chain_id {
+            10 => Some(OP_MAINNET_CONFIG),
+            11155420 => Some(OP_SEPOLIA_CONFIG),
+            8453 => Some(BASE_MAINNET_CONFIG),
+            84532 => Some(BASE_SEPOLIA_CONFIG),
+            _ => None,
+        }
+    }
+}
+
+/// The [RollupConfig] for OP Mainnet.
+pub const OP_MAINNET_CONFIG: RollupConfig = RollupConfig {
+    genesis: ChainGenesis {
+        l1: BlockNumHash {
+            hash: b256!("438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108"),
+            number: 17_422_590_u64,
+        },
+        l2: BlockNumHash {
+            hash: b256!("dbf6a80fef073de06add9b0d14026d6e5a86c85f6d102c36d3d8e9cf89c2afd3"),
+            number: 105_235_063_u64,
+        },
+        l2_time: 1_686_068_903_u64,
+        system_config: Some(SystemConfig {
+            batcher_address: address!("6887246668a3b87f54deb3b94ba47a6f63f32985"),
+            overhead: uint!(0xbc_U256),
+            scalar: uint!(0xa6fe0_U256),
+            gas_limit: 30_000_000_u64,
+            base_fee_scalar: None,
+            blob_base_fee_scalar: None,
+        }),
+    },
+    block_time: 2_u64,
+    max_sequencer_drift: 600_u64,
+    seq_window_size: 3600_u64,
+    channel_timeout: 300_u64,
+    granite_channel_timeout: 50,
+    l1_chain_id: 1_u64,
+    l2_chain_id: 10_u64,
+    base_fee_params: OP_BASE_FEE_PARAMS,
+    canyon_base_fee_params: OP_CANYON_BASE_FEE_PARAMS,
+    regolith_time: Some(0_u64),
+    canyon_time: Some(1_704_992_401_u64),
+    delta_time: Some(1_708_560_000_u64),
+    ecotone_time: Some(1_710_374_401_u64),
+    fjord_time: Some(1_720_627_201_u64),
+    granite_time: Some(1_726_070_401_u64),
+    holocene_time: None,
+    batch_inbox_address: address!("ff00000000000000000000000000000000000010"),
+    deposit_contract_address: address!("beb5fc579115071764c7423a4f12edde41f106ed"),
+    l1_system_config_address: address!("229047fed2591dbec1ef1118d64f7af3db9eb290"),
+    protocol_versions_address: address!("8062abc286f5e7d9428a0ccb9abd71e50d93b935"),
+    superchain_config_address: Some(address!("95703e0982140D16f8ebA6d158FccEde42f04a4C")),
+    da_challenge_address: None,
+    blobs_enabled_l1_timestamp: None,
+};
+
+/// The [RollupConfig] for OP Sepolia.
+pub const OP_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
+    genesis: ChainGenesis {
+        l1: BlockNumHash {
+            hash: b256!("48f520cf4ddaf34c8336e6e490632ea3cf1e5e93b0b2bc6e917557e31845371b"),
+            number: 4071408,
+        },
+        l2: BlockNumHash {
+            hash: b256!("102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d"),
+            number: 0,
+        },
+        l2_time: 1691802540,
+        system_config: Some(SystemConfig {
+            batcher_address: address!("8f23bb38f531600e5d8fddaaec41f13fab46e98c"),
+            overhead: uint!(0xbc_U256),
+            scalar: uint!(0xa6fe0_U256),
+            gas_limit: 30_000_000,
+            base_fee_scalar: None,
+            blob_base_fee_scalar: None,
+        }),
+    },
+    block_time: 2,
+    max_sequencer_drift: 600,
+    seq_window_size: 3600,
+    channel_timeout: 300,
+    granite_channel_timeout: 50,
+    l1_chain_id: 11155111,
+    l2_chain_id: 11155420,
+    base_fee_params: OP_SEPOLIA_BASE_FEE_PARAMS,
+    canyon_base_fee_params: OP_SEPOLIA_CANYON_BASE_FEE_PARAMS,
+    regolith_time: Some(0),
+    canyon_time: Some(1699981200),
+    delta_time: Some(1703203200),
+    ecotone_time: Some(1708534800),
+    fjord_time: Some(1716998400),
+    granite_time: Some(1723478400),
+    holocene_time: None,
+    batch_inbox_address: address!("ff00000000000000000000000000000011155420"),
+    deposit_contract_address: address!("16fc5058f25648194471939df75cf27a2fdc48bc"),
+    l1_system_config_address: address!("034edd2a225f7f429a63e0f1d2084b9e0a93b538"),
+    protocol_versions_address: address!("79add5713b383daa0a138d3c4780c7a1804a8090"),
+    superchain_config_address: Some(address!("C2Be75506d5724086DEB7245bd260Cc9753911Be")),
+    da_challenge_address: None,
+    blobs_enabled_l1_timestamp: None,
+};
+
+/// The [RollupConfig] for Base Mainnet.
+pub const BASE_MAINNET_CONFIG: RollupConfig = RollupConfig {
+    genesis: ChainGenesis {
+        l1: BlockNumHash {
+            hash: b256!("5c13d307623a926cd31415036c8b7fa14572f9dac64528e857a470511fc30771"),
+            number: 17_481_768_u64,
+        },
+        l2: BlockNumHash {
+            hash: b256!("f712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd"),
+            number: 0_u64,
+        },
+        l2_time: 1686789347_u64,
+        system_config: Some(SystemConfig {
+            batcher_address: address!("5050f69a9786f081509234f1a7f4684b5e5b76c9"),
+            overhead: uint!(0xbc_U256),
+            scalar: uint!(0xa6fe0_U256),
+            gas_limit: 30_000_000_u64,
+            base_fee_scalar: None,
+            blob_base_fee_scalar: None,
+        }),
+    },
+    block_time: 2,
+    max_sequencer_drift: 600,
+    seq_window_size: 3600,
+    channel_timeout: 300,
+    granite_channel_timeout: 50,
+    l1_chain_id: 1,
+    l2_chain_id: 8453,
+    base_fee_params: OP_BASE_FEE_PARAMS,
+    canyon_base_fee_params: OP_CANYON_BASE_FEE_PARAMS,
+    regolith_time: Some(0_u64),
+    canyon_time: Some(1704992401),
+    delta_time: Some(1708560000),
+    ecotone_time: Some(1710374401),
+    fjord_time: Some(1720627201),
+    granite_time: Some(1_726_070_401_u64),
+    holocene_time: None,
+    batch_inbox_address: address!("ff00000000000000000000000000000000008453"),
+    deposit_contract_address: address!("49048044d57e1c92a77f79988d21fa8faf74e97e"),
+    l1_system_config_address: address!("73a79fab69143498ed3712e519a88a918e1f4072"),
+    protocol_versions_address: address!("8062abc286f5e7d9428a0ccb9abd71e50d93b935"),
+    superchain_config_address: Some(address!("95703e0982140D16f8ebA6d158FccEde42f04a4C")),
+    da_challenge_address: None,
+    blobs_enabled_l1_timestamp: None,
+};
+
+/// The [RollupConfig] for Base Sepolia.
+pub const BASE_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
+    genesis: ChainGenesis {
+        l1: BlockNumHash {
+            hash: b256!("cac9a83291d4dec146d6f7f69ab2304f23f5be87b1789119a0c5b1e4482444ed"),
+            number: 4370868,
+        },
+        l2: BlockNumHash {
+            hash: b256!("0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4"),
+            number: 0,
+        },
+        l2_time: 1695768288,
+        system_config: Some(SystemConfig {
+            batcher_address: address!("6cdebe940bc0f26850285caca097c11c33103e47"),
+            overhead: uint!(0x834_U256),
+            scalar: uint!(0xf4240_U256),
+            gas_limit: 25000000,
+            base_fee_scalar: None,
+            blob_base_fee_scalar: None,
+        }),
+    },
+    block_time: 2,
+    max_sequencer_drift: 600,
+    seq_window_size: 3600,
+    channel_timeout: 300,
+    granite_channel_timeout: 50,
+    l1_chain_id: 11155111,
+    l2_chain_id: 84532,
+    base_fee_params: BASE_SEPOLIA_BASE_FEE_PARAMS,
+    canyon_base_fee_params: BASE_SEPOLIA_CANYON_BASE_FEE_PARAMS,
+    regolith_time: Some(0),
+    canyon_time: Some(1699981200),
+    delta_time: Some(1703203200),
+    ecotone_time: Some(1708534800),
+    fjord_time: Some(1716998400),
+    granite_time: Some(1723478400),
+    holocene_time: None,
+    batch_inbox_address: address!("ff00000000000000000000000000000000084532"),
+    deposit_contract_address: address!("49f53e41452c74589e85ca1677426ba426459e85"),
+    l1_system_config_address: address!("f272670eb55e895584501d564afeb048bed26194"),
+    protocol_versions_address: address!("79add5713b383daa0a138d3c4780c7a1804a8090"),
+    superchain_config_address: Some(address!("C2Be75506d5724086DEB7245bd260Cc9753911Be")),
+    da_challenge_address: None,
+    blobs_enabled_l1_timestamp: None,
+};
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::U256;
+
+    use super::*;
+
+    #[test]
+    fn test_regolith_active() {
+        let mut config = RollupConfig::default();
+        assert!(!config.is_regolith_active(0));
+        config.regolith_time = Some(10);
+        assert!(config.is_regolith_active(10));
+        assert!(!config.is_regolith_active(9));
+    }
+
+    #[test]
+    fn test_canyon_active() {
+        let mut config = RollupConfig::default();
+        assert!(!config.is_canyon_active(0));
+        config.canyon_time = Some(10);
+        assert!(config.is_canyon_active(10));
+        assert!(!config.is_canyon_active(9));
+    }
+
+    #[test]
+    fn test_delta_active() {
+        let mut config = RollupConfig::default();
+        assert!(!config.is_delta_active(0));
+        config.delta_time = Some(10);
+        assert!(config.is_delta_active(10));
+        assert!(!config.is_delta_active(9));
+    }
+
+    #[test]
+    fn test_ecotone_active() {
+        let mut config = RollupConfig::default();
+        assert!(!config.is_ecotone_active(0));
+        config.ecotone_time = Some(10);
+        assert!(config.is_ecotone_active(10));
+        assert!(!config.is_ecotone_active(9));
+    }
+
+    #[test]
+    fn test_fjord_active() {
+        let mut config = RollupConfig::default();
+        assert!(!config.is_fjord_active(0));
+        config.fjord_time = Some(10);
+        assert!(config.is_fjord_active(10));
+        assert!(!config.is_fjord_active(9));
+    }
+
+    #[test]
+    fn test_granite_active() {
+        let mut config = RollupConfig::default();
+        assert!(!config.is_granite_active(0));
+        config.granite_time = Some(10);
+        assert!(config.is_granite_active(10));
+        assert!(!config.is_granite_active(9));
+    }
+
+    #[test]
+    fn test_holocene_active() {
+        let mut config = RollupConfig::default();
+        assert!(!config.is_holocene_active(0));
+        config.holocene_time = Some(10);
+        assert!(config.is_holocene_active(10));
+        assert!(!config.is_holocene_active(9));
+    }
+
+    #[test]
+    fn test_alt_da_enabled() {
+        let mut config = RollupConfig::default();
+        assert!(!config.is_alt_da_enabled());
+        config.da_challenge_address = Some(Address::ZERO);
+        assert!(!config.is_alt_da_enabled());
+        config.da_challenge_address = Some(address!("0000000000000000000000000000000000000001"));
+        assert!(config.is_alt_da_enabled());
+    }
+
+    #[test]
+    fn test_granite_channel_timeout() {
+        let mut config =
+            RollupConfig { channel_timeout: 100, granite_time: Some(10), ..Default::default() };
+        assert_eq!(config.channel_timeout(0), 100);
+        assert_eq!(config.channel_timeout(10), GRANITE_CHANNEL_TIMEOUT);
+        config.granite_time = None;
+        assert_eq!(config.channel_timeout(10), 100);
+    }
+
+    #[test]
+    fn test_max_sequencer_drift() {
+        let mut config = RollupConfig { max_sequencer_drift: 100, ..Default::default() };
+        assert_eq!(config.max_sequencer_drift(0), 100);
+        config.fjord_time = Some(10);
+        assert_eq!(config.max_sequencer_drift(0), 100);
+        assert_eq!(config.max_sequencer_drift(10), FJORD_MAX_SEQUENCER_DRIFT);
+    }
+
+    #[test]
+    fn test_deserialize_reference_rollup_config() {
+        // Reference serialized rollup config from the `op-node`.
+        let ser_cfg = r#"
+{
+  "genesis": {
+    "l1": {
+      "hash": "0x481724ee99b1f4cb71d826e2ec5a37265f460e9b112315665c977f4050b0af54",
+      "number": 10
+    },
+    "l2": {
+      "hash": "0x88aedfbf7dea6bfa2c4ff315784ad1a7f145d8f650969359c003bbed68c87631",
+      "number": 0
+    },
+    "l2_time": 1725557164,
+    "system_config": {
+      "batcherAddr": "0xc81f87a644b41e49b3221f41251f15c6cb00ce03",
+      "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "scalar": "0x00000000000000000000000000000000000000000000000000000000000f4240",
+      "gasLimit": 30000000
+    }
+  },
+  "block_time": 2,
+  "max_sequencer_drift": 600,
+  "seq_window_size": 3600,
+  "channel_timeout": 300,
+  "l1_chain_id": 3151908,
+  "l2_chain_id": 1337,
+  "regolith_time": 0,
+  "canyon_time": 0,
+  "delta_time": 0,
+  "ecotone_time": 0,
+  "fjord_time": 0,
+  "batch_inbox_address": "0xff00000000000000000000000000000000042069",
+  "deposit_contract_address": "0x08073dc48dde578137b8af042bcbc1c2491f1eb2",
+  "l1_system_config_address": "0x94ee52a9d8edd72a85dea7fae3ba6d75e4bf1710",
+  "protocol_versions_address": "0x0000000000000000000000000000000000000000"
+}
+        "#;
+        let config: RollupConfig = serde_json::from_str(ser_cfg).unwrap();
+
+        // Validate standard fields.
+        assert_eq!(
+            config.genesis,
+            ChainGenesis {
+                l1: BlockNumHash {
+                    hash: b256!("481724ee99b1f4cb71d826e2ec5a37265f460e9b112315665c977f4050b0af54"),
+                    number: 10
+                },
+                l2: BlockNumHash {
+                    hash: b256!("88aedfbf7dea6bfa2c4ff315784ad1a7f145d8f650969359c003bbed68c87631"),
+                    number: 0
+                },
+                l2_time: 1725557164,
+                system_config: Some(SystemConfig {
+                    batcher_address: address!("c81f87a644b41e49b3221f41251f15c6cb00ce03"),
+                    overhead: U256::ZERO,
+                    scalar: U256::from(0xf4240),
+                    gas_limit: 30_000_000,
+                    base_fee_scalar: None,
+                    blob_base_fee_scalar: None
+                })
+            }
+        );
+        assert_eq!(config.block_time, 2);
+        assert_eq!(config.max_sequencer_drift, 600);
+        assert_eq!(config.seq_window_size, 3600);
+        assert_eq!(config.channel_timeout, 300);
+        assert_eq!(config.l1_chain_id, 3151908);
+        assert_eq!(config.l2_chain_id, 1337);
+        assert_eq!(config.regolith_time, Some(0));
+        assert_eq!(config.canyon_time, Some(0));
+        assert_eq!(config.delta_time, Some(0));
+        assert_eq!(config.ecotone_time, Some(0));
+        assert_eq!(config.fjord_time, Some(0));
+        assert_eq!(
+            config.batch_inbox_address,
+            address!("ff00000000000000000000000000000000042069")
+        );
+        assert_eq!(
+            config.deposit_contract_address,
+            address!("08073dc48dde578137b8af042bcbc1c2491f1eb2")
+        );
+        assert_eq!(
+            config.l1_system_config_address,
+            address!("94ee52a9d8edd72a85dea7fae3ba6d75e4bf1710")
+        );
+        assert_eq!(config.protocol_versions_address, Address::ZERO);
+
+        // Validate non-standard fields.
+        assert_eq!(config.granite_channel_timeout, GRANITE_CHANNEL_TIMEOUT);
+        assert_eq!(config.base_fee_params, OP_BASE_FEE_PARAMS);
+        assert_eq!(config.canyon_base_fee_params, OP_CANYON_BASE_FEE_PARAMS);
+    }
+}

--- a/crates/genesis/src/rollup.rs
+++ b/crates/genesis/src/rollup.rs
@@ -24,7 +24,7 @@ pub const FJORD_MAX_SEQUENCER_DRIFT: u64 = 1800;
 pub const GRANITE_CHANNEL_TIMEOUT: u64 = 50;
 
 #[cfg(feature = "serde")]
-fn default_granite_channel_timeout() -> u64 {
+const fn default_granite_channel_timeout() -> u64 {
     GRANITE_CHANNEL_TIMEOUT
 }
 
@@ -176,7 +176,7 @@ impl Default for RollupConfig {
 /// Loads the rollup config for the OP-Stack chain given the chain config and address list.
 pub fn load_op_stack_rollup_config(chain_config: &ChainConfig) -> RollupConfig {
     RollupConfig {
-        genesis: chain_config.genesis.clone(),
+        genesis: chain_config.genesis,
         l1_chain_id: chain_config.l1_chain_id,
         l2_chain_id: chain_config.chain_id,
         base_fee_params: base_fee_params(chain_config.chain_id),
@@ -317,7 +317,7 @@ impl RollupConfig {
     }
 
     /// Returns the [RollupConfig] for the given L2 chain ID.
-    pub fn from_l2_chain_id(l2_chain_id: u64) -> Option<RollupConfig> {
+    pub const fn from_l2_chain_id(l2_chain_id: u64) -> Option<RollupConfig> {
         match l2_chain_id {
             10 => Some(OP_MAINNET_CONFIG),
             11155420 => Some(OP_SEPOLIA_CONFIG),

--- a/crates/genesis/src/system.rs
+++ b/crates/genesis/src/system.rs
@@ -78,10 +78,9 @@ impl SystemConfig {
                 if log.address == rollup_config.l1_system_config_address
                     && !topics.is_empty()
                     && topics[0] == CONFIG_UPDATE_TOPIC
+                    && self.process_config_update_log(log, rollup_config, l1_time).is_err()
                 {
-                    if let Err(_) = self.process_config_update_log(log, rollup_config, l1_time) {
-                        return Err("Failed to process config update log");
-                    }
+                    return Err("Failed to process config update log");
                 }
                 Ok::<_, &'static str>(())
             })?;
@@ -298,7 +297,7 @@ mod test {
             b256!("0000000000000000000000000000000000000000000000000000000000000000");
 
         let mut system_config = SystemConfig::default();
-        let rollup_config = mock_rollup_config(system_config.clone());
+        let rollup_config = mock_rollup_config(system_config);
 
         let update_log = Log {
             address: Address::ZERO,
@@ -327,7 +326,7 @@ mod test {
             b256!("0000000000000000000000000000000000000000000000000000000000000001");
 
         let mut system_config = SystemConfig::default();
-        let rollup_config = mock_rollup_config(system_config.clone());
+        let rollup_config = mock_rollup_config(system_config);
 
         let update_log = Log {
             address: Address::ZERO,
@@ -354,7 +353,7 @@ mod test {
             b256!("0000000000000000000000000000000000000000000000000000000000000001");
 
         let mut system_config = SystemConfig::default();
-        let rollup_config = mock_rollup_config(system_config.clone());
+        let rollup_config = mock_rollup_config(system_config);
 
         let update_log = Log {
             address: Address::ZERO,
@@ -381,7 +380,7 @@ mod test {
             b256!("0000000000000000000000000000000000000000000000000000000000000002");
 
         let mut system_config = SystemConfig::default();
-        let rollup_config = mock_rollup_config(system_config.clone());
+        let rollup_config = mock_rollup_config(system_config);
 
         let update_log = Log {
             address: Address::ZERO,

--- a/crates/genesis/src/system.rs
+++ b/crates/genesis/src/system.rs
@@ -1,0 +1,403 @@
+//! System Config Type
+
+use crate::RollupConfig;
+use alloy_consensus::{Eip658Value, Receipt};
+use alloy_primitives::{address, b256, Address, Log, B256, U256, U64};
+use alloy_sol_types::{sol, SolType};
+
+/// `keccak256("ConfigUpdate(uint256,uint8,bytes)")`
+pub const CONFIG_UPDATE_TOPIC: B256 =
+    b256!("1d2b0bda21d56b8bd12d4f94ebacffdfb35f5e226f84b461103bb8beab6353be");
+
+/// The initial version of the system config event log.
+pub const CONFIG_UPDATE_EVENT_VERSION_0: B256 = B256::ZERO;
+
+/// System configuration.
+#[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct SystemConfig {
+    /// Batcher address
+    #[cfg_attr(feature = "serde", serde(rename = "batcherAddr"))]
+    pub batcher_address: Address,
+    /// Fee overhead value
+    pub overhead: U256,
+    /// Fee scalar value
+    pub scalar: U256,
+    /// Gas limit value
+    pub gas_limit: u64,
+    /// Base fee scalar value
+    pub base_fee_scalar: Option<u64>,
+    /// Blob base fee scalar value
+    pub blob_base_fee_scalar: Option<u64>,
+}
+
+/// Represents type of update to the system config.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[repr(u64)]
+pub enum SystemConfigUpdateType {
+    /// Batcher update type
+    Batcher = 0,
+    /// Gas config update type
+    GasConfig = 1,
+    /// Gas limit update type
+    GasLimit = 2,
+    /// Unsafe block signer update type
+    UnsafeBlockSigner = 3,
+}
+
+impl TryFrom<u64> for SystemConfigUpdateType {
+    type Error = &'static str;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(SystemConfigUpdateType::Batcher),
+            1 => Ok(SystemConfigUpdateType::GasConfig),
+            2 => Ok(SystemConfigUpdateType::GasLimit),
+            3 => Ok(SystemConfigUpdateType::UnsafeBlockSigner),
+            _ => Err("Invalid SystemConfigUpdateType value"),
+        }
+    }
+}
+
+impl SystemConfig {
+    /// Filters all L1 receipts to find config updates and applies the config updates.
+    pub fn update_with_receipts(
+        &mut self,
+        receipts: &[Receipt],
+        rollup_config: &RollupConfig,
+        l1_time: u64,
+    ) -> Result<(), &'static str> {
+        for receipt in receipts {
+            if Eip658Value::Eip658(false) == receipt.status {
+                continue;
+            }
+
+            receipt.logs.iter().try_for_each(|log| {
+                let topics = log.topics();
+                if log.address == rollup_config.l1_system_config_address
+                    && !topics.is_empty()
+                    && topics[0] == CONFIG_UPDATE_TOPIC
+                {
+                    if let Err(_) = self.process_config_update_log(log, rollup_config, l1_time) {
+                        return Err("Failed to process config update log");
+                    }
+                }
+                Ok::<_, &'static str>(())
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Decodes an EVM log entry emitted by the system config contract and applies it as a
+    /// [SystemConfig] change.
+    ///
+    /// Parse log data for:
+    ///
+    /// ```text
+    /// event ConfigUpdate(
+    ///    uint256 indexed version,
+    ///    UpdateType indexed updateType,
+    ///    bytes data
+    /// );
+    /// ```
+    fn process_config_update_log(
+        &mut self,
+        log: &Log,
+        rollup_config: &RollupConfig,
+        l1_time: u64,
+    ) -> Result<(), &'static str> {
+        if log.topics().len() < 3 {
+            return Err("Invalid config update log: not enough topics");
+        }
+        if log.topics()[0] != CONFIG_UPDATE_TOPIC {
+            return Err("Invalid config update log: invalid topic");
+        }
+
+        // Parse the config update log
+        let version = log.topics()[1];
+        if version != CONFIG_UPDATE_EVENT_VERSION_0 {
+            return Err("Invalid config update log: unsupported version");
+        }
+        let Ok(topic_bytes) = log.topics()[2].as_slice()[0..8].try_into() else {
+            return Err("Invalid config update log: invalid update type");
+        };
+        let update_type = u64::from_be_bytes(topic_bytes);
+        let log_data = log.data.data.as_ref();
+
+        match update_type.try_into()? {
+            SystemConfigUpdateType::Batcher => {
+                if log_data.len() != 96 {
+                    return Err("Invalid config update log: invalid data length");
+                }
+
+                let Ok(pointer) = <sol!(uint64)>::abi_decode(&log_data[0..32], true) else {
+                    return Err("Failed to decode batcher update log");
+                };
+                if pointer != 32 {
+                    return Err("Invalid config update log: invalid data pointer");
+                }
+                let Ok(length) = <sol!(uint64)>::abi_decode(&log_data[32..64], true) else {
+                    return Err("Failed to decode batcher update log");
+                };
+                if length != 32 {
+                    return Err("Invalid config update log: invalid data length");
+                }
+
+                let Ok(batcher_address) =
+                    <sol!(address)>::abi_decode(&log.data.data.as_ref()[64..], true)
+                else {
+                    return Err("Failed to decode batcher update log");
+                };
+                self.batcher_address = batcher_address;
+            }
+            SystemConfigUpdateType::GasConfig => {
+                if log_data.len() != 128 {
+                    return Err("Invalid config update log: invalid data length");
+                }
+
+                let Ok(pointer) = <sol!(uint64)>::abi_decode(&log_data[0..32], true) else {
+                    return Err("Invalid config update log: invalid data pointer");
+                };
+
+                if pointer != 32 {
+                    return Err("Invalid config update log: invalid data pointer");
+                }
+                let Ok(length) = <sol!(uint64)>::abi_decode(&log_data[32..64], true) else {
+                    return Err("Invalid config update log: invalid data length");
+                };
+                if length != 64 {
+                    return Err("Invalid config update log: invalid data length");
+                }
+
+                let Ok(overhead) = <sol!(uint256)>::abi_decode(&log_data[64..96], true) else {
+                    return Err("Invalid config update log: invalid overhead");
+                };
+                let Ok(scalar) = <sol!(uint256)>::abi_decode(&log_data[96..], true) else {
+                    return Err("Invalid config update log: invalid scalar");
+                };
+
+                if rollup_config.is_ecotone_active(l1_time) {
+                    if RollupConfig::check_ecotone_l1_system_config_scalar(scalar.to_be_bytes())
+                        .is_err()
+                    {
+                        // ignore invalid scalars, retain the old system-config scalar
+                        return Ok(());
+                    }
+
+                    // retain the scalar data in encoded form
+                    self.scalar = scalar;
+                    // zero out the overhead, it will not affect the state-transition after Ecotone
+                    self.overhead = U256::ZERO;
+                } else {
+                    self.scalar = scalar;
+                    self.overhead = overhead;
+                }
+            }
+            SystemConfigUpdateType::GasLimit => {
+                if log_data.len() != 96 {
+                    return Err("Invalid config update log: invalid data length");
+                }
+
+                let Ok(pointer) = <sol!(uint64)>::abi_decode(&log_data[0..32], true) else {
+                    return Err("Invalid config update log: invalid data pointer");
+                };
+                if pointer != 32 {
+                    return Err("Invalid config update log: invalid data pointer");
+                }
+                let Ok(length) = <sol!(uint64)>::abi_decode(&log_data[32..64], true) else {
+                    return Err("Invalid config update log: invalid data length");
+                };
+                if length != 32 {
+                    return Err("Invalid config update log: invalid data length");
+                }
+
+                let Ok(gas_limit) = <sol!(uint256)>::abi_decode(&log_data[64..], true) else {
+                    return Err("Invalid config update log: invalid gas limit");
+                };
+                self.gas_limit = U64::from(gas_limit).saturating_to::<u64>();
+            }
+            SystemConfigUpdateType::UnsafeBlockSigner => {
+                // Ignored in derivation
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// System accounts
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SystemAccounts {
+    /// The address that can deposit attributes
+    pub attributes_depositor: Address,
+    /// The address of the attributes predeploy
+    pub attributes_predeploy: Address,
+    /// The address of the fee vault
+    pub fee_vault: Address,
+}
+
+impl Default for SystemAccounts {
+    fn default() -> Self {
+        Self {
+            attributes_depositor: address!("deaddeaddeaddeaddeaddeaddeaddeaddead0001"),
+            attributes_predeploy: address!("4200000000000000000000000000000000000015"),
+            fee_vault: address!("4200000000000000000000000000000000000011"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ChainGenesis;
+    use alloc::vec;
+    use alloy_primitives::{b256, hex, LogData, B256};
+
+    fn mock_rollup_config(system_config: SystemConfig) -> RollupConfig {
+        RollupConfig {
+            genesis: ChainGenesis { system_config: Some(system_config), ..Default::default() },
+            block_time: 2,
+            l1_chain_id: 1,
+            l2_chain_id: 10,
+            regolith_time: Some(0),
+            canyon_time: Some(0),
+            delta_time: Some(0),
+            ecotone_time: Some(10),
+            fjord_time: Some(0),
+            granite_time: Some(0),
+            holocene_time: Some(0),
+            blobs_enabled_l1_timestamp: Some(0),
+            da_challenge_address: Some(Address::ZERO),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_system_config_serde() {
+        let sc_str = r#"{
+          "batcherAddr": "0x6887246668a3b87F54DeB3b94Ba47a6f63F32985",
+          "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+          "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+          "gasLimit": 30000000
+        }"#;
+        let system_config: SystemConfig = serde_json::from_str(sc_str).unwrap();
+        assert_eq!(
+            system_config.batcher_address,
+            address!("6887246668a3b87F54DeB3b94Ba47a6f63F32985")
+        );
+        assert_eq!(system_config.overhead, U256::from(0xbc));
+        assert_eq!(system_config.scalar, U256::from(0xa6fe0));
+        assert_eq!(system_config.gas_limit, 30000000);
+    }
+
+    #[test]
+    fn test_system_config_update_batcher_log() {
+        const UPDATE_TYPE: B256 =
+            b256!("0000000000000000000000000000000000000000000000000000000000000000");
+
+        let mut system_config = SystemConfig::default();
+        let rollup_config = mock_rollup_config(system_config.clone());
+
+        let update_log = Log {
+            address: Address::ZERO,
+            data: LogData::new_unchecked(
+                vec![
+                    CONFIG_UPDATE_TOPIC,
+                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    UPDATE_TYPE,
+                ],
+                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
+            )
+        };
+
+        // Update the batcher address.
+        system_config.process_config_update_log(&update_log, &rollup_config, 0).unwrap();
+
+        assert_eq!(
+            system_config.batcher_address,
+            address!("000000000000000000000000000000000000bEEF")
+        );
+    }
+
+    #[test]
+    fn test_system_config_update_gas_config_log() {
+        const UPDATE_TYPE: B256 =
+            b256!("0000000000000000000000000000000000000000000000000000000000000001");
+
+        let mut system_config = SystemConfig::default();
+        let rollup_config = mock_rollup_config(system_config.clone());
+
+        let update_log = Log {
+            address: Address::ZERO,
+            data: LogData::new_unchecked(
+                vec![
+                    CONFIG_UPDATE_TOPIC,
+                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    UPDATE_TYPE,
+                ],
+                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef").into()
+            )
+        };
+
+        // Update the batcher address.
+        system_config.process_config_update_log(&update_log, &rollup_config, 0).unwrap();
+
+        assert_eq!(system_config.overhead, U256::from(0xbabe));
+        assert_eq!(system_config.scalar, U256::from(0xbeef));
+    }
+
+    #[test]
+    fn test_system_config_update_gas_config_log_ecotone() {
+        const UPDATE_TYPE: B256 =
+            b256!("0000000000000000000000000000000000000000000000000000000000000001");
+
+        let mut system_config = SystemConfig::default();
+        let rollup_config = mock_rollup_config(system_config.clone());
+
+        let update_log = Log {
+            address: Address::ZERO,
+            data: LogData::new_unchecked(
+                vec![
+                    CONFIG_UPDATE_TOPIC,
+                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    UPDATE_TYPE,
+                ],
+                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef").into()
+            )
+        };
+
+        // Update the batcher address.
+        system_config.process_config_update_log(&update_log, &rollup_config, 10).unwrap();
+
+        assert_eq!(system_config.overhead, U256::from(0));
+        assert_eq!(system_config.scalar, U256::from(0xbeef));
+    }
+
+    #[test]
+    fn test_system_config_update_gas_limit_log() {
+        const UPDATE_TYPE: B256 =
+            b256!("0000000000000000000000000000000000000000000000000000000000000002");
+
+        let mut system_config = SystemConfig::default();
+        let rollup_config = mock_rollup_config(system_config.clone());
+
+        let update_log = Log {
+            address: Address::ZERO,
+            data: LogData::new_unchecked(
+                vec![
+                    CONFIG_UPDATE_TOPIC,
+                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    UPDATE_TYPE,
+                ],
+                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
+            )
+        };
+
+        // Update the batcher address.
+        system_config.process_config_update_log(&update_log, &rollup_config, 0).unwrap();
+
+        assert_eq!(system_config.gas_limit, 0xbeef_u64);
+    }
+}

--- a/crates/genesis/src/system.rs
+++ b/crates/genesis/src/system.rs
@@ -118,10 +118,10 @@ impl SystemConfig {
         if version != CONFIG_UPDATE_EVENT_VERSION_0 {
             return Err("Invalid config update log: unsupported version");
         }
-        let Ok(topic_bytes) = log.topics()[2].as_slice()[0..8].try_into() else {
+        let Ok(topic_bytes) = <&[u8; 8]>::try_from(&log.topics()[2].as_slice()[24..]) else {
             return Err("Invalid config update log: invalid update type");
         };
-        let update_type = u64::from_be_bytes(topic_bytes);
+        let update_type = u64::from_be_bytes(*topic_bytes);
         let log_data = log.data.data.as_ref();
 
         match update_type.try_into()? {

--- a/crates/genesis/src/system.rs
+++ b/crates/genesis/src/system.rs
@@ -47,7 +47,7 @@ pub enum SystemConfigUpdateType {
 }
 
 impl TryFrom<u64> for SystemConfigUpdateType {
-    type Error = &'static str;
+    type Error = SystemConfigUpdateError;
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         match value {
@@ -55,7 +55,9 @@ impl TryFrom<u64> for SystemConfigUpdateType {
             1 => Ok(SystemConfigUpdateType::GasConfig),
             2 => Ok(SystemConfigUpdateType::GasLimit),
             3 => Ok(SystemConfigUpdateType::UnsafeBlockSigner),
-            _ => Err("Invalid SystemConfigUpdateType value"),
+            _ => Err(SystemConfigUpdateError::LogProcessing(
+                LogProcessingError::InvalidSystemConfigUpdateType(value),
+            )),
         }
     }
 }
@@ -67,7 +69,7 @@ impl SystemConfig {
         receipts: &[Receipt],
         rollup_config: &RollupConfig,
         l1_time: u64,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), SystemConfigUpdateError> {
         for receipt in receipts {
             if Eip658Value::Eip658(false) == receipt.status {
                 continue;
@@ -78,11 +80,11 @@ impl SystemConfig {
                 if log.address == rollup_config.l1_system_config_address
                     && !topics.is_empty()
                     && topics[0] == CONFIG_UPDATE_TOPIC
-                    && self.process_config_update_log(log, rollup_config, l1_time).is_err()
                 {
-                    return Err("Failed to process config update log");
+                    // Safety: Error is bubbled up by the trailing `?`
+                    self.process_config_update_log(log, rollup_config, l1_time)?;
                 }
-                Ok::<_, &'static str>(())
+                Ok(())
             })?;
         }
         Ok(())
@@ -105,125 +107,356 @@ impl SystemConfig {
         log: &Log,
         rollup_config: &RollupConfig,
         l1_time: u64,
-    ) -> Result<(), &'static str> {
+    ) -> Result<SystemConfigUpdateType, SystemConfigUpdateError> {
+        // Validate the log
         if log.topics().len() < 3 {
-            return Err("Invalid config update log: not enough topics");
+            return Err(SystemConfigUpdateError::LogProcessing(
+                LogProcessingError::InvalidTopicLen(log.topics().len()),
+            ));
         }
         if log.topics()[0] != CONFIG_UPDATE_TOPIC {
-            return Err("Invalid config update log: invalid topic");
+            return Err(SystemConfigUpdateError::LogProcessing(LogProcessingError::InvalidTopic));
         }
 
         // Parse the config update log
         let version = log.topics()[1];
         if version != CONFIG_UPDATE_EVENT_VERSION_0 {
-            return Err("Invalid config update log: unsupported version");
+            return Err(SystemConfigUpdateError::LogProcessing(
+                LogProcessingError::UnsupportedVersion(version),
+            ));
         }
         let Ok(topic_bytes) = <&[u8; 8]>::try_from(&log.topics()[2].as_slice()[24..]) else {
-            return Err("Invalid config update log: invalid update type");
+            return Err(SystemConfigUpdateError::LogProcessing(
+                LogProcessingError::UpdateTypeDecodingError,
+            ));
         };
         let update_type = u64::from_be_bytes(*topic_bytes);
         let log_data = log.data.data.as_ref();
 
+        // Apply the update
         match update_type.try_into()? {
             SystemConfigUpdateType::Batcher => {
-                if log_data.len() != 96 {
-                    return Err("Invalid config update log: invalid data length");
-                }
-
-                let Ok(pointer) = <sol!(uint64)>::abi_decode(&log_data[0..32], true) else {
-                    return Err("Failed to decode batcher update log");
-                };
-                if pointer != 32 {
-                    return Err("Invalid config update log: invalid data pointer");
-                }
-                let Ok(length) = <sol!(uint64)>::abi_decode(&log_data[32..64], true) else {
-                    return Err("Failed to decode batcher update log");
-                };
-                if length != 32 {
-                    return Err("Invalid config update log: invalid data length");
-                }
-
-                let Ok(batcher_address) =
-                    <sol!(address)>::abi_decode(&log.data.data.as_ref()[64..], true)
-                else {
-                    return Err("Failed to decode batcher update log");
-                };
-                self.batcher_address = batcher_address;
+                self.update_batcher_address(log_data).map_err(SystemConfigUpdateError::Batcher)
             }
-            SystemConfigUpdateType::GasConfig => {
-                if log_data.len() != 128 {
-                    return Err("Invalid config update log: invalid data length");
-                }
-
-                let Ok(pointer) = <sol!(uint64)>::abi_decode(&log_data[0..32], true) else {
-                    return Err("Invalid config update log: invalid data pointer");
-                };
-
-                if pointer != 32 {
-                    return Err("Invalid config update log: invalid data pointer");
-                }
-                let Ok(length) = <sol!(uint64)>::abi_decode(&log_data[32..64], true) else {
-                    return Err("Invalid config update log: invalid data length");
-                };
-                if length != 64 {
-                    return Err("Invalid config update log: invalid data length");
-                }
-
-                let Ok(overhead) = <sol!(uint256)>::abi_decode(&log_data[64..96], true) else {
-                    return Err("Invalid config update log: invalid overhead");
-                };
-                let Ok(scalar) = <sol!(uint256)>::abi_decode(&log_data[96..], true) else {
-                    return Err("Invalid config update log: invalid scalar");
-                };
-
-                if rollup_config.is_ecotone_active(l1_time) {
-                    if RollupConfig::check_ecotone_l1_system_config_scalar(scalar.to_be_bytes())
-                        .is_err()
-                    {
-                        // ignore invalid scalars, retain the old system-config scalar
-                        return Ok(());
-                    }
-
-                    // retain the scalar data in encoded form
-                    self.scalar = scalar;
-                    // zero out the overhead, it will not affect the state-transition after Ecotone
-                    self.overhead = U256::ZERO;
-                } else {
-                    self.scalar = scalar;
-                    self.overhead = overhead;
-                }
-            }
+            SystemConfigUpdateType::GasConfig => self
+                .update_gas_config(log_data, rollup_config, l1_time)
+                .map_err(SystemConfigUpdateError::GasConfig),
             SystemConfigUpdateType::GasLimit => {
-                if log_data.len() != 96 {
-                    return Err("Invalid config update log: invalid data length");
-                }
-
-                let Ok(pointer) = <sol!(uint64)>::abi_decode(&log_data[0..32], true) else {
-                    return Err("Invalid config update log: invalid data pointer");
-                };
-                if pointer != 32 {
-                    return Err("Invalid config update log: invalid data pointer");
-                }
-                let Ok(length) = <sol!(uint64)>::abi_decode(&log_data[32..64], true) else {
-                    return Err("Invalid config update log: invalid data length");
-                };
-                if length != 32 {
-                    return Err("Invalid config update log: invalid data length");
-                }
-
-                let Ok(gas_limit) = <sol!(uint256)>::abi_decode(&log_data[64..], true) else {
-                    return Err("Invalid config update log: invalid gas limit");
-                };
-                self.gas_limit = U64::from(gas_limit).saturating_to::<u64>();
+                self.update_gas_limit(log_data).map_err(SystemConfigUpdateError::GasLimit)
             }
+            // Ignored in derivation
             SystemConfigUpdateType::UnsafeBlockSigner => {
-                // Ignored in derivation
+                Ok(SystemConfigUpdateType::UnsafeBlockSigner)
             }
         }
+    }
 
-        Ok(())
+    /// Updates the batcher address in the [SystemConfig] given the log data.
+    fn update_batcher_address(
+        &mut self,
+        log_data: &[u8],
+    ) -> Result<SystemConfigUpdateType, BatcherUpdateError> {
+        if log_data.len() != 96 {
+            return Err(BatcherUpdateError::InvalidDataLen(log_data.len()));
+        }
+
+        let Ok(pointer) = <sol!(uint64)>::abi_decode(&log_data[0..32], true) else {
+            return Err(BatcherUpdateError::PointerDecodingError);
+        };
+        if pointer != 32 {
+            return Err(BatcherUpdateError::InvalidDataPointer(pointer));
+        }
+        let Ok(length) = <sol!(uint64)>::abi_decode(&log_data[32..64], true) else {
+            return Err(BatcherUpdateError::LengthDecodingError);
+        };
+        if length != 32 {
+            return Err(BatcherUpdateError::InvalidDataLength(length));
+        }
+
+        let Ok(batcher_address) = <sol!(address)>::abi_decode(&log_data[64..], true) else {
+            return Err(BatcherUpdateError::BatcherAddressDecodingError);
+        };
+        self.batcher_address = batcher_address;
+        Ok(SystemConfigUpdateType::Batcher)
+    }
+
+    /// Updates the [SystemConfig] gas config - both the overhead and scalar values
+    /// given the log data and rollup config.
+    fn update_gas_config(
+        &mut self,
+        log_data: &[u8],
+        rollup_config: &RollupConfig,
+        l1_time: u64,
+    ) -> Result<SystemConfigUpdateType, GasConfigUpdateError> {
+        if log_data.len() != 128 {
+            return Err(GasConfigUpdateError::InvalidDataLen(log_data.len()));
+        }
+
+        let Ok(pointer) = <sol!(uint64)>::abi_decode(&log_data[0..32], true) else {
+            return Err(GasConfigUpdateError::PointerDecodingError);
+        };
+        if pointer != 32 {
+            return Err(GasConfigUpdateError::InvalidDataPointer(pointer));
+        }
+        let Ok(length) = <sol!(uint64)>::abi_decode(&log_data[32..64], true) else {
+            return Err(GasConfigUpdateError::LengthDecodingError);
+        };
+        if length != 64 {
+            return Err(GasConfigUpdateError::InvalidDataLength(length));
+        }
+
+        let Ok(overhead) = <sol!(uint256)>::abi_decode(&log_data[64..96], true) else {
+            return Err(GasConfigUpdateError::OverheadDecodingError);
+        };
+        let Ok(scalar) = <sol!(uint256)>::abi_decode(&log_data[96..], true) else {
+            return Err(GasConfigUpdateError::ScalarDecodingError);
+        };
+
+        if rollup_config.is_ecotone_active(l1_time) {
+            if RollupConfig::check_ecotone_l1_system_config_scalar(scalar.to_be_bytes()).is_err() {
+                // ignore invalid scalars, retain the old system-config scalar
+                return Ok(SystemConfigUpdateType::GasConfig);
+            }
+
+            // retain the scalar data in encoded form
+            self.scalar = scalar;
+            // zero out the overhead, it will not affect the state-transition after Ecotone
+            self.overhead = U256::ZERO;
+        } else {
+            self.scalar = scalar;
+            self.overhead = overhead;
+        }
+
+        Ok(SystemConfigUpdateType::GasConfig)
+    }
+
+    /// Updates the gas limit of the [SystemConfig] given the log data.
+    fn update_gas_limit(
+        &mut self,
+        log_data: &[u8],
+    ) -> Result<SystemConfigUpdateType, GasLimitUpdateError> {
+        if log_data.len() != 96 {
+            return Err(GasLimitUpdateError::InvalidDataLen(log_data.len()));
+        }
+
+        let Ok(pointer) = <sol!(uint64)>::abi_decode(&log_data[0..32], true) else {
+            return Err(GasLimitUpdateError::PointerDecodingError);
+        };
+        if pointer != 32 {
+            return Err(GasLimitUpdateError::InvalidDataPointer(pointer));
+        }
+        let Ok(length) = <sol!(uint64)>::abi_decode(&log_data[32..64], true) else {
+            return Err(GasLimitUpdateError::LengthDecodingError);
+        };
+        if length != 32 {
+            return Err(GasLimitUpdateError::InvalidDataLength(length));
+        }
+
+        let Ok(gas_limit) = <sol!(uint256)>::abi_decode(&log_data[64..], true) else {
+            return Err(GasLimitUpdateError::GasLimitDecodingError);
+        };
+        self.gas_limit = U64::from(gas_limit).saturating_to::<u64>();
+        Ok(SystemConfigUpdateType::GasLimit)
     }
 }
+
+/// An error for processing the [SystemConfig] update log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum SystemConfigUpdateError {
+    /// An error occurred while processing the update log.
+    LogProcessing(LogProcessingError),
+    /// A batcher update error.
+    Batcher(BatcherUpdateError),
+    /// A gas config update error.
+    GasConfig(GasConfigUpdateError),
+    /// A gas limit update error.
+    GasLimit(GasLimitUpdateError),
+}
+
+impl core::fmt::Display for SystemConfigUpdateError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::LogProcessing(err) => write!(f, "Log processing error: {}", err),
+            Self::Batcher(err) => write!(f, "Batcher update error: {}", err),
+            Self::GasConfig(err) => write!(f, "Gas config update error: {}", err),
+            Self::GasLimit(err) => write!(f, "Gas limit update error: {}", err),
+        }
+    }
+}
+
+/// An error occurred while processing the update log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum LogProcessingError {
+    /// Received an incorrect number of log topics.
+    InvalidTopicLen(usize),
+    /// The log topic is invalid.
+    InvalidTopic,
+    /// The config update log version is unsupported.
+    UnsupportedVersion(B256),
+    /// Failed to decode the update type from the config update log.
+    UpdateTypeDecodingError,
+    /// An invalid system config update type.
+    InvalidSystemConfigUpdateType(u64),
+}
+
+impl core::fmt::Display for LogProcessingError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidTopicLen(len) => {
+                write!(f, "Invalid config update log: invalid topic length: {}", len)
+            }
+            Self::InvalidTopic => write!(f, "Invalid config update log: invalid topic"),
+            Self::UnsupportedVersion(version) => {
+                write!(f, "Invalid config update log: unsupported version: {}", version)
+            }
+            Self::UpdateTypeDecodingError => {
+                write!(f, "Failed to decode config update log: update type")
+            }
+            Self::InvalidSystemConfigUpdateType(value) => {
+                write!(f, "Invalid system config update type: {}", value)
+            }
+        }
+    }
+}
+
+/// An error for updating the batcher address on the [SystemConfig].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum BatcherUpdateError {
+    /// Invalid data length.
+    InvalidDataLen(usize),
+    /// Failed to decode the data pointer argument from the batcher update log.
+    PointerDecodingError,
+    /// The data pointer is invalid.
+    InvalidDataPointer(u64),
+    /// Failed to decode the data length argument from the batcher update log.
+    LengthDecodingError,
+    /// The data length is invalid.
+    InvalidDataLength(u64),
+    /// Failed to decode the batcher address argument from the batcher update log.
+    BatcherAddressDecodingError,
+}
+
+impl core::fmt::Display for BatcherUpdateError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidDataLen(len) => {
+                write!(f, "Invalid config update log: invalid data length: {}", len)
+            }
+            Self::PointerDecodingError => {
+                write!(f, "Failed to decode batcher update log: data pointer")
+            }
+            Self::InvalidDataPointer(pointer) => {
+                write!(f, "Invalid config update log: invalid data pointer: {}", pointer)
+            }
+            Self::LengthDecodingError => {
+                write!(f, "Failed to decode batcher update log: data length")
+            }
+            Self::InvalidDataLength(length) => {
+                write!(f, "Invalid config update log: invalid data length: {}", length)
+            }
+            Self::BatcherAddressDecodingError => {
+                write!(f, "Failed to decode batcher update log: batcher address")
+            }
+        }
+    }
+}
+
+/// An error for updating the gas config on the [SystemConfig].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum GasConfigUpdateError {
+    /// Invalid data length.
+    InvalidDataLen(usize),
+    /// Failed to decode the data pointer argument from the gas config update log.
+    PointerDecodingError,
+    /// The data pointer is invalid.
+    InvalidDataPointer(u64),
+    /// Failed to decode the data length argument from the gas config update log.
+    LengthDecodingError,
+    /// The data length is invalid.
+    InvalidDataLength(u64),
+    /// Failed to decode the overhead argument from the gas config update log.
+    OverheadDecodingError,
+    /// Failed to decode the scalar argument from the gas config update log.
+    ScalarDecodingError,
+}
+
+impl core::fmt::Display for GasConfigUpdateError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidDataLen(len) => {
+                write!(f, "Invalid config update log: invalid data length: {}", len)
+            }
+            Self::PointerDecodingError => {
+                write!(f, "Failed to decode gas config update log: data pointer")
+            }
+            Self::InvalidDataPointer(pointer) => {
+                write!(f, "Invalid config update log: invalid data pointer: {}", pointer)
+            }
+            Self::LengthDecodingError => {
+                write!(f, "Failed to decode gas config update log: data length")
+            }
+            Self::InvalidDataLength(length) => {
+                write!(f, "Invalid config update log: invalid data length: {}", length)
+            }
+            Self::OverheadDecodingError => {
+                write!(f, "Failed to decode gas config update log: overhead")
+            }
+            Self::ScalarDecodingError => {
+                write!(f, "Failed to decode gas config update log: scalar")
+            }
+        }
+    }
+}
+
+/// An error for updating the gas limit on the [SystemConfig].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum GasLimitUpdateError {
+    /// Invalid data length.
+    InvalidDataLen(usize),
+    /// Failed to decode the data pointer argument from the gas limit update log.
+    PointerDecodingError,
+    /// The data pointer is invalid.
+    InvalidDataPointer(u64),
+    /// Failed to decode the data length argument from the gas limit update log.
+    LengthDecodingError,
+    /// The data length is invalid.
+    InvalidDataLength(u64),
+    /// Failed to decode the gas limit argument from the gas limit update log.
+    GasLimitDecodingError,
+}
+
+impl core::fmt::Display for GasLimitUpdateError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidDataLen(len) => {
+                write!(f, "Invalid config update log: invalid data length: {}", len)
+            }
+            Self::PointerDecodingError => {
+                write!(f, "Failed to decode gas limit update log: data pointer")
+            }
+            Self::InvalidDataPointer(pointer) => {
+                write!(f, "Invalid config update log: invalid data pointer: {}", pointer)
+            }
+            Self::LengthDecodingError => {
+                write!(f, "Failed to decode gas limit update log: data length")
+            }
+            Self::InvalidDataLength(length) => {
+                write!(f, "Invalid config update log: invalid data length: {}", length)
+            }
+            Self::GasLimitDecodingError => {
+                write!(f, "Failed to decode gas limit update log: gas limit")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for GasLimitUpdateError {}
 
 /// System accounts
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/genesis/src/system.rs
+++ b/crates/genesis/src/system.rs
@@ -274,6 +274,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_system_config_serde() {
         let sc_str = r#"{
           "batcherAddr": "0x6887246668a3b87F54DeB3b94Ba47a6f63F32985",

--- a/scripts/check_no_std.sh
+++ b/scripts/check_no_std.sh
@@ -4,6 +4,7 @@ set -eo pipefail
 no_std_packages=(
   op-alloy-consensus
   op-alloy-protocol
+  op-alloy-genesis
 )
 
 for package in "${no_std_packages[@]}"; do


### PR DESCRIPTION
### Description

Introduces an `op-alloy-genesis` crate similar to [`alloy-genesis`](https://docs.rs/alloy-genesis/latest/alloy_genesis/) that contains Optimism genesis types.

This is part of an effort to remove _both_ `superchain-primitives` and `kona-primitives` to place all optimism core types in `op-alloy` crates.