### PR TITLE
chore(protocol): Remove `L1BlockInfoTx::Holocene` variant

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -41,4 +41,4 @@ pub use deposits::{
 };
 
 pub mod block_info;
-pub use block_info::{L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoHolocene, L1BlockInfoTx};
+pub use block_info::{L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoTx};

--- a/crates/protocol/src/utils.rs
+++ b/crates/protocol/src/utils.rs
@@ -1,9 +1,6 @@
 //! Utility methods used by protocol types.
 
-use crate::{
-    block_info::DecodeError, L1BlockInfoBedrock, L1BlockInfoEcotone,
-    L1BlockInfoTx,
-};
+use crate::{block_info::DecodeError, L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoTx};
 use alloy_primitives::B256;
 use op_alloy_consensus::{OpBlock, OpTxEnvelope};
 use op_alloy_genesis::{RollupConfig, SystemConfig};

--- a/crates/protocol/src/utils.rs
+++ b/crates/protocol/src/utils.rs
@@ -1,7 +1,7 @@
 //! Utility methods used by protocol types.
 
 use crate::{
-    block_info::DecodeError, L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoHolocene,
+    block_info::DecodeError, L1BlockInfoBedrock, L1BlockInfoEcotone,
     L1BlockInfoTx,
 };
 use alloy_primitives::B256;
@@ -82,11 +82,6 @@ pub fn to_system_config(
     let l1_fee_scalar = match l1_info {
         L1BlockInfoTx::Bedrock(L1BlockInfoBedrock { l1_fee_scalar, .. }) => l1_fee_scalar,
         L1BlockInfoTx::Ecotone(L1BlockInfoEcotone {
-            base_fee_scalar,
-            blob_base_fee_scalar,
-            ..
-        })
-        | L1BlockInfoTx::Holocene(L1BlockInfoHolocene {
             base_fee_scalar,
             blob_base_fee_scalar,
             ..


### PR DESCRIPTION
## Overview

Removes the `Holocene` variant of the L1 info transaction. The specification of the dynamic EIP-1559 parameters has changed to put this feature in the `PayloadAttributes` instead.

https://github.com/ethereum-optimism/specs/pull/404