### PR TITLE
fix: remove 4844 transaction type

### DIFF
--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -32,11 +32,6 @@ pub enum OpReceiptEnvelope<T = Log> {
     /// [EIP-1559]: https://eips.ethereum.org/EIPS/eip-1559
     #[cfg_attr(feature = "serde", serde(rename = "0x2", alias = "0x02"))]
     Eip1559(ReceiptWithBloom<T>),
-    /// Receipt envelope with type flag 2, containing a [EIP-4844] receipt.
-    ///
-    /// [EIP-4844]: https://eips.ethereum.org/EIPS/eip-4844
-    #[cfg_attr(feature = "serde", serde(rename = "0x3", alias = "0x03"))]
-    Eip4844(ReceiptWithBloom<T>),
     /// Receipt envelope with type flag 126, containing a [deposit] receipt.
     ///
     /// [deposit]: https://specs.optimism.io/protocol/deposits.html
@@ -51,7 +46,6 @@ impl<T> OpReceiptEnvelope<T> {
             Self::Legacy(_) => OpTxType::Legacy,
             Self::Eip2930(_) => OpTxType::Eip2930,
             Self::Eip1559(_) => OpTxType::Eip1559,
-            Self::Eip4844(_) => OpTxType::Eip4844,
             Self::Deposit(_) => OpTxType::Deposit,
         }
     }
@@ -82,7 +76,6 @@ impl<T> OpReceiptEnvelope<T> {
             Self::Legacy(t) => &t.logs_bloom,
             Self::Eip2930(t) => &t.logs_bloom,
             Self::Eip1559(t) => &t.logs_bloom,
-            Self::Eip4844(t) => &t.logs_bloom,
             Self::Deposit(t) => &t.logs_bloom,
         }
     }
@@ -117,7 +110,7 @@ impl<T> OpReceiptEnvelope<T> {
     /// receipt types may be added.
     pub const fn as_receipt(&self) -> Option<&Receipt<T>> {
         match self {
-            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) | Self::Eip4844(t) => {
+            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) => {
                 Some(&t.receipt)
             }
             Self::Deposit(t) => Some(&t.receipt.inner),
@@ -132,7 +125,6 @@ impl OpReceiptEnvelope {
             Self::Legacy(t) => t.length(),
             Self::Eip2930(t) => t.length(),
             Self::Eip1559(t) => t.length(),
-            Self::Eip4844(t) => t.length(),
             Self::Deposit(t) => t.length(),
         }
     }
@@ -203,7 +195,6 @@ impl Encodable2718 for OpReceiptEnvelope {
             Self::Legacy(_) => None,
             Self::Eip2930(_) => Some(OpTxType::Eip2930 as u8),
             Self::Eip1559(_) => Some(OpTxType::Eip1559 as u8),
-            Self::Eip4844(_) => Some(OpTxType::Eip4844 as u8),
             Self::Deposit(_) => Some(OpTxType::Deposit as u8),
         }
     }
@@ -219,7 +210,7 @@ impl Encodable2718 for OpReceiptEnvelope {
         }
         match self {
             Self::Deposit(t) => t.encode(out),
-            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) | Self::Eip4844(t) => {
+            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) => {
                 t.encode(out)
             }
         }
@@ -235,7 +226,6 @@ impl Decodable2718 for OpReceiptEnvelope {
             }
             OpTxType::Eip1559 => Ok(Self::Eip1559(Decodable::decode(buf)?)),
             OpTxType::Eip2930 => Ok(Self::Eip2930(Decodable::decode(buf)?)),
-            OpTxType::Eip4844 => Ok(Self::Eip4844(Decodable::decode(buf)?)),
             OpTxType::Deposit => Ok(Self::Deposit(Decodable::decode(buf)?)),
         }
     }
@@ -255,7 +245,6 @@ where
             0 => Ok(Self::Legacy(ReceiptWithBloom::<T>::arbitrary(u)?)),
             1 => Ok(Self::Eip2930(ReceiptWithBloom::<T>::arbitrary(u)?)),
             2 => Ok(Self::Eip1559(ReceiptWithBloom::<T>::arbitrary(u)?)),
-            3 => Ok(Self::Eip4844(ReceiptWithBloom::<T>::arbitrary(u)?)),
             _ => Ok(Self::Deposit(OpDepositReceiptWithBloom::<T>::arbitrary(u)?)),
         }
     }

--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -110,9 +110,7 @@ impl<T> OpReceiptEnvelope<T> {
     /// receipt types may be added.
     pub const fn as_receipt(&self) -> Option<&Receipt<T>> {
         match self {
-            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) => {
-                Some(&t.receipt)
-            }
+            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) => Some(&t.receipt),
             Self::Deposit(t) => Some(&t.receipt.inner),
         }
     }
