### PR TITLE
feat(genesis): Arbitrary Support

### DIFF
--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -261,7 +261,7 @@ impl alloy_rlp::Decodable for OpDepositReceiptWithBloom {
     }
 }
 
-#[cfg(all(test, feature = "arbitrary"))]
+#[cfg(any(test, feature = "arbitrary"))]
 impl<'a, T> arbitrary::Arbitrary<'a> for OpDepositReceipt<T>
 where
     T: arbitrary::Arbitrary<'a>,
@@ -284,7 +284,7 @@ where
     }
 }
 
-#[cfg(all(test, feature = "arbitrary"))]
+#[cfg(any(test, feature = "arbitrary"))]
 impl<'a, T> arbitrary::Arbitrary<'a> for OpDepositReceiptWithBloom<T>
 where
     T: arbitrary::Arbitrary<'a>,

--- a/crates/genesis/Cargo.toml
+++ b/crates/genesis/Cargo.toml
@@ -21,14 +21,21 @@ alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
 
-# `serde` feature dependencies
+# `arbitrary` feature
+arbitrary = { workspace = true, features = ["derive"], optional = true }
+
+# `serde` feature
 serde = { workspace = true, optional = true }
 serde_repr = { workspace = true, optional = true }
 
 [dev-dependencies]
+alloy-primitives = { workspace = true, features = ["rand"] }
+arbitrary = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+rand.workspace = true
 
 [features]
 default = ["serde", "std"]
 std = []
+arbitrary = ["std", "dep:arbitrary", "alloy-consensus/arbitrary", "alloy-eips/arbitrary", "alloy-primitives/rand"]
 serde = ["dep:serde", "dep:serde_repr", "alloy-primitives/serde", "alloy-eips/serde", "alloy-consensus/serde"]

