### PR TITLE
fix(protocol): Clean up std feature gating

### DIFF
--- a/crates/protocol/src/batch_tx.rs
+++ b/crates/protocol/src/batch_tx.rs
@@ -1,7 +1,6 @@
 //! Transaction Types
 
 use crate::Frame;
-#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use alloy_primitives::Bytes;
 
@@ -41,7 +40,6 @@ impl BatchTransaction {
 #[cfg(test)]
 mod test {
     use super::*;
-    #[cfg(not(feature = "std"))]
     use alloc::vec;
 
     #[test]

--- a/crates/protocol/src/block_info.rs
+++ b/crates/protocol/src/block_info.rs
@@ -1,7 +1,6 @@
 //! This module contains the [L1BlockInfoTx] type, and various encoding / decoding methods for it.
 
-use super::{DepositSourceDomain, L1InfoDepositSource};
-#[cfg(not(feature = "std"))]
+use crate::{DepositSourceDomain, L1InfoDepositSource};
 use alloc::{
     format,
     string::{String, ToString},
@@ -454,7 +453,6 @@ impl L1BlockInfoEcotone {
 #[cfg(test)]
 mod test {
     use super::*;
-    #[cfg(not(feature = "std"))]
     use alloc::string::ToString;
     use alloy_primitives::{address, b256, hex};
 

--- a/crates/protocol/src/channel.rs
+++ b/crates/protocol/src/channel.rs
@@ -1,14 +1,10 @@
 //! Channel Types
 
-#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-
 use alloy_primitives::Bytes;
 use hashbrown::HashMap;
 
-use crate::block::BlockInfo;
-
-use crate::{frame::Frame, ChannelId};
+use crate::{block::BlockInfo, frame::Frame, ChannelId};
 
 /// [MAX_RLP_BYTES_PER_CHANNEL] is the maximum amount of bytes that will be read from
 /// a channel. This limit is set when decoding the RLP.
@@ -201,12 +197,10 @@ impl Channel {
 #[cfg(test)]
 mod test {
     use super::*;
-    #[cfg(not(feature = "std"))]
-    use alloc::string::String;
-    #[cfg(not(feature = "std"))]
-    use alloc::string::ToString;
-    #[cfg(not(feature = "std"))]
-    use alloc::vec;
+    use alloc::{
+        string::{String, ToString},
+        vec,
+    };
 
     struct FrameValidityTestCase {
         #[allow(dead_code)]

--- a/crates/protocol/src/deposits.rs
+++ b/crates/protocol/src/deposits.rs
@@ -1,5 +1,5 @@
 //! Contains deposit transaction types and helper methods.
-#[cfg(not(feature = "std"))]
+
 use alloc::{string::String, vec::Vec};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{b256, keccak256, Address, Bytes, Log, TxKind, B256, U256, U64};
@@ -402,7 +402,6 @@ pub(crate) fn unmarshal_deposit_version0(
 #[cfg(test)]
 mod test {
     use super::*;
-    #[cfg(not(feature = "std"))]
     use alloc::vec;
     use alloy_primitives::{address, b256, hex, LogData};
 

--- a/crates/protocol/src/frame.rs
+++ b/crates/protocol/src/frame.rs
@@ -1,9 +1,7 @@
 //! Frame Types
 
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 use crate::ChannelId;
+use alloc::vec::Vec;
 
 /// The version of the derivation pipeline.
 pub const DERIVATION_VERSION_0: u8 = 0;
@@ -180,7 +178,6 @@ impl Frame {
 #[cfg(test)]
 mod test {
     use super::*;
-    #[cfg(not(feature = "std"))]
     use alloc::vec;
 
     #[test]

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -16,7 +16,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 /// [CHANNEL_ID_LENGTH] is the length of the channel ID.


### PR DESCRIPTION
### Description

Cleans up the `op-alloy-protocol` crate, removing `#[cfg(feature = "std")]` feature gates across the crate.

Also touches up some imports.