### PR TITLE
feat(rpc-types-engine): no_std Support

### DIFF
--- a/crates/rpc-types-engine/Cargo.toml
+++ b/crates/rpc-types-engine/Cargo.toml
@@ -24,5 +24,6 @@ alloy-serde = { workspace = true, optional = true }
 serde_json.workspace = true
 
 [features]
-default = ["serde"]
+default = ["std", "serde"]
+std = ["alloy-primitives/std", "alloy-rpc-types-engine/std", "op-alloy-protocol/std"]
 serde = ["dep:serde", "dep:alloy-serde", "alloy-rpc-types-engine/serde", "op-alloy-protocol/serde"]

--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -14,6 +14,9 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 
 mod payload;
 pub use payload::*;

--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -14,7 +14,6 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
-#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 

--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -3,6 +3,7 @@ use alloy_rpc_types_engine::{
     BlobsBundleV1, ExecutionPayloadV3, ExecutionPayloadV4, PayloadAttributes,
 };
 use op_alloy_protocol::L2BlockInfo;
+use alloc::vec::Vec;
 
 /// Optimism Payload Attributes
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -1,9 +1,9 @@
+use alloc::vec::Vec;
 use alloy_primitives::{Bytes, B256, U256};
 use alloy_rpc_types_engine::{
     BlobsBundleV1, ExecutionPayloadV3, ExecutionPayloadV4, PayloadAttributes,
 };
 use op_alloy_protocol::L2BlockInfo;
-use alloc::vec::Vec;
 
 /// Optimism Payload Attributes
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
### Description

Adds `no_std` support to `op-alloy-rpc-types-engine` now that upstream `alloy-rpc-types-engine` has `no_std` support.