### PR TITLE
feat(rpc-types): no_std Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ alloy-sol-types = { version = "0.8", default-features = false }
 alloy = { version = "0.3.4" }
 alloy-consensus = { version = "0.3.4", default-features = false }
 alloy-network = { version = "0.3.4", default-features = false }
+alloy-network-primitives = { version = "0.3.4", default-features = false }
 alloy-rpc-types = { version = "0.3.4" }
 alloy-rpc-types-engine = { version = "0.3.4", default-features = false }
 alloy-rpc-types-eth = { version = "0.3.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ alloy-consensus = { version = "0.3.4", default-features = false }
 alloy-network = { version = "0.3.4", default-features = false }
 alloy-rpc-types = { version = "0.3.4" }
 alloy-rpc-types-engine = { version = "0.3.4", default-features = false }
-alloy-rpc-types-eth = { version = "0.3.4" }
+alloy-rpc-types-eth = { version = "0.3.4", default-features = false }
 alloy-eips = { version = "0.3.4", default-features = false }
 alloy-serde = { version = "0.3.4", default-features = false }
 alloy-signer = { version = "0.3.4", default-features = false }
@@ -72,17 +72,19 @@ jsonrpsee-core = "0.24"
 jsonrpsee-types = "0.24"
 
 # misc
+cfg-if = "1"
+hashbrown = "0.14.5"
 spin = { version = "0.9.8", features = ["mutex"] }
 derive_more = { version = "1.0", default-features = false }
 
 ## misc-testing
-hashbrown = "0.14.5"
 arbitrary = { version = "1.3", features = ["derive"] }
 rand = "0.8"
 thiserror = "1.0"
 proptest = "1.4"
 proptest-derive = "0.4"
 tokio = "1"
+
 ## crypto
 c-kzg = { version = "1.0", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -11,17 +11,14 @@ homepage.workspace = true
 repository.workspace = true
 exclude.workspace = true
 
-[lints]
-workspace = true
-
 [dependencies]
-op-alloy-consensus = { workspace = true, features = ["serde"] }
+# Workspace
+op-alloy-consensus.workspace = true
 op-alloy-rpc-types.workspace = true
 
+# Alloy
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-network.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types-eth.workspace = true
-
-

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -12,16 +12,25 @@ repository.workspace = true
 exclude.workspace = true
 
 [dependencies]
+# Workspace
 op-alloy-consensus = { workspace = true, features = ["serde"] }
 
-alloy-primitives = { workspace = true, features = ["rlp", "serde", "std"] }
-alloy-rpc-types-eth.workspace = true
-alloy-network.workspace = true
+# Alloy
+alloy-primitives = { workspace = true, features = ["rlp", "serde"] }
+alloy-rpc-types-eth = { workspace = true, features = ["serde"] }
 alloy-serde.workspace = true
-alloy-eips.workspace = true
+alloy-eips = { workspace = true, features = ["serde"] }
 
+# Serde
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+
+# `no_std` support
+cfg-if.workspace = true
+hashbrown = { workspace = true, features = ["serde"] }
+
+# std
+alloy-network = { workspace = true, optional = true }
 
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }
@@ -30,13 +39,20 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 alloy-primitives = { workspace = true, features = ["arbitrary"] }
 alloy-consensus = { workspace = true, features = ["arbitrary"] }
 alloy-rpc-types = { workspace = true, features = ["arbitrary"] }
-
 arbitrary = { workspace = true, features = ["derive"] }
 rand.workspace = true
 
 [features]
+default = ["std"]
+std = [
+  "dep:alloy-network",
+  "alloy-eips/std",
+  "alloy-primitives/std",
+  "alloy-rpc-types-eth/std",
+]
 arbitrary = [
-    "dep:arbitrary",
-    "alloy-primitives/arbitrary",
-    "alloy-rpc-types-eth/arbitrary",
+  "std",
+  "dep:arbitrary",
+  "alloy-primitives/arbitrary",
+  "alloy-rpc-types-eth/arbitrary",
 ]

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -19,6 +19,7 @@ op-alloy-consensus = { workspace = true, features = ["serde"] }
 alloy-primitives = { workspace = true, features = ["rlp", "serde"] }
 alloy-rpc-types-eth = { workspace = true, features = ["serde"] }
 alloy-serde.workspace = true
+alloy-network-primitives.workspace = true
 alloy-eips = { workspace = true, features = ["serde"] }
 
 # Serde
@@ -28,9 +29,6 @@ serde_json = { workspace = true }
 # `no_std` support
 cfg-if.workspace = true
 hashbrown = { workspace = true, features = ["serde"] }
-
-# std
-alloy-network = { workspace = true, optional = true }
 
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }
@@ -45,7 +43,7 @@ rand.workspace = true
 [features]
 default = ["std"]
 std = [
-  "dep:alloy-network",
+  "alloy-network-primitives/std",
   "alloy-eips/std",
   "alloy-primitives/std",
   "alloy-rpc-types-eth/std",

--- a/crates/rpc-types/src/lib.rs
+++ b/crates/rpc-types/src/lib.rs
@@ -14,6 +14,21 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+/// Standardized collections across `std` and `no_std` environments.
+pub mod collections {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "std")] {
+            pub use std::collections::{hash_set, HashMap, HashSet};
+            use hashbrown as _;
+        } else {
+            pub use hashbrown::{hash_set, HashMap, HashSet};
+        }
+    }
+}
 
 pub mod config;
 pub mod genesis;