@@ -210,9 +208,7 @@ impl Encodable2718 for OpReceiptEnvelope {
         }
         match self {
             Self::Deposit(t) => t.encode(out),
-            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) => {
-                t.encode(out)
-            }
+            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) => t.encode(out),
         }
     }
 }

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1,6 +1,4 @@
-use alloy_consensus::{
-    Signed, TxEip1559, TxEip2930, TxLegacy,
-};
+use alloy_consensus::{Signed, TxEip1559, TxEip2930, TxLegacy};
 use alloy_eips::eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718};
 use alloy_rlp::{Decodable, Encodable, Header};
 use derive_more::Display;
@@ -37,8 +35,7 @@ pub enum OpTxType {
 
 impl OpTxType {
     /// List of all variants.
-    pub const ALL: [Self; 4] =
-        [Self::Legacy, Self::Eip2930, Self::Eip1559, Self::Deposit];
+    pub const ALL: [Self; 4] = [Self::Legacy, Self::Eip2930, Self::Eip1559, Self::Deposit];
 }
 
 #[cfg(any(test, feature = "arbitrary"))]

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1,5 +1,5 @@
 use alloy_consensus::{
-    Signed, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip4844WithSidecar, TxLegacy,
+    Signed, TxEip1559, TxEip2930, TxLegacy,
 };
 use alloy_eips::eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718};
 use alloy_rlp::{Decodable, Encodable, Header};
