### PR TITLE
fix: no_std for op-alloy-rpc-types-engine

### DIFF
--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -14,6 +14,7 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 

--- a/scripts/check_no_std.sh
+++ b/scripts/check_no_std.sh
@@ -5,6 +5,8 @@ no_std_packages=(
   op-alloy-consensus
   op-alloy-protocol
   op-alloy-genesis
+  op-alloy-rpc-types
+  op-alloy-rpc-types-engine
 )
 
 for package in "${no_std_packages[@]}"; do


### PR DESCRIPTION
### Description

`op-alloy-rpc-types-engine` was missing the `no_std` attribute. This adds it in with added `no_std` checks in ci.