### PR TITLE
feat(provider): OP engine api trait ext + superchain signal type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           cache-on-failure: true
       - name: cargo hack
         run: |
-          cargo hack build --workspace --target wasm32-unknown-unknown --exclude op-alloy-network --exclude op-alloy-rpc-types --exclude op-alloy-rpc-jsonrpsee
+          cargo hack build --workspace --target wasm32-unknown-unknown --exclude op-alloy-network --exclude op-alloy-rpc-types --exclude op-alloy-rpc-jsonrpsee --exclude op-alloy-provider
 
   wasm-wasi:
     runs-on: ubuntu-latest
@@ -94,7 +94,7 @@ jobs:
           cache-on-failure: true
       - name: cargo hack
         run: |
-          cargo hack build --workspace --target wasm32-wasi --exclude op-alloy-network --exclude op-alloy-rpc-types --exclude op-alloy-rpc-jsonrpsee
+          cargo hack build --workspace --target wasm32-wasi --exclude op-alloy-network --exclude op-alloy-rpc-types --exclude op-alloy-rpc-jsonrpsee --exclude op-alloy-provider
 
   no-std:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ alloy-rpc-types-eth = { version = "0.3.6", default-features = false }
 alloy-eips = { version = "0.3.6", default-features = false }
 alloy-serde = { version = "0.3.6", default-features = false }
 alloy-signer = { version = "0.3.6", default-features = false }
+alloy-provider = { version = "0.3.6", default-features = false }
+alloy-transport = { version = "0.3.6", default-features = false }
 
 # Serde
 serde_repr = "0.1"

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "op-alloy-provider"
+description = "Interface with an OP Stack blockchain"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+authors.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[dependencies]
+# Workspace
+op-alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
+
+# Alloy
+alloy-primitives = { workspace = true, features = ["rlp", "serde"] }
+alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
+alloy-provider.workspace = true
+alloy-network.workspace = true
+alloy-transport.workspace = true
+
+# arbitrary
+arbitrary = { workspace = true, features = ["derive"], optional = true }
+
+# misc
+async-trait = "0.1.82"
+
+[dev-dependencies]
+alloy-primitives = { workspace = true, features = ["arbitrary"] }
+alloy-consensus = { workspace = true, features = ["arbitrary"] }
+alloy-rpc-types = { workspace = true, features = ["arbitrary"] }
+arbitrary = { workspace = true, features = ["derive"] }
+rand.workspace = true
+
+[features]
+default = ["std"]
+std = [
+  "alloy-primitives/std",
+]
+arbitrary = [
+  "std",
+  "dep:arbitrary",
+  "alloy-primitives/arbitrary",
+]

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -22,26 +22,11 @@ alloy-provider.workspace = true
 alloy-network.workspace = true
 alloy-transport.workspace = true
 
-# arbitrary
-arbitrary = { workspace = true, features = ["derive"], optional = true }
-
 # misc
 async-trait = "0.1.82"
-
-[dev-dependencies]
-alloy-primitives = { workspace = true, features = ["arbitrary"] }
-alloy-consensus = { workspace = true, features = ["arbitrary"] }
-alloy-rpc-types = { workspace = true, features = ["arbitrary"] }
-arbitrary = { workspace = true, features = ["derive"] }
-rand.workspace = true
 
 [features]
 default = ["std"]
 std = [
   "alloy-primitives/std",
-]
-arbitrary = [
-  "std",
-  "dep:arbitrary",
-  "alloy-primitives/arbitrary",
 ]

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -24,9 +24,3 @@ alloy-transport.workspace = true
 
 # misc
 async-trait = "0.1.82"
-
-[features]
-default = ["std"]
-std = [
-  "alloy-primitives/std",
-]

--- a/crates/provider/README.md
+++ b/crates/provider/README.md
@@ -1,0 +1,3 @@
+# alloy-provider
+
+Interface with an OP Stack blockchain.

