### PR TITLE
feat: Superchain Primitives Removal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ op-alloy-rpc-jsonrpsee = { version = "0.2.11", path = "crates/rpc-jsonrpsee" }
 op-alloy-rpc-types = { version = "0.2.11", path = "crates/rpc-types" }
 op-alloy-rpc-types-engine = { version = "0.2.11", path = "crates/rpc-types-engine" }
 op-alloy-consensus = { version = "0.2.11", path = "crates/consensus", default-features = false }
-op-alloy-genesis = { version = "0.2.11", path = "crates/genesis" }
+op-alloy-genesis = { version = "0.2.11", path = "crates/genesis", default-features = false }
 op-alloy-protocol = { version = "0.2.11", path = "crates/protocol", default-features = false }
 
 alloy-rlp = { version = "0.3", default-features = false }
@@ -49,9 +49,6 @@ alloy-rpc-types-eth = { version = "0.3.4" }
 alloy-eips = { version = "0.3.4", default-features = false }
 alloy-serde = { version = "0.3.4", default-features = false }
 alloy-signer = { version = "0.3.4", default-features = false }
-
-# Superchain
-superchain-primitives = { version = "0.4", default-features = false }
 
 # Serde
 serde_repr = "0.1"

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -13,6 +13,7 @@ exclude.workspace = true
 
 [dependencies]
 # Workspace
+op-alloy-genesis.workspace = true
 op-alloy-consensus.workspace = true
 
 # Alloy
@@ -20,9 +21,6 @@ alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 alloy-eips.workspace = true
 alloy-consensus.workspace = true
-
-# Superchain
-superchain-primitives.workspace = true
 
 # Misc
 hashbrown.workspace = true
@@ -36,5 +34,5 @@ serde_json.workspace = true
 
 [features]
 default = ["serde", "std"]
-std = []
-serde = ["dep:serde", "dep:alloy-serde", "superchain-primitives/serde"]
+std = ["op-alloy-consensus/std", "op-alloy-genesis/std"]
+serde = ["dep:serde", "dep:alloy-serde", "op-alloy-consensus/serde", "op-alloy-genesis/serde"]

--- a/crates/protocol/src/block_info.rs
+++ b/crates/protocol/src/block_info.rs
@@ -11,7 +11,7 @@ use alloy_consensus::Header;
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{address, Address, Bytes, TxKind, B256, U256};
 use op_alloy_consensus::{OpTxEnvelope, TxDeposit};
-use superchain_primitives::{RollupConfig, SystemConfig};
+use op_alloy_genesis::{RollupConfig, SystemConfig};
 
 /// The system transaction gas limit post-Regolith
 const REGOLITH_SYSTEM_TX_GAS: u128 = 1_000_000;


### PR DESCRIPTION
### Description

Removes the [`superchain-primitives`](https://crates.io/crates/superchain-primitives) crate as a dependency.

It is now deprecated in favor of `op-alloy-genesis`.

Bindings for the go [`superchain-registry`](https://github.com/ethereum-optimism/superchain-registry) now live in the [`superhcain`](https://crates.io/crates/superchain) crate.

