### PR TITLE
feat(protocol): Add Frame Iterator

### DIFF
--- a/crates/protocol/src/frame.rs
+++ b/crates/protocol/src/frame.rs
@@ -95,6 +95,11 @@ pub struct Frame {
 }
 
 impl Frame {
+    /// Creates a new [Frame].
+    pub const fn new(id: ChannelId, number: u16, data: Vec<u8>, is_last: bool) -> Self {
+        Self { id, number, data, is_last }
+    }
+
     /// Encode the frame into a byte vector.
     pub fn encode(&self) -> Vec<u8> {
         let mut encoded = Vec::with_capacity(16 + 2 + 4 + self.data.len() + 1);
@@ -129,6 +134,13 @@ impl Frame {
         let data = encoded[22..22 + data_len].to_vec();
         let is_last = encoded[22 + data_len] == 1;
         Ok((BASE_FRAME_LEN + data_len, Self { id, number, data, is_last }))
+    }
+
+    /// Parses a single frame from the given data at the given starting position,
+    /// returning the frame and the number of bytes consumed.
+    pub fn parse_frame(data: &[u8], start: usize) -> Result<(usize, Self), FrameDecodingError> {
+        let (frame_len, frame) = Self::decode(&data[start..])?;
+        Ok((frame_len, frame))
     }
 
     /// Parse the on chain serialization of frame(s) in an L1 transaction. Currently

--- a/crates/protocol/src/iter.rs
+++ b/crates/protocol/src/iter.rs
@@ -1,0 +1,81 @@
+//! An iterator over encoded frames.
+
+use crate::frame::{Frame, FrameParseError, DERIVATION_VERSION_0};
+
+/// An iterator over encoded frames.
+#[derive(Debug, Clone)]
+pub struct FrameIter<'a> {
+    encoded: &'a [u8],
+    cursor: usize,
+}
+
+impl<'a> FrameIter<'a> {
+    /// Creates a new [FrameIter].
+    pub const fn new(encoded: &'a [u8]) -> Self {
+        Self { encoded, cursor: 1 }
+    }
+}
+
+impl<'a> From<&'a [u8]> for FrameIter<'a> {
+    fn from(encoded: &'a [u8]) -> Self {
+        Self::new(encoded)
+    }
+}
+
+impl<'a> Iterator for FrameIter<'a> {
+    type Item = Result<Frame, FrameParseError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cursor >= self.encoded.len() {
+            return None;
+        }
+        if self.encoded[0] != DERIVATION_VERSION_0 {
+            return None;
+        }
+
+        let (new_start, frame) = Frame::parse_frame(self.encoded, self.cursor)
+            .map_err(FrameParseError::FrameDecodingError)
+            .ok()?;
+
+        self.cursor += new_start;
+        Some(Ok(frame))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_iterate_none() {
+        let bytes = Vec::new();
+        let mut iter = FrameIter::new(bytes.as_slice());
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_iterate_missing_version() {
+        let bytes = vec![0x01, 0x02, 0x03, 0x04, 0x05];
+        let mut iter = FrameIter::new(bytes.as_slice());
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_iterate_many_frames() {
+        let frame = Frame { id: [0xFF; 16], number: 0xEE, data: vec![0xDD; 50], is_last: true };
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&[DERIVATION_VERSION_0]);
+        (0..5).for_each(|_| {
+            bytes.extend_from_slice(&frame.encode());
+        });
+
+        // Create a frame iterator from the bytes.
+        let mut iter = FrameIter::new(bytes.as_slice());
+
+        // Check that the iterator returns the same frame 5 times.
+        (0..5).for_each(|_| {
+            let next = iter.next().unwrap().unwrap();
+            assert_eq!(next, frame);
+        });
+    }
+}

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -26,6 +26,9 @@ pub use frame::{
     Frame, FrameDecodingError, FrameParseError, DERIVATION_VERSION_0, FRAME_OVERHEAD, MAX_FRAME_LEN,
 };
 
+mod iter;
+pub use iter::FrameIter;
+
 mod utils;
 pub use utils::{starts_with_2718_deposit, to_system_config, OpBlockConversionError};
 


### PR DESCRIPTION
### Description

Post-holocene, `kona-derive` performs [prunes](https://github.com/anton-rs/kona/blob/main/crates/derive/src/stages/frame_queue.rs#L62-L109) `Frame`s using **forwards**-invalidation. Once the `FrameQueue` stage in the pipeline pulls in encoded frame data from the previous stage, it decodes the data into individual frames and then once all decoded, it prunes invalid frames.

Instead of parsing all frames, we can construct an iterator over encoded `Frame` data, both encoding and pruning each frame individually as they are parsed from the raw, encoded data.