--- a/crates/provider/src/ext/engine.rs
+++ b/crates/provider/src/ext/engine.rs
@@ -1,0 +1,308 @@
+use alloy_network::Network;
+use alloy_primitives::{BlockHash, B256};
+use alloy_provider::Provider;
+use alloy_rpc_types_engine::{
+    ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadEnvelopeV2, ExecutionPayloadInputV2,
+    ExecutionPayloadV3, ExecutionPayloadV4, ForkchoiceState, ForkchoiceUpdated, PayloadId,
+    PayloadStatus,
+};
+use alloy_transport::{Transport, TransportResult};
+use op_alloy_rpc_types_engine::{
+    OptimismExecutionPayloadEnvelopeV3, OptimismExecutionPayloadEnvelopeV4,
+    OptimismPayloadAttributes, ProtocolVersion, SuperchainSignal,
+};
+
+/// Extension trait that gives access to Optimism engine API RPC methods.
+///
+/// Note:
+/// > The provider should use a JWT authentication layer.
+///
+/// This follows the Optimism specs that can be found at:
+/// <https://specs.optimism.io/protocol/exec-engine.html#engine-api>
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait OpEngineApi<N, T>: Send + Sync {
+    /// Sends the given payload to the execution layer client, as specified for the Shanghai fork.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/shanghai.md#engine_newpayloadv2>
+    ///
+    /// No modifications needed for OP compatibility.
+    async fn new_payload_v2(
+        &self,
+        payload: ExecutionPayloadInputV2,
+    ) -> TransportResult<PayloadStatus>;
+
+    /// Sends the given payload to the execution layer client, as specified for the Cancun fork.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#engine_newpayloadv3>
+    ///
+    /// OP modifications:
+    /// - expected versioned hashes MUST be an empty array: therefore the `versioned_hashes`
+    ///   parameter is removed.
+    /// - parent beacon block root MUST be the parent beacon block root from the L1 origin block of
+    ///   the L2 block.
+    async fn new_payload_v3(
+        &self,
+        payload: ExecutionPayloadV3,
+        parent_beacon_block_root: B256,
+    ) -> TransportResult<PayloadStatus>;
+
+    /// Sends the given payload to the execution layer client, as specified for the Prague fork.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/blob/03911ffc053b8b806123f1fc237184b0092a485a/src/engine/prague.md#engine_newpayloadv4>
+    ///
+    /// OP modifications: TODO
+    async fn new_payload_v4(
+        &self,
+        payload: ExecutionPayloadV4,
+        parent_beacon_block_root: B256,
+    ) -> TransportResult<PayloadStatus>;
+
+    /// Updates the execution layer client with the given fork choice, as specified for the Shanghai
+    /// fork.
+    ///
+    /// Caution: This should not accept the `parentBeaconBlockRoot` field in the payload attributes.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/shanghai.md#engine_forkchoiceupdatedv2>
+    ///
+    /// OP modifications:
+    /// - The `payload_attributes` parameter is extended with the `OptimismPayloadAttributes` type
+    ///   as described in <https://specs.optimism.io/protocol/exec-engine.html#extended-payloadattributesv2>
+    async fn fork_choice_updated_v2(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<OptimismPayloadAttributes>,
+    ) -> TransportResult<ForkchoiceUpdated>;
+
+    /// Updates the execution layer client with the given fork choice, as specified for the Cancun
+    /// fork.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#engine_forkchoiceupdatedv3>
+    ///
+    /// OP modifications:
+    /// - Must be called with an Ecotone payload
+    /// - Attributes must contain the parent beacon block root field
+    /// - The `payload_attributes` parameter is extended with the `OptimismPayloadAttributes` type
+    ///   as described in <https://specs.optimism.io/protocol/exec-engine.html#extended-payloadattributesv2>
+    async fn fork_choice_updated_v3(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<OptimismPayloadAttributes>,
+    ) -> TransportResult<ForkchoiceUpdated>;
+
+    /// Retrieves an execution payload from a previously started build process, as specified for the
+    /// Shanghai fork.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/shanghai.md#engine_getpayloadv2>
+    ///
+    /// Note:
+    /// > Provider software MAY stop the corresponding build process after serving this call.
+    ///
+    /// No modifications needed for OP compatibility.
+    async fn get_payload_v2(
+        &self,
+        payload_id: PayloadId,
+    ) -> TransportResult<ExecutionPayloadEnvelopeV2>;
+
+    /// Retrieves an execution payload from a previously started build process, as specified for the
+    /// Cancun fork.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#engine_getpayloadv3>
+    ///
+    /// Note:
+    /// > Provider software MAY stop the corresponding build process after serving this call.
+    ///
+    /// OP modifications:
+    /// - the response type is extended to [`OptimismExecutionPayloadEnvelopeV3`].
+    async fn get_payload_v3(
+        &self,
+        payload_id: PayloadId,
+    ) -> TransportResult<OptimismExecutionPayloadEnvelopeV3>;
+
+    /// Returns the most recent version of the payload that is available in the corresponding
+    /// payload build process at the time of receiving this call.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md#engine_getpayloadv4>
+    ///
+    /// Note:
+    /// > Provider software MAY stop the corresponding build process after serving this call.
+    ///
+    /// OP modifications:
+    /// - the response type is extended to [`ExecutionPayloadEnvelopeV4`].
+    async fn get_payload_v4(
+        &self,
+        payload_id: PayloadId,
+    ) -> TransportResult<OptimismExecutionPayloadEnvelopeV4>;
+
+    /// Returns the execution payload bodies by the given hash.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/blob/6452a6b194d7db269bf1dbd087a267251d3cc7f8/src/engine/shanghai.md#engine_getpayloadbodiesbyhashv1>
+    async fn get_payload_bodies_by_hash_v1(
+        &self,
+        block_hashes: Vec<BlockHash>,
+    ) -> TransportResult<ExecutionPayloadBodiesV1>;
+
+    /// Returns the execution payload bodies by the range starting at `start`, containing `count`
+    /// blocks.
+    ///
+    /// WARNING: This method is associated with the BeaconBlocksByRange message in the consensus
+    /// layer p2p specification, meaning the input should be treated as untrusted or potentially
+    /// adversarial.
+    ///
+    /// Implementers should take care when acting on the input to this method, specifically
+    /// ensuring that the range is limited properly, and that the range boundaries are computed
+    /// correctly and without panics.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/blob/6452a6b194d7db269bf1dbd087a267251d3cc7f8/src/engine/shanghai.md#engine_getpayloadbodiesbyrangev1>
+    async fn get_payload_bodies_by_range_v1(
+        &self,
+        start: u64,
+        count: u64,
+    ) -> TransportResult<ExecutionPayloadBodiesV1>;
+
+    /// Returns the execution client version information.
+    ///
+    /// Note:
+    /// > The `client_version` parameter identifies the consensus client.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/identification.md#engine_getclientversionv1>
+    async fn get_client_version_v1(
+        &self,
+        client_version: ClientVersionV1,
+    ) -> TransportResult<Vec<ClientVersionV1>>;
+
+    /// Returns the list of Engine API methods supported by the execution layer client software.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/blob/6452a6b194d7db269bf1dbd087a267251d3cc7f8/src/engine/common.md#capabilities>
+    async fn exchange_capabilities(
+        &self,
+        capabilities: Vec<String>,
+    ) -> TransportResult<Vec<String>>;
+
+    /// Signals superchain information to the Engine
+    ///
+    /// V1 signals which protocol version is recommended and required.
+    async fn signal_superchain_v1(
+        &self,
+        signal: SuperchainSignal,
+    ) -> TransportResult<ProtocolVersion>;
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl<N, T, P> OpEngineApi<N, T> for P
+where
+    N: Network,
+    T: Transport + Clone,
+    P: Provider<T, N>,
+{
+    async fn new_payload_v2(
+        &self,
+        payload: ExecutionPayloadInputV2,
+    ) -> TransportResult<PayloadStatus> {
+        self.client().request("engine_newPayloadV2", (payload,)).await
+    }
+
+    async fn new_payload_v3(
+        &self,
+        payload: ExecutionPayloadV3,
+        parent_beacon_block_root: B256,
+    ) -> TransportResult<PayloadStatus> {
+        // Note: The `versioned_hashes` parameter is always an empty array for OP chains.
+        let versioned_hashes: Vec<B256> = vec![];
+
+        self.client()
+            .request("engine_newPayloadV3", (payload, versioned_hashes, parent_beacon_block_root))
+            .await
+    }
+
+    async fn new_payload_v4(
+        &self,
+        payload: ExecutionPayloadV4,
+        parent_beacon_block_root: B256,
+    ) -> TransportResult<PayloadStatus> {
+        // Note: The `versioned_hashes` parameter is always an empty array for OP chains.
+        let versioned_hashes: Vec<B256> = vec![];
+
+        self.client()
+            .request("engine_newPayloadV4", (payload, versioned_hashes, parent_beacon_block_root))
+            .await
+    }
+
+    async fn fork_choice_updated_v2(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<OptimismPayloadAttributes>,
+    ) -> TransportResult<ForkchoiceUpdated> {
+        self.client()
+            .request("engine_forkchoiceUpdatedV2", (fork_choice_state, payload_attributes))
+            .await
+    }
+
+    async fn fork_choice_updated_v3(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<OptimismPayloadAttributes>,
+    ) -> TransportResult<ForkchoiceUpdated> {
+        self.client()
+            .request("engine_forkchoiceUpdatedV3", (fork_choice_state, payload_attributes))
+            .await
+    }
+
+    async fn get_payload_v2(
+        &self,
+        payload_id: PayloadId,
+    ) -> TransportResult<ExecutionPayloadEnvelopeV2> {
+        self.client().request("engine_getPayloadV2", (payload_id,)).await
+    }
+
+    async fn get_payload_v3(
+        &self,
+        payload_id: PayloadId,
+    ) -> TransportResult<OptimismExecutionPayloadEnvelopeV3> {
+        self.client().request("engine_getPayloadV3", (payload_id,)).await
+    }
+
+    async fn get_payload_v4(
+        &self,
+        payload_id: PayloadId,
+    ) -> TransportResult<OptimismExecutionPayloadEnvelopeV4> {
+        self.client().request("engine_getPayloadV4", (payload_id,)).await
+    }
+
+    async fn get_payload_bodies_by_hash_v1(
+        &self,
+        block_hashes: Vec<BlockHash>,
+    ) -> TransportResult<ExecutionPayloadBodiesV1> {
+        self.client().request("engine_getPayloadBodiesByHashV1", (block_hashes,)).await
+    }
+
+    async fn get_payload_bodies_by_range_v1(
+        &self,
+        start: u64,
+        count: u64,
+    ) -> TransportResult<ExecutionPayloadBodiesV1> {
+        self.client().request("engine_getPayloadBodiesByRangeV1", (start, count)).await
+    }
+
+    async fn get_client_version_v1(
+        &self,
+        client_version: ClientVersionV1,
+    ) -> TransportResult<Vec<ClientVersionV1>> {
+        self.client().request("engine_getClientVersionV1", (client_version,)).await
+    }
+
+    async fn exchange_capabilities(
+        &self,
+        capabilities: Vec<String>,
+    ) -> TransportResult<Vec<String>> {
+        self.client().request("engine_exchangeCapabilities", (capabilities,)).await
+    }
+
+    async fn signal_superchain_v1(
+        &self,
+        signal: SuperchainSignal,
+    ) -> TransportResult<ProtocolVersion> {
+        self.client().request("engine_signalSuperchainV1", (signal,)).await
+    }
+}

--- a/crates/provider/src/ext/engine.rs
+++ b/crates/provider/src/ext/engine.rs
@@ -128,7 +128,7 @@ pub trait OpEngineApi<N, T>: Send + Sync {
     /// > Provider software MAY stop the corresponding build process after serving this call.
     ///
     /// OP modifications:
-    /// - the response type is extended to [`ExecutionPayloadEnvelopeV4`].
+    /// - the response type is extended to [`OptimismExecutionPayloadEnvelopeV4`].
     async fn get_payload_v4(
         &self,
         payload_id: PayloadId,

--- a/crates/provider/src/ext/mod.rs
+++ b/crates/provider/src/ext/mod.rs
@@ -1,0 +1,4 @@
+//! Extended APIs for the OP provider module.
+
+/// Engine API extension.
+pub mod engine;

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -1,0 +1,19 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/alloy.jpg",
+    html_favicon_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/favicon.ico"
+)]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    unreachable_pub,
+    clippy::missing_const_for_fn,
+    rustdoc::all
+)]
+#![deny(unused_must_use, rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod ext;

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -14,6 +14,5 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
-#![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod ext;