--- a/crates/genesis/src/addresses.rs
+++ b/crates/genesis/src/addresses.rs
@@ -4,6 +4,7 @@ use alloy_primitives::Address;
 
 /// The set of network-specific contracts for a given chain.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "PascalCase"))]
 pub struct AddressList {

--- a/crates/genesis/src/chain.rs
+++ b/crates/genesis/src/chain.rs
@@ -9,6 +9,7 @@ use alloy_primitives::Address;
 
 /// Level of integration with the superchain.
 #[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde_repr::Serialize_repr, serde_repr::Deserialize_repr))]
 #[repr(u8)]
 pub enum SuperchainLevel {
@@ -23,6 +24,7 @@ pub enum SuperchainLevel {
 
 /// AltDA configuration.
 #[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AltDAConfig {
     /// AltDA challenge address
@@ -35,6 +37,7 @@ pub struct AltDAConfig {
 
 /// Hardfork configuration.
 #[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HardForkConfiguration {
     /// Canyon hardfork activation time
@@ -65,6 +68,7 @@ pub struct HardForkConfiguration {
 /// [ccg]: https://github.com/ethereum-optimism/op-geth/blob/optimism/params/config.go#L342
 /// [ccr]: https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/superchain.go#L80
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChainConfig {
     /// Chain name (e.g. "Base")

--- a/crates/genesis/src/genesis.rs
+++ b/crates/genesis/src/genesis.rs
@@ -17,6 +17,22 @@ pub struct ChainGenesis {
     pub system_config: Option<SystemConfig>,
 }
 
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for ChainGenesis {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let system_config = Option::<SystemConfig>::arbitrary(u)?;
+        let l1_num_hash = BlockNumHash {
+            number: u64::arbitrary(u)?,
+            hash: alloy_primitives::B256::arbitrary(u)?,
+        };
+        let l2_num_hash = BlockNumHash {
+            number: u64::arbitrary(u)?,
+            hash: alloy_primitives::B256::arbitrary(u)?,
+        };
+        Ok(Self { l1: l1_num_hash, l2: l2_num_hash, l2_time: u.arbitrary()?, system_config })
+    }
+}
+
 #[cfg(test)]
 #[cfg(feature = "serde")]
 mod tests {

--- a/crates/genesis/src/params.rs
+++ b/crates/genesis/src/params.rs
@@ -64,6 +64,7 @@ pub const fn base_fee_params(chain_id: u64) -> OptimismBaseFeeParams {
 
 /// Optimism Base Fee Configuration
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OptimismBaseFeeParams {
     /// EIP 1559 Elasticity Parameter

--- a/crates/genesis/src/rollup.rs
+++ b/crates/genesis/src/rollup.rs
@@ -140,6 +140,44 @@ pub struct RollupConfig {
     pub da_challenge_address: Option<Address>,
 }
 
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for RollupConfig {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            genesis: ChainGenesis::arbitrary(u)?,
+            block_time: u.arbitrary()?,
+            max_sequencer_drift: u.arbitrary()?,
+            seq_window_size: u.arbitrary()?,
+            channel_timeout: u.arbitrary()?,
+            granite_channel_timeout: u.arbitrary()?,
+            l1_chain_id: u.arbitrary()?,
+            l2_chain_id: u.arbitrary()?,
+            base_fee_params: BaseFeeParams {
+                max_change_denominator: u.arbitrary()?,
+                elasticity_multiplier: u.arbitrary()?,
+            },
+            canyon_base_fee_params: BaseFeeParams {
+                max_change_denominator: u.arbitrary()?,
+                elasticity_multiplier: u.arbitrary()?,
+            },
+            regolith_time: Option::<u64>::arbitrary(u)?,
+            canyon_time: Option::<u64>::arbitrary(u)?,
+            delta_time: Option::<u64>::arbitrary(u)?,
+            ecotone_time: Option::<u64>::arbitrary(u)?,
+            fjord_time: Option::<u64>::arbitrary(u)?,
+            granite_time: Option::<u64>::arbitrary(u)?,
+            holocene_time: Option::<u64>::arbitrary(u)?,
+            batch_inbox_address: Address::arbitrary(u)?,
+            deposit_contract_address: Address::arbitrary(u)?,
+            l1_system_config_address: Address::arbitrary(u)?,
+            protocol_versions_address: Address::arbitrary(u)?,
+            superchain_config_address: Option::<Address>::arbitrary(u)?,
+            blobs_enabled_l1_timestamp: Option::<u64>::arbitrary(u)?,
+            da_challenge_address: Option::<Address>::arbitrary(u)?,
+        })
+    }
+}
+
 // Need to manually implement Default because [`BaseFeeParams`] has no Default impl.
 impl Default for RollupConfig {
     fn default() -> Self {
@@ -474,6 +512,17 @@ mod tests {
     use super::*;
     #[cfg(feature = "serde")]
     use alloy_primitives::U256;
+    use arbitrary::Arbitrary;
+    use rand::Rng;
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn arbitrary_rollup_config() {
+        let mut bytes = [0u8; 1024];
+        rand::thread_rng().fill(bytes.as_mut_slice());
+        let _: RollupConfig =
+            RollupConfig::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap();
+    }
 
     #[test]
     fn test_regolith_active() {

--- a/crates/genesis/src/system.rs
+++ b/crates/genesis/src/system.rs
@@ -14,6 +14,7 @@ pub const CONFIG_UPDATE_EVENT_VERSION_0: B256 = B256::ZERO;
 
 /// System configuration.
 #[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct SystemConfig {
@@ -573,6 +574,17 @@ mod test {
     use super::*;
     use alloc::vec;
     use alloy_primitives::{b256, hex, LogData, B256};
+    use arbitrary::Arbitrary;
+    use rand::Rng;
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn arbitrary_system_config() {
+        let mut bytes = [0u8; 1024];
+        rand::thread_rng().fill(bytes.as_mut_slice());
+        let _: SystemConfig =
+            SystemConfig::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap();
+    }
 
     #[test]
     #[cfg(feature = "serde")]


### PR DESCRIPTION
### Description

In [`kona`](https://github.com/anton-rs/kona), we'd like to test against arbitrary inputs for various points in the derivation pipeline. implementing arbitrary across op-alloy input types enables this.

This PR implements [`arbitrary::Arbitrary`](https://docs.rs/arbitrary/latest/arbitrary/trait.Arbitrary.html) across all `op-alloy-genesis` crate types.