### PR TITLE
feat(rpc-types-engine): EIP-1559 parameters in `OptimismPayloadAttributes`

### DIFF
--- a/crates/rpc-types-engine/src/attributes.rs
+++ b/crates/rpc-types-engine/src/attributes.rs
@@ -1,7 +1,7 @@
 //! Optimism-specific payload attributes.
 
 use alloc::vec::Vec;
-use alloy_primitives::{Bytes, FixedBytes};
+use alloy_primitives::{Bytes, B64};
 use alloy_rpc_types_engine::PayloadAttributes;
 use op_alloy_protocol::L2BlockInfo;
 
@@ -30,7 +30,7 @@ pub struct OptimismPayloadAttributes {
     ///
     /// Prior to Holocene activation, this field should always be [None].
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub eip_1559_params: Option<FixedBytes<8>>,
+    pub eip_1559_params: Option<B64>,
 }
 
 /// Optimism Payload Attributes with parent block reference.

--- a/crates/rpc-types-engine/src/attributes.rs
+++ b/crates/rpc-types-engine/src/attributes.rs
@@ -70,3 +70,54 @@ impl OptimismAttributesWithParent {
         self.is_last_in_span
     }
 }
+
+#[cfg(all(test, feature = "serde"))]
+mod test {
+    use super::*;
+    use alloy_primitives::{b64, Address, B256};
+    use alloy_rpc_types_engine::PayloadAttributes;
+
+    #[test]
+    fn test_serde_roundtrip_attributes_pre_holocene() {
+        let attributes = OptimismPayloadAttributes {
+            payload_attributes: PayloadAttributes {
+                timestamp: 0x1337,
+                prev_randao: B256::ZERO,
+                suggested_fee_recipient: Address::ZERO,
+                withdrawals: Default::default(),
+                parent_beacon_block_root: Some(B256::ZERO),
+            },
+            transactions: Some(vec![b"hello".to_vec().into()]),
+            no_tx_pool: Some(true),
+            gas_limit: Some(42),
+            eip_1559_params: None,
+        };
+
+        let ser = serde_json::to_string(&attributes).unwrap();
+        let de: OptimismPayloadAttributes = serde_json::from_str(&ser).unwrap();
+
+        assert_eq!(attributes, de);
+    }
+
+    #[test]
+    fn test_serde_roundtrip_attributes_post_holocene() {
+        let attributes = OptimismPayloadAttributes {
+            payload_attributes: PayloadAttributes {
+                timestamp: 0x1337,
+                prev_randao: B256::ZERO,
+                suggested_fee_recipient: Address::ZERO,
+                withdrawals: Default::default(),
+                parent_beacon_block_root: Some(B256::ZERO),
+            },
+            transactions: Some(vec![b"hello".to_vec().into()]),
+            no_tx_pool: Some(true),
+            gas_limit: Some(42),
+            eip_1559_params: Some(b64!("0000dead0000beef")),
+        };
+
+        let ser = serde_json::to_string(&attributes).unwrap();
+        let de: OptimismPayloadAttributes = serde_json::from_str(&ser).unwrap();
+
+        assert_eq!(attributes, de);
+    }
+}

--- a/crates/rpc-types-engine/src/attributes.rs
+++ b/crates/rpc-types-engine/src/attributes.rs
@@ -1,7 +1,7 @@
 //! Optimism-specific payload attributes.
 
 use alloc::vec::Vec;
-use alloy_primitives::Bytes;
+use alloy_primitives::{Bytes, FixedBytes};
 use alloy_rpc_types_engine::PayloadAttributes;
 use op_alloy_protocol::L2BlockInfo;
 
@@ -26,6 +26,11 @@ pub struct OptimismPayloadAttributes {
         serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")
     )]
     pub gas_limit: Option<u64>,
+    /// If set, this sets the EIP-1559 parameters for the block.
+    ///
+    /// Prior to Holocene activation, this field should always be [None].
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub eip_1559_params: Option<FixedBytes<8>>,
 }
 
 /// Optimism Payload Attributes with parent block reference.


### PR DESCRIPTION
## Overview

Adds the `eip1559Params` field to the `OptimismPayloadAttributes, per https://github.com/ethereum-optimism/specs/pull/404