@@ -30,9 +30,6 @@ pub enum OpTxType {
     /// EIP-1559 transaction type.
     #[display("eip1559")]
     Eip1559 = 2,
-    /// EIP-4844 transaction type.
-    #[display("eip4844")]
-    Eip4844 = 3,
     /// Optimism Deposit transaction type.
     #[display("deposit")]
     Deposit = 126,
@@ -40,8 +37,8 @@ pub enum OpTxType {
 
 impl OpTxType {
     /// List of all variants.
-    pub const ALL: [Self; 5] =
-        [Self::Legacy, Self::Eip2930, Self::Eip1559, Self::Eip4844, Self::Deposit];
+    pub const ALL: [Self; 4] =
+        [Self::Legacy, Self::Eip2930, Self::Eip1559, Self::Deposit];
 }
 
 #[cfg(any(test, feature = "arbitrary"))]
@@ -66,7 +63,6 @@ impl TryFrom<u8> for OpTxType {
             0 => Self::Legacy,
             1 => Self::Eip2930,
             2 => Self::Eip1559,
-            3 => Self::Eip4844,
             126 => Self::Deposit,
             _ => return Err(Eip2718Error::UnexpectedType(value)),
         })
@@ -98,15 +94,6 @@ pub enum OpTxEnvelope {
     /// A [`TxEip1559`] tagged with type 2.
     #[cfg_attr(feature = "serde", serde(rename = "0x2", alias = "0x02"))]
     Eip1559(Signed<TxEip1559>),
-    /// A TxEip4844 tagged with type 3.
-    /// An EIP-4844 transaction has two network representations:
-    /// 1 - The transaction itself, which is a regular RLP-encoded transaction and used to retrieve
-    /// historical transactions..
-    ///
-    /// 2 - The transaction with a sidecar, which is the form used to
-    /// send transactions to the network.
-    #[cfg_attr(feature = "serde", serde(rename = "0x3", alias = "0x03"))]
-    Eip4844(Signed<TxEip4844Variant>),
     /// A [`TxDeposit`] tagged with type 0x7E.
     #[cfg_attr(feature = "serde", serde(rename = "0x7E", alias = "0x7E"))]
     Deposit(TxDeposit),
@@ -127,30 +114,6 @@ impl From<Signed<TxEip2930>> for OpTxEnvelope {
 impl From<Signed<TxEip1559>> for OpTxEnvelope {
     fn from(v: Signed<TxEip1559>) -> Self {
         Self::Eip1559(v)
-    }
-}
-
-impl From<Signed<TxEip4844Variant>> for OpTxEnvelope {
-    fn from(v: Signed<TxEip4844Variant>) -> Self {
-        Self::Eip4844(v)
-    }
-}
-
-impl From<Signed<TxEip4844>> for OpTxEnvelope {
-    fn from(v: Signed<TxEip4844>) -> Self {
-        let (tx, signature, hash) = v.into_parts();
-        Self::Eip4844(Signed::new_unchecked(TxEip4844Variant::TxEip4844(tx), signature, hash))
-    }
-}
-
-impl From<Signed<TxEip4844WithSidecar>> for OpTxEnvelope {
-    fn from(v: Signed<TxEip4844WithSidecar>) -> Self {
-        let (tx, signature, hash) = v.into_parts();
-        Self::Eip4844(Signed::new_unchecked(
-            TxEip4844Variant::TxEip4844WithSidecar(tx),
-            signature,
-            hash,
-        ))
     }
 }
 
@@ -223,7 +186,6 @@ impl OpTxEnvelope {
             Self::Legacy(_) => OpTxType::Legacy,
             Self::Eip2930(_) => OpTxType::Eip2930,
             Self::Eip1559(_) => OpTxType::Eip1559,
-            Self::Eip4844(_) => OpTxType::Eip4844,
             Self::Deposit(_) => OpTxType::Deposit,
         }
     }
@@ -240,22 +202,6 @@ impl OpTxEnvelope {
                 let payload_length = t.tx().fields_len() + t.signature().rlp_vrs_len();
                 Header { list: true, payload_length }.length() + payload_length
             }
-            Self::Eip4844(t) => match t.tx() {
-                TxEip4844Variant::TxEip4844(tx) => {
-                    let payload_length = tx.fields_len() + t.signature().rlp_vrs_len();
-                    Header { list: true, payload_length }.length() + payload_length
-                }
-                TxEip4844Variant::TxEip4844WithSidecar(tx) => {
-                    let inner_payload_length = tx.tx().fields_len() + t.signature().rlp_vrs_len();
-                    let inner_header = Header { list: true, payload_length: inner_payload_length };
-
-                    let outer_payload_length =
-                        inner_header.length() + inner_payload_length + tx.sidecar.fields_len();
-                    let outer_header = Header { list: true, payload_length: outer_payload_length };
-
-                    outer_header.length() + outer_payload_length
-                }
-            },
             Self::Deposit(t) => {
                 let payload_length = t.fields_len();
                 Header { list: true, payload_length }.length() + payload_length
@@ -309,7 +255,6 @@ impl Decodable2718 for OpTxEnvelope {
         match ty.try_into().map_err(|_| Eip2718Error::UnexpectedType(ty))? {
             OpTxType::Eip2930 => Ok(Self::Eip2930(TxEip2930::decode_signed_fields(buf)?)),
             OpTxType::Eip1559 => Ok(Self::Eip1559(TxEip1559::decode_signed_fields(buf)?)),
-            OpTxType::Eip4844 => Ok(Self::Eip4844(TxEip4844Variant::decode_signed_fields(buf)?)),
             OpTxType::Deposit => Ok(Self::Deposit(TxDeposit::decode(buf)?)),
             OpTxType::Legacy => {
                 Err(alloy_rlp::Error::Custom("type-0 eip2718 transactions are not supported")
@@ -329,7 +274,6 @@ impl Encodable2718 for OpTxEnvelope {
             Self::Legacy(_) => None,
             Self::Eip2930(_) => Some(OpTxType::Eip2930 as u8),
             Self::Eip1559(_) => Some(OpTxType::Eip1559 as u8),
-            Self::Eip4844(_) => Some(OpTxType::Eip4844 as u8),
             Self::Deposit(_) => Some(OpTxType::Deposit as u8),
         }
     }
@@ -346,9 +290,6 @@ impl Encodable2718 for OpTxEnvelope {
                 tx.tx().encode_with_signature(tx.signature(), out, false);
             }
             Self::Eip1559(tx) => {
-                tx.tx().encode_with_signature(tx.signature(), out, false);
-            }
-            Self::Eip4844(tx) => {
                 tx.tx().encode_with_signature(tx.signature(), out, false);
             }
             Self::Deposit(tx) => {

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -1,5 +1,5 @@
 use crate::{OpTxEnvelope, OpTxType, TxDeposit};
-use alloy_consensus::{Transaction, TxEip1559, TxEip2930, TxEip4844Variant, TxLegacy};
+use alloy_consensus::{Transaction, TxEip1559, TxEip2930, TxLegacy};
 use alloy_eips::eip2930::AccessList;
 use alloy_primitives::TxKind;
 
@@ -25,9 +25,6 @@ pub enum OpTypedTransaction {
     /// EIP-1559 transaction
     #[cfg_attr(feature = "serde", serde(rename = "0x02", alias = "0x2"))]
     Eip1559(TxEip1559),
-    /// EIP-4844 transaction
-    #[cfg_attr(feature = "serde", serde(rename = "0x03", alias = "0x3"))]
-    Eip4844(TxEip4844Variant),
     /// Optimism deposit transaction
     #[cfg_attr(feature = "serde", serde(rename = "0x7E", alias = "0x7E"))]
     Deposit(TxDeposit),
@@ -51,12 +48,6 @@ impl From<TxEip1559> for OpTypedTransaction {
     }
 }
 
-impl From<TxEip4844Variant> for OpTypedTransaction {
-    fn from(tx: TxEip4844Variant) -> Self {
-        Self::Eip4844(tx)
-    }
-}
-
 impl From<TxDeposit> for OpTypedTransaction {
     fn from(tx: TxDeposit) -> Self {
         Self::Deposit(tx)
@@ -69,7 +60,6 @@ impl From<OpTxEnvelope> for OpTypedTransaction {
             OpTxEnvelope::Legacy(tx) => Self::Legacy(tx.strip_signature()),
             OpTxEnvelope::Eip2930(tx) => Self::Eip2930(tx.strip_signature()),
             OpTxEnvelope::Eip1559(tx) => Self::Eip1559(tx.strip_signature()),
-            OpTxEnvelope::Eip4844(tx) => Self::Eip4844(tx.strip_signature()),
             OpTxEnvelope::Deposit(tx) => Self::Deposit(tx),
         }
     }
@@ -82,7 +72,6 @@ impl OpTypedTransaction {
             Self::Legacy(_) => OpTxType::Legacy,
             Self::Eip2930(_) => OpTxType::Eip2930,
             Self::Eip1559(_) => OpTxType::Eip1559,
-            Self::Eip4844(_) => OpTxType::Eip4844,
             Self::Deposit(_) => OpTxType::Deposit,
         }
     }
@@ -111,14 +100,6 @@ impl OpTypedTransaction {
         }
     }
 
-    /// Return the inner EIP-4844 transaction if it exists.
-    pub const fn eip4844(&self) -> Option<&TxEip4844Variant> {
-        match self {
-            Self::Eip4844(tx) => Some(tx),
-            _ => None,
-        }
-    }
-
     /// Return the inner deposit transaction if it exists.
     pub const fn deposit(&self) -> Option<&TxDeposit> {
         match self {
@@ -134,7 +115,6 @@ impl Transaction for OpTypedTransaction {
             Self::Legacy(tx) => tx.chain_id(),
             Self::Eip2930(tx) => tx.chain_id(),
             Self::Eip1559(tx) => tx.chain_id(),
-            Self::Eip4844(tx) => tx.chain_id(),
             Self::Deposit(tx) => tx.chain_id(),
         }
     }
@@ -144,7 +124,6 @@ impl Transaction for OpTypedTransaction {
             Self::Legacy(tx) => tx.nonce(),
             Self::Eip2930(tx) => tx.nonce(),
             Self::Eip1559(tx) => tx.nonce(),
-            Self::Eip4844(tx) => tx.nonce(),
             Self::Deposit(tx) => tx.nonce(),
         }
     }
@@ -154,7 +133,6 @@ impl Transaction for OpTypedTransaction {
             Self::Legacy(tx) => tx.gas_limit(),
             Self::Eip2930(tx) => tx.gas_limit(),
             Self::Eip1559(tx) => tx.gas_limit(),
-            Self::Eip4844(tx) => tx.gas_limit(),
             Self::Deposit(tx) => tx.gas_limit(),
         }
     }
@@ -164,7 +142,6 @@ impl Transaction for OpTypedTransaction {
             Self::Legacy(tx) => tx.gas_price(),
             Self::Eip2930(tx) => tx.gas_price(),
             Self::Eip1559(tx) => tx.gas_price(),
-            Self::Eip4844(tx) => tx.gas_price(),
             Self::Deposit(tx) => tx.gas_price(),
         }
     }
@@ -174,7 +151,6 @@ impl Transaction for OpTypedTransaction {
             Self::Legacy(tx) => tx.max_fee_per_gas(),
             Self::Eip2930(tx) => tx.max_fee_per_gas(),
             Self::Eip1559(tx) => tx.max_fee_per_gas(),
-            Self::Eip4844(tx) => tx.max_fee_per_gas(),
             Self::Deposit(tx) => tx.max_fee_per_gas(),
         }
     }
@@ -184,7 +160,6 @@ impl Transaction for OpTypedTransaction {
             Self::Legacy(tx) => tx.max_priority_fee_per_gas(),
             Self::Eip2930(tx) => tx.max_priority_fee_per_gas(),
             Self::Eip1559(tx) => tx.max_priority_fee_per_gas(),
-            Self::Eip4844(tx) => tx.max_priority_fee_per_gas(),
             Self::Deposit(tx) => tx.max_priority_fee_per_gas(),
         }
     }
@@ -194,7 +169,6 @@ impl Transaction for OpTypedTransaction {
             Self::Legacy(tx) => tx.max_fee_per_blob_gas(),
             Self::Eip2930(tx) => tx.max_fee_per_blob_gas(),
             Self::Eip1559(tx) => tx.max_fee_per_blob_gas(),
-            Self::Eip4844(tx) => tx.max_fee_per_blob_gas(),
             Self::Deposit(tx) => tx.max_fee_per_blob_gas(),
         }
     }
@@ -204,7 +178,6 @@ impl Transaction for OpTypedTransaction {
             Self::Legacy(tx) => tx.priority_fee_or_price(),
             Self::Eip2930(tx) => tx.priority_fee_or_price(),
             Self::Eip1559(tx) => tx.priority_fee_or_price(),
-            Self::Eip4844(tx) => tx.priority_fee_or_price(),
             Self::Deposit(tx) => tx.priority_fee_or_price(),
         }
     }