--- a/crates/rpc-types/src/net.rs
+++ b/crates/rpc-types/src/net.rs
@@ -1,9 +1,11 @@
 #![allow(missing_docs)]
 //! Network RPC types
 
+use crate::collections::HashMap;
+use alloc::{string::String, vec::Vec};
 use alloy_primitives::ChainId;
+use core::net::IpAddr;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, net::IpAddr};
 
 // https://github.com/ethereum-optimism/optimism/blob/8dd17a7b114a7c25505cd2e15ce4e3d0f7e3f7c1/op-node/p2p/store/iface.go#L13
 #[derive(Clone, Debug, Copy, Serialize, Deserialize)]

--- a/crates/rpc-types/src/receipt.rs
+++ b/crates/rpc-types/src/receipt.rs
@@ -1,8 +1,5 @@
 //! Receipt types for RPC
 
-use alloy_eips::eip7702::SignedAuthorization;
-use alloy_network::ReceiptResponse;
-use alloy_primitives::{Address, BlockHash, TxHash, B256};
 use alloy_serde::OtherFields;
 use op_alloy_consensus::OpReceiptEnvelope;
 use serde::{Deserialize, Serialize};
@@ -20,8 +17,9 @@ pub struct OpTransactionReceipt {
     pub l1_block_info: L1BlockInfo,
 }
 
