### PR TITLE
Replace `UnsignedTx` and `TxEnvelope` with op types in `Network` impl

### DIFF
--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -11,7 +11,7 @@ pub use alloy_network::*;
 use alloy_consensus::TxType;
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_rpc_types_eth::AccessList;
-use op_alloy_consensus::OpTxType;
+use op_alloy_consensus::{OpTxEnvelope, OpTxType, OpTypedTransaction};
 
 /// Types for an Op-stack network.
 #[derive(Clone, Copy, Debug)]
@@ -22,9 +22,9 @@ pub struct Optimism {
 impl Network for Optimism {
     type TxType = OpTxType;
 
-    type TxEnvelope = alloy_consensus::TxEnvelope;
+    type TxEnvelope = OpTxEnvelope;
 
-    type UnsignedTx = alloy_consensus::TypedTransaction;
+    type UnsignedTx = OpTypedTransaction;
 
     type ReceiptEnvelope = op_alloy_consensus::OpReceiptEnvelope;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Bug: deposit tx not covered by alloy transaction envelope and unsigned transaction types in `Network` impl for `Optimism`

## Solution

Replaces alloy types for `Network::TxEnvelope` and `Network::UnsignedTx` with OP types `OpTxEnvelope` and `OpTypedTransaction` respectively.

blocked by https://github.com/alloy-rs/op-alloy/issues/27

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