@@ -214,7 +187,6 @@ impl Transaction for OpTypedTransaction {
             Self::Legacy(tx) => tx.to(),
             Self::Eip2930(tx) => tx.to(),
             Self::Eip1559(tx) => tx.to(),
-            Self::Eip4844(tx) => tx.to(),
             Self::Deposit(tx) => tx.to(),
         }
     }
@@ -224,7 +196,6 @@ impl Transaction for OpTypedTransaction {
             Self::Legacy(tx) => tx.value(),
             Self::Eip2930(tx) => tx.value(),
             Self::Eip1559(tx) => tx.value(),
-            Self::Eip4844(tx) => tx.value(),
             Self::Deposit(tx) => tx.value(),
         }
     }
@@ -234,7 +205,6 @@ impl Transaction for OpTypedTransaction {
             Self::Legacy(tx) => tx.input(),
             Self::Eip2930(tx) => tx.input(),
             Self::Eip1559(tx) => tx.input(),
-            Self::Eip4844(tx) => tx.input(),
             Self::Deposit(tx) => tx.input(),
         }
     }
@@ -244,7 +214,6 @@ impl Transaction for OpTypedTransaction {
             Self::Legacy(_) => OpTxType::Legacy as u8,
             Self::Eip2930(_) => OpTxType::Eip2930 as u8,
             Self::Eip1559(_) => OpTxType::Eip1559 as u8,
-            Self::Eip4844(_) => OpTxType::Eip4844 as u8,
             Self::Deposit(_) => OpTxType::Deposit as u8,
         }
     }
