### PR TITLE
l1Origin -> l1origin during deser of `L2BlockRef`

### DIFF
--- a/crates/rpc-types/src/sync.rs
+++ b/crates/rpc-types/src/sync.rs
@@ -19,7 +19,7 @@ pub struct L2BlockRef {
     /// The timestamp.
     pub timestamp: u64,
     /// The L1 origin.
-    #[serde(rename = "l1Origin")]
+    #[serde(rename = "l1origin")]
     pub l1_origin: BlockNumHash,
     /// The sequence number.
     pub sequence_number: u64,


### PR DESCRIPTION
Currently, I'm not able to deserialize the response from `optimism_outputAtBlock` with the `OutputResponse` type. It is happening because the `serde(rename = ..)` is set to `l1Origin` instead of `l1origin`.

According to the [link](https://github.com/ethereum-optimism/optimism/blob/develop/op-service/eth/id.go#L33) embedded in the code, it should be `l1origin`.