-impl ReceiptResponse for OpTransactionReceipt {
-    fn contract_address(&self) -> Option<Address> {
+#[cfg(feature = "std")]
+impl alloy_network::ReceiptResponse for OpTransactionReceipt {
+    fn contract_address(&self) -> Option<alloy_primitives::Address> {
         self.inner.contract_address
     }
 
@@ -29,7 +27,7 @@ impl ReceiptResponse for OpTransactionReceipt {
         self.inner.inner.status()
     }
 
-    fn block_hash(&self) -> Option<BlockHash> {
+    fn block_hash(&self) -> Option<alloy_primitives::BlockHash> {
         self.inner.block_hash
     }
 
@@ -37,7 +35,7 @@ impl ReceiptResponse for OpTransactionReceipt {
         self.inner.block_number
     }
 
-    fn transaction_hash(&self) -> TxHash {
+    fn transaction_hash(&self) -> alloy_primitives::TxHash {
         self.inner.transaction_hash
     }
 
@@ -61,15 +59,15 @@ impl ReceiptResponse for OpTransactionReceipt {
         self.inner.blob_gas_price()
     }
 
-    fn from(&self) -> Address {
+    fn from(&self) -> alloy_primitives::Address {
         self.inner.from()
     }
 
-    fn to(&self) -> Option<Address> {
+    fn to(&self) -> Option<alloy_primitives::Address> {
         self.inner.to()
     }
 
-    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+    fn authorization_list(&self) -> Option<&[alloy_eips::eip7702::SignedAuthorization]> {
         self.inner.authorization_list()
     }
 
@@ -77,7 +75,7 @@ impl ReceiptResponse for OpTransactionReceipt {
         self.inner.cumulative_gas_used()
     }
 
-    fn state_root(&self) -> Option<B256> {
+    fn state_root(&self) -> Option<alloy_primitives::B256> {
         self.inner.state_root()
     }
 }
@@ -112,6 +110,7 @@ mod l1_fee_scalar_serde {
     where
         S: serde::Serializer,
     {
+        use alloc::string::ToString;
         if let Some(v) = value {
             return s.serialize_str(&v.to_string());
         }
@@ -122,6 +121,7 @@ mod l1_fee_scalar_serde {
     where
         D: serde::Deserializer<'de>,
     {
+        use alloc::string::String;
         let s: Option<String> = Option::deserialize(deserializer)?;
         if let Some(s) = s {
             return Ok(Some(s.parse::<f64>().map_err(de::Error::custom)?));

--- a/crates/rpc-types/src/receipt.rs
+++ b/crates/rpc-types/src/receipt.rs
@@ -17,8 +17,7 @@ pub struct OpTransactionReceipt {
     pub l1_block_info: L1BlockInfo,
 }
 
-#[cfg(feature = "std")]
-impl alloy_network::ReceiptResponse for OpTransactionReceipt {
+impl alloy_network_primitives::ReceiptResponse for OpTransactionReceipt {
     fn contract_address(&self) -> Option<alloy_primitives::Address> {
         self.inner.contract_address
     }

--- a/crates/rpc-types/src/transaction.rs
+++ b/crates/rpc-types/src/transaction.rs
@@ -1,6 +1,5 @@
 //! Optimism specific types related to transactions.
 
-use alloy_network::TransactionResponse;
 use alloy_primitives::B256;
 use alloy_serde::OtherFields;
 use serde::{Deserialize, Serialize};
@@ -28,7 +27,8 @@ pub struct Transaction {
     pub deposit_receipt_version: Option<u64>,
 }
 
-impl TransactionResponse for Transaction {
+#[cfg(feature = "std")]
+impl alloy_network::TransactionResponse for Transaction {
     fn from(&self) -> alloy_primitives::Address {
         self.inner.from()
     }

--- a/crates/rpc-types/src/transaction.rs
+++ b/crates/rpc-types/src/transaction.rs
@@ -27,18 +27,17 @@ pub struct Transaction {
     pub deposit_receipt_version: Option<u64>,
 }
 
-#[cfg(feature = "std")]
-impl alloy_network::TransactionResponse for Transaction {
+impl alloy_network_primitives::TransactionResponse for Transaction {
+    fn tx_hash(&self) -> alloy_primitives::TxHash {
+        self.inner.tx_hash()
+    }
+
     fn from(&self) -> alloy_primitives::Address {
         self.inner.from()
     }
 
     fn to(&self) -> Option<alloy_primitives::Address> {
         self.inner.to()
-    }
-
-    fn tx_hash(&self) -> alloy_primitives::TxHash {
-        self.inner.tx_hash()
     }
 
     fn value(&self) -> alloy_primitives::U256 {


### PR DESCRIPTION
### Description

`no_std` support for the `op-alloy-rpc-types` crate. Also does some nice cleanup. Need to add doc comments to the `net` module.