### PR TITLE
Add holocene time to genesis info

### DIFF
--- a/crates/rpc-types/src/genesis.rs
+++ b/crates/rpc-types/src/genesis.rs
@@ -48,6 +48,8 @@ pub struct OptimismGenesisInfo {
     pub fjord_time: Option<u64>,
     /// granite hardfork timestamp
     pub granite_time: Option<u64>,
+    /// holocene hardfork timestamp
+    pub holocene_time: Option<u64>,
 }
 
 impl OptimismGenesisInfo {
@@ -126,6 +128,7 @@ mod tests {
                 ecotone_time: Some(0),
                 fjord_time: None,
                 granite_time: None,
+                holocene_time: None,
             }
         );
     }
@@ -183,6 +186,7 @@ mod tests {
                     ecotone_time: Some(0),
                     fjord_time: None,
                     granite_time: None,
+                    holocene_time: None,
                 }),
                 base_fee_info: Some(OptimismBaseFeeInfo {
                     eip1559_elasticity: None,
@@ -204,6 +208,7 @@ mod tests {
                     ecotone_time: Some(0),
                     fjord_time: None,
                     granite_time: None,
+                    holocene_time: None,
                 }),
                 base_fee_info: Some(OptimismBaseFeeInfo {
                     eip1559_elasticity: None,
@@ -223,7 +228,8 @@ mod tests {
           "canyonTime": 0,
           "ecotoneTime": 0,
           "fjordTime": 0,
-          "graniteTime": 0
+          "graniteTime": 0,
+          "holoceneTime": 0
         }
         "#;
 
@@ -240,6 +246,7 @@ mod tests {
                     ecotone_time: Some(0),
                     fjord_time: Some(0),
                     granite_time: Some(0),
+                    holocene_time: Some(0),
                 }),
                 base_fee_info: None,
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
Support holocene time in genesis for the next Optimism hardfork.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
op-reth uses types from op-alloy, thus adding `holocene_time` to OptimismGenesisInfo so that op-reth can read the holocene activation time from genesis/superchain config 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