--- a/crates/rpc-types-engine/Cargo.toml
+++ b/crates/rpc-types-engine/Cargo.toml
@@ -24,6 +24,7 @@ derive_more = { workspace = true, features = ["display"] }
 # serde
 serde = { workspace = true, optional = true }
 alloy-serde = { workspace = true, optional = true }
+cfg-if = { version = "1.0" }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/rpc-types-engine/Cargo.toml
+++ b/crates/rpc-types-engine/Cargo.toml
@@ -20,7 +20,7 @@ op-alloy-genesis.workspace = true
 op-alloy-consensus.workspace = true
 
 derive_more = { workspace = true, features = ["display"] }
-thiserror.workspace = true
+thiserror = { workspace = true, optional = true }
 
 # serde
 serde = { workspace = true, optional = true }
@@ -32,6 +32,7 @@ serde_json.workspace = true
 [features]
 default = ["std", "serde"]
 std = [
+  "dep:thiserror",
   "alloy-primitives/std",
   "alloy-rpc-types-engine/std",
   "op-alloy-protocol/std",

--- a/crates/rpc-types-engine/Cargo.toml
+++ b/crates/rpc-types-engine/Cargo.toml
@@ -20,7 +20,7 @@ op-alloy-genesis.workspace = true
 op-alloy-consensus.workspace = true
 
 derive_more = { workspace = true, features = ["display"] }
-cfg-if.workspace = true
+thiserror.workspace = true
 
 # serde
 serde = { workspace = true, optional = true }

--- a/crates/rpc-types-engine/Cargo.toml
+++ b/crates/rpc-types-engine/Cargo.toml
@@ -20,7 +20,6 @@ op-alloy-genesis.workspace = true
 op-alloy-consensus.workspace = true
 
 derive_more = { workspace = true, features = ["display"] }
-thiserror = { workspace = true, optional = true }
 
 # serde
 serde = { workspace = true, optional = true }
@@ -32,7 +31,6 @@ serde_json.workspace = true
 [features]
 default = ["std", "serde"]
 std = [
-  "dep:thiserror",
   "alloy-primitives/std",
   "alloy-rpc-types-engine/std",
   "op-alloy-protocol/std",

--- a/crates/rpc-types-engine/Cargo.toml
+++ b/crates/rpc-types-engine/Cargo.toml
@@ -20,11 +20,11 @@ op-alloy-genesis.workspace = true
 op-alloy-consensus.workspace = true
 
 derive_more = { workspace = true, features = ["display"] }
+cfg-if.workspace = true
 
 # serde
 serde = { workspace = true, optional = true }
 alloy-serde = { workspace = true, optional = true }
-cfg-if = { version = "1.0" }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -36,6 +36,9 @@ pub use payload_v3::OptimismExecutionPayloadEnvelopeV3;
 mod payload_v4;
 pub use payload_v4::OptimismExecutionPayloadEnvelopeV4;
 
+mod superchain;
+pub use superchain::{ProtocolVersion, SuperchainSignal};
+
 mod errors;
 pub use errors::{ToL2BlockRefError, ToSystemConfigError};
 

--- a/crates/rpc-types-engine/src/superchain.rs
+++ b/crates/rpc-types-engine/src/superchain.rs
@@ -1,4 +1,7 @@
-use alloc::{format, string::String};
+use alloc::{
+    format,
+    string::{String, ToString},
+};
 use core::array::TryFromSliceError;
 
 use alloy_primitives::{B256, B64};

--- a/crates/rpc-types-engine/src/superchain.rs
+++ b/crates/rpc-types-engine/src/superchain.rs
@@ -1,3 +1,4 @@
+use alloc::{format, string::String};
 use core::array::TryFromSliceError;
 
 use alloy_primitives::{B256, B64};

--- a/crates/rpc-types-engine/src/superchain.rs
+++ b/crates/rpc-types-engine/src/superchain.rs
@@ -33,7 +33,7 @@ pub struct SuperchainSignal {
 /// said hardforks.
 ///
 /// The Protocol Version is Semver-compatible. It is encoded as a single 32 bytes long
-/// <protocol version>. The version must be encoded as 32 bytes of DATA in JSON RPC usage.
+/// protocol version. The version must be encoded as 32 bytes of DATA in JSON RPC usage.
 ///
 /// See also: <https://specs.optimism.io/protocol/superchain-upgrades.html#protocol-version>
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/crates/rpc-types-engine/src/superchain.rs
+++ b/crates/rpc-types-engine/src/superchain.rs
@@ -1,0 +1,146 @@
+use core::array::TryFromSliceError;
+
+use alloy_primitives::{B256, B64};
+use cfg_if::cfg_if;
+
+/// Superchain Signal information.
+///
+/// The execution engine SHOULD warn the user when the recommended version is newer than the current
+/// version supported by the execution engine.
+///
+/// The execution engine SHOULD take safety precautions if it does not meet the required protocol
+/// version. This may include halting the engine, with consent of the execution engine operator.
+///
+/// See also: <https://specs.optimism.io/protocol/exec-engine.html#engine_signalsuperchainv1>
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct SuperchainSignal {
+    /// The recommended Supercain Protocol Version.
+    pub recommended: ProtocolVersion,
+    /// The minimum Supercain Protocol Version required.
+    pub required: ProtocolVersion,
+}
+
+/// Formatted Superchain Protocol Version.
+///
+/// The Protocol Version documents the progression of the total set of canonical OP-Stack
+/// specifications. Components of the OP-Stack implement the subset of their respective protocol
+/// component domain, up to a given Protocol Version of the OP-Stack.
+///
+/// The Protocol Version **is NOT a hardfork identifier**, but rather indicates software-support for
+/// a well-defined set of features introduced in past and future hardforks, not the activation of
+/// said hardforks.
+///
+/// The Protocol Version is Semver-compatible. It is encoded as a single 32 bytes long
+/// <protocol version>. The version must be encoded as 32 bytes of DATA in JSON RPC usage.
+///
+/// See also: <https://specs.optimism.io/protocol/superchain-upgrades.html#protocol-version>
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ProtocolVersion {
+    /// Version-type 0.
+    V0(ProtocolVersionFormatV0),
+}
+
+cfg_if! {
+    if #[cfg(feature = "serde")] {
+        use serde::{de, Serialize, Serializer, Deserialize, Deserializer};
+
+        impl Serialize for ProtocolVersion {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                match self {
+                    Self::V0(value) => {
+                        // <protocol version> ::= <version-type><typed-payload>
+                        // <version-type> ::= <uint8>
+                        // <typed-payload> ::= <31 bytes>
+                        let mut bytes = [0u8; 32];
+                        bytes[0] = 0x00; // this is not necessary, but addded for clarity
+                        bytes[1..].copy_from_slice(&Into::<[u8; 31]>::into(*value));
+
+                        B256::from_slice(&bytes).serialize(serializer)
+                    }
+                }
+            }
+        }
+
+        impl<'de> Deserialize<'de> for ProtocolVersion {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                // The version must be encoded as 32 bytes of DATA in JSON RPC usage.
+                let value = B256::deserialize(deserializer)?;
+
+                // <protocol version> ::= <version-type><typed-payload>
+                // <version-type> ::= <uint8>
+                // <typed-payload> ::= <31 bytes>
+                let version_type = value[0];
+                let typed_payload = &value[1..];
+
+                match version_type {
+                    0 => Ok(Self::V0(ProtocolVersionFormatV0::try_from(typed_payload).map_err(de::Error::custom)?)),
+                    other => Err(de::Error::custom(format!("unsupported protocol version: {}", other))),
+                }
+            }
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ProtocolVersionFormatV0 {
+    pub build: B64,
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+    pub pre_release: u32,
+}
+
+impl From<ProtocolVersionFormatV0> for [u8; 31] {
+    fn from(value: ProtocolVersionFormatV0) -> Self {
+        // Version-type 0:
+        //
+        // <reserved><build><major><minor><patch><pre-release>
+        // <reserved> ::= <7 zeroed bytes>
+        // <build> ::= <8 bytes>
+        // <major> ::= <big-endian uint32>
+        // <minor> ::= <big-endian uint32>
+        // <patch> ::= <big-endian uint32>
+        // <pre-release> ::= <big-endian uint32>
+
+        let mut bytes = [0u8; 31];
+        bytes[0..7].copy_from_slice(&[0u8; 7]);
+        bytes[7..15].copy_from_slice(&value.build.0);
+        bytes[15..19].copy_from_slice(&value.major.to_be_bytes());
+        bytes[19..23].copy_from_slice(&value.minor.to_be_bytes());
+        bytes[23..27].copy_from_slice(&value.patch.to_be_bytes());
+        bytes[27..31].copy_from_slice(&value.pre_release.to_be_bytes());
+        bytes
+    }
+}
+
+impl TryFrom<&[u8]> for ProtocolVersionFormatV0 {
+    type Error = TryFromSliceError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        // Version-type 0:
+        //
+        // <reserved><build><major><minor><patch><pre-release>
+        // <reserved> ::= <7 zeroed bytes>
+        // <build> ::= <8 bytes>
+        // <major> ::= <big-endian uint32>
+        // <minor> ::= <big-endian uint32>
+        // <patch> ::= <big-endian uint32>
+        // <pre-release> ::= <big-endian uint32>
+
+        Ok(Self {
+            build: B64::from_slice(&value[7..15]),
+            major: u32::from_be_bytes(value[15..19].try_into()?),
+            minor: u32::from_be_bytes(value[19..23].try_into()?),
+            patch: u32::from_be_bytes(value[23..27].try_into()?),
+            pre_release: u32::from_be_bytes(value[27..31].try_into()?),
+        })
+    }
+}

--- a/crates/rpc-types-engine/src/superchain.rs
+++ b/crates/rpc-types-engine/src/superchain.rs
@@ -1,7 +1,6 @@
 use core::array::TryFromSliceError;
 
 use alloy_primitives::{B256, B64};
-use cfg_if::cfg_if;
 
 /// Superchain Signal information.
 ///
@@ -37,55 +36,74 @@ pub struct SuperchainSignal {
 ///
 /// See also: <https://specs.optimism.io/protocol/superchain-upgrades.html#protocol-version>
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ProtocolVersion {
     /// Version-type 0.
     V0(ProtocolVersionFormatV0),
 }
 
-cfg_if! {
-    if #[cfg(feature = "serde")] {
-        use serde::{de, Serialize, Serializer, Deserialize, Deserializer};
+#[derive(Copy, Clone, Debug, thiserror::Error)]
+pub enum ProtocolVersionError {
+    #[error("Unsupported version: {0}")]
+    UnsupportedVersion(u8),
+    #[error("Invalid version format length. Got {0}, expected 31")]
+    InvalidLength(usize),
+    #[error("Invalid version format encoding")]
+    FromSlice(#[from] TryFromSliceError),
+}
 
-        impl Serialize for ProtocolVersion {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-            where
-                S: Serializer,
-            {
-                match self {
-                    Self::V0(value) => {
-                        // <protocol version> ::= <version-type><typed-payload>
-                        // <version-type> ::= <uint8>
-                        // <typed-payload> ::= <31 bytes>
-                        let mut bytes = [0u8; 32];
-                        bytes[0] = 0x00; // this is not necessary, but addded for clarity
-                        bytes[1..].copy_from_slice(&Into::<[u8; 31]>::into(*value));
+impl From<ProtocolVersion> for B256 {
+    fn from(value: ProtocolVersion) -> B256 {
+        let mut bytes = [0u8; 32];
 
-                        B256::from_slice(&bytes).serialize(serializer)
-                    }
-                }
-            }
-        }
-
-        impl<'de> Deserialize<'de> for ProtocolVersion {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                // The version must be encoded as 32 bytes of DATA in JSON RPC usage.
-                let value = B256::deserialize(deserializer)?;
-
+        match value {
+            ProtocolVersion::V0(value) => {
                 // <protocol version> ::= <version-type><typed-payload>
                 // <version-type> ::= <uint8>
                 // <typed-payload> ::= <31 bytes>
-                let version_type = value[0];
-                let typed_payload = &value[1..];
-
-                match version_type {
-                    0 => Ok(Self::V0(ProtocolVersionFormatV0::try_from(typed_payload).map_err(de::Error::custom)?)),
-                    other => Err(de::Error::custom(format!("unsupported protocol version: {}", other))),
-                }
+                bytes[0] = 0x00; // this is not necessary, but addded for clarity
+                bytes[1..].copy_from_slice(&value.into_slice());
+                B256::from_slice(&bytes)
             }
         }
+    }
+}
+
+impl TryFrom<B256> for ProtocolVersion {
+    type Error = ProtocolVersionError;
+
+    fn try_from(value: B256) -> Result<Self, Self::Error> {
+        // <protocol version> ::= <version-type><typed-payload>
+        // <version-type> ::= <uint8>
+        // <typed-payload> ::= <31 bytes>
+        let version_type = value[0];
+        let typed_payload = &value[1..];
+
+        match version_type {
+            0 => Ok(Self::V0(ProtocolVersionFormatV0::try_from_slice(typed_payload)?)),
+            other => Err(ProtocolVersionError::UnsupportedVersion(other)),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for ProtocolVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        B256::from(*self).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for ProtocolVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = B256::deserialize(deserializer)?;
+        Self::try_from(value).map_err(serde::de::Error::custom)
     }
 }
 
@@ -98,42 +116,58 @@ pub struct ProtocolVersionFormatV0 {
     pub pre_release: u32,
 }
 
-impl From<ProtocolVersionFormatV0> for [u8; 31] {
-    fn from(value: ProtocolVersionFormatV0) -> Self {
-        // Version-type 0:
-        //
-        // <reserved><build><major><minor><patch><pre-release>
-        // <reserved> ::= <7 zeroed bytes>
-        // <build> ::= <8 bytes>
-        // <major> ::= <big-endian uint32>
-        // <minor> ::= <big-endian uint32>
-        // <patch> ::= <big-endian uint32>
-        // <pre-release> ::= <big-endian uint32>
-
-        let mut bytes = [0u8; 31];
-        bytes[0..7].copy_from_slice(&[0u8; 7]);
-        bytes[7..15].copy_from_slice(&value.build.0);
-        bytes[15..19].copy_from_slice(&value.major.to_be_bytes());
-        bytes[19..23].copy_from_slice(&value.minor.to_be_bytes());
-        bytes[23..27].copy_from_slice(&value.patch.to_be_bytes());
-        bytes[27..31].copy_from_slice(&value.pre_release.to_be_bytes());
-        bytes
+impl std::fmt::Display for ProtocolVersionFormatV0 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{build}.{major}.{minor}.{patch}-{pre_release}",
+            build = self.build,
+            major = self.major,
+            minor = self.minor,
+            patch = self.patch,
+            pre_release = self.pre_release
+        )
     }
 }
 
-impl TryFrom<&[u8]> for ProtocolVersionFormatV0 {
-    type Error = TryFromSliceError;
+impl ProtocolVersionFormatV0 {
+    /// Version-type 0 byte encoding:
+    ///
+    /// ```text
+    /// <reserved><build><major><minor><patch><pre-release>
+    /// <reserved> ::= <7 zeroed bytes>
+    /// <build> ::= <8 bytes>
+    /// <major> ::= <big-endian uint32>
+    /// <minor> ::= <big-endian uint32>
+    /// <patch> ::= <big-endian uint32>
+    /// <pre-release> ::= <big-endian uint32>
+    /// ```
+    pub fn into_slice(self) -> [u8; 31] {
+        let mut bytes = [0u8; 31];
+        bytes[0..7].copy_from_slice(&[0u8; 7]);
+        bytes[7..15].copy_from_slice(&self.build.0);
+        bytes[15..19].copy_from_slice(&self.major.to_be_bytes());
+        bytes[19..23].copy_from_slice(&self.minor.to_be_bytes());
+        bytes[23..27].copy_from_slice(&self.patch.to_be_bytes());
+        bytes[27..31].copy_from_slice(&self.pre_release.to_be_bytes());
+        bytes
+    }
 
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        // Version-type 0:
-        //
-        // <reserved><build><major><minor><patch><pre-release>
-        // <reserved> ::= <7 zeroed bytes>
-        // <build> ::= <8 bytes>
-        // <major> ::= <big-endian uint32>
-        // <minor> ::= <big-endian uint32>
-        // <patch> ::= <big-endian uint32>
-        // <pre-release> ::= <big-endian uint32>
+    /// Version-type 0 byte encoding:
+    ///
+    /// ```text
+    /// <reserved><build><major><minor><patch><pre-release>
+    /// <reserved> ::= <7 zeroed bytes>
+    /// <build> ::= <8 bytes>
+    /// <major> ::= <big-endian uint32>
+    /// <minor> ::= <big-endian uint32>
+    /// <patch> ::= <big-endian uint32>
+    /// <pre-release> ::= <big-endian uint32>
+    /// ```
+    fn try_from_slice(value: &[u8]) -> Result<Self, ProtocolVersionError> {
+        if value.len() != 31 {
+            return Err(ProtocolVersionError::InvalidLength(value.len()));
+        }
 
         Ok(Self {
             build: B64::from_slice(&value[7..15]),

--- a/crates/rpc-types-engine/src/superchain.rs
+++ b/crates/rpc-types-engine/src/superchain.rs
@@ -90,6 +90,55 @@ impl ProtocolVersion {
             other => Err(ProtocolVersionError::UnsupportedVersion(other)),
         }
     }
+
+    /// Returns the inner value of the ProtocolVersion enum
+    pub const fn inner(&self) -> ProtocolVersionFormatV0 {
+        match self {
+            ProtocolVersion::V0(value) => *value,
+        }
+    }
+
+    /// Returns the inner value of the ProtocolVersion enum if it is V0, otherwise None
+    pub const fn as_v0(&self) -> Option<ProtocolVersionFormatV0> {
+        match self {
+            ProtocolVersion::V0(value) => Some(*value),
+        }
+    }
+
+    /// Differentiates forks and custom-builds of standard protocol
+    pub const fn build(&self) -> B64 {
+        match self {
+            ProtocolVersion::V0(value) => value.build,
+        }
+    }
+
+    /// Incompatible API changes
+    pub const fn major(&self) -> u32 {
+        match self {
+            ProtocolVersion::V0(value) => value.major,
+        }
+    }
+
+    /// Identifies additional functionality in backwards compatible manner
+    pub const fn minor(&self) -> u32 {
+        match self {
+            ProtocolVersion::V0(value) => value.minor,
+        }
+    }
+
+    /// Identifies backward-compatible bug-fixes
+    pub const fn patch(&self) -> u32 {
+        match self {
+            ProtocolVersion::V0(value) => value.patch,
+        }
+    }
+
+    /// Identifies unstable versions that may not satisfy the above
+    pub const fn pre_release(&self) -> u32 {
+        match self {
+            ProtocolVersion::V0(value) => value.pre_release,
+        }
+    }
 }
 
 #[cfg(feature = "serde")]
@@ -115,10 +164,15 @@ impl<'de> serde::Deserialize<'de> for ProtocolVersion {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct ProtocolVersionFormatV0 {
+    /// Differentiates forks and custom-builds of standard protocol
     pub build: B64,
+    /// Incompatible API changes
     pub major: u32,
+    /// Identifies additional functionality in backwards compatible manner
     pub minor: u32,
+    /// Identifies backward-compatible bug-fixes
     pub patch: u32,
+    /// Identifies unstable versions that may not satisfy the above
     pub pre_release: u32,
 }
 
@@ -127,12 +181,12 @@ impl std::fmt::Display for ProtocolVersionFormatV0 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{build}.{major}.{minor}.{patch}-{pre_release}",
-            build = self.build,
+            "v{major}.{minor}.{patch}-{pre_release}+{build}",
             major = self.major,
             minor = self.minor,
             patch = self.patch,
-            pre_release = self.pre_release
+            pre_release = self.pre_release,
+            build = self.build,
         )
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Adds a `provider` crate (`op-alloy-provider`) with some extension API traits for the OP engine API.
Additionally, adds the `SuperchainSignal` type along with the canonical decoding impl for the V0 type.

Ref: https://github.com/paradigmxyz/op-rs/issues/11