@@ -254,7 +223,6 @@ impl Transaction for OpTypedTransaction {
             Self::Legacy(tx) => tx.access_list(),
             Self::Eip2930(tx) => tx.access_list(),
             Self::Eip1559(tx) => tx.access_list(),
-            Self::Eip4844(tx) => tx.access_list(),
             Self::Deposit(tx) => tx.access_list(),
         }
     }
@@ -264,7 +232,6 @@ impl Transaction for OpTypedTransaction {
             Self::Legacy(tx) => tx.blob_versioned_hashes(),
             Self::Eip2930(tx) => tx.blob_versioned_hashes(),
             Self::Eip1559(tx) => tx.blob_versioned_hashes(),
-            Self::Eip4844(tx) => tx.blob_versioned_hashes(),
             Self::Deposit(tx) => tx.blob_versioned_hashes(),
         }
     }
@@ -274,7 +241,6 @@ impl Transaction for OpTypedTransaction {
             Self::Legacy(tx) => tx.authorization_list(),
             Self::Eip2930(tx) => tx.authorization_list(),
             Self::Eip1559(tx) => tx.authorization_list(),
-            Self::Eip4844(tx) => tx.authorization_list(),
             Self::Deposit(tx) => tx.authorization_list(),
         }
     }

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -10,7 +10,6 @@ use alloy_primitives::TxKind;
 /// 1. Legacy (pre-EIP2718) [`TxLegacy`]
 /// 2. EIP2930 (state access lists) [`TxEip2930`]
 /// 3. EIP1559 [`TxEip1559`]
-/// 4. EIP4844 [`TxEip4844Variant`]
 /// 4. Deposit [`TxDeposit`]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

EIP-4844 transactions are not supported on OP stack networks https://specs.optimism.io/protocol/exec-engine.html#ecotone-disable-blob-transactions

## Solution

Removes 4844 variants from transaction and receipt consensus types.

We still have those on RPC types, should we introduce op-specific RPC types? it would also unblock https://github.com/alloy-rs/op-alloy/pull/121

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
