### PR TITLE
fix(engine): Missing Error Source

### DIFF
--- a/crates/rpc-types-engine/src/errors.rs
+++ b/crates/rpc-types-engine/src/errors.rs
@@ -29,7 +29,15 @@ pub enum ToL2BlockRefError {
     BlockInfoDecodeError(DecodeError),
 }
 
-impl core::error::Error for ToL2BlockRefError {}
+impl core::error::Error for ToL2BlockRefError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::TxEnvelopeDecodeError(err) => Some(err),
+            Self::BlockInfoDecodeError(err) => Some(err),
+            _ => None,
+        }
+    }
+}
 
 /// An error that can occur when converting an [crate::OptimismExecutionPayloadEnvelopeV4] to a
 /// [op_alloy_genesis::SystemConfig].
@@ -58,4 +66,12 @@ pub enum ToSystemConfigError {
     MissingSystemConfig,
 }
 
-impl core::error::Error for ToSystemConfigError {}
+impl core::error::Error for ToSystemConfigError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::TxEnvelopeDecodeError(err) => Some(err),
+            Self::BlockInfoDecodeError(err) => Some(err),
+            _ => None,
+        }
+    }
+}

--- a/crates/rpc-types-engine/src/errors.rs
+++ b/crates/rpc-types-engine/src/errors.rs
@@ -29,10 +29,25 @@ pub enum ToL2BlockRefError {
     BlockInfoDecodeError(DecodeError),
 }
 
+// Since `Eip2718Error` uses an msrv prior to rust `1.81`, the `core::error::Error` type
+// is not stabalized and `Eip2718Error` only implements `std::error::Error` and not
+// `core::error::Error`. So we need to implement `std::error::Error` to provide the `Eip2718Error`
+// as a source when the `std` feature is enabled.
+#[cfg(feature = "std")]
+impl std::error::Error for ToL2BlockRefError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::TxEnvelopeDecodeError(err) => Some(err),
+            Self::BlockInfoDecodeError(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(not(feature = "std"))]
 impl core::error::Error for ToL2BlockRefError {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
-            Self::TxEnvelopeDecodeError(err) => Some(err),
             Self::BlockInfoDecodeError(err) => Some(err),
             _ => None,
         }
@@ -66,10 +81,25 @@ pub enum ToSystemConfigError {
     MissingSystemConfig,
 }
 
+// Since `Eip2718Error` uses an msrv prior to rust `1.81`, the `core::error::Error` type
+// is not stabalized and `Eip2718Error` only implements `std::error::Error` and not
+// `core::error::Error`. So we need to implement `std::error::Error` to provide the `Eip2718Error`
+// as a source when the `std` feature is enabled.
+#[cfg(feature = "std")]
+impl std::error::Error for ToSystemConfigError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::TxEnvelopeDecodeError(err) => Some(err),
+            Self::BlockInfoDecodeError(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(not(feature = "std"))]
 impl core::error::Error for ToSystemConfigError {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
-            Self::TxEnvelopeDecodeError(err) => Some(err),
             Self::BlockInfoDecodeError(err) => Some(err),
             _ => None,
         }


### PR DESCRIPTION
### Description

Fixes `op-alloy-rpc-types-engine` conversion errors to provide their source for 2718 decoding errors and block info decoding errors.