### PR TITLE
fix(rpc-types): Op Prefix Naming Convention

### DIFF
--- a/crates/rpc-types/src/genesis.rs
+++ b/crates/rpc-types/src/genesis.rs
@@ -6,14 +6,14 @@ use serde::de::Error;
 /// Container type for all Optimism specific fields in a genesis file.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct OptimismChainInfo {
+pub struct OpChainInfo {
     /// Genesis information
     pub genesis_info: Option<OptimismGenesisInfo>,
     /// Base fee information
     pub base_fee_info: Option<OptimismBaseFeeInfo>,
 }
 
-impl OptimismChainInfo {
+impl OpChainInfo {
     /// Extracts the Optimism specific fields from a genesis file. These fields are expected to be
     /// contained in the `genesis.config` under `extra_fields` property.
     pub fn extract_from(others: &OtherFields) -> Option<Self> {
@@ -21,7 +21,7 @@ impl OptimismChainInfo {
     }
 }
 
-impl TryFrom<&OtherFields> for OptimismChainInfo {
+impl TryFrom<&OtherFields> for OpChainInfo {
     type Error = serde_json::Error;
 
     fn try_from(others: &OtherFields) -> Result<Self, Self::Error> {
@@ -172,11 +172,11 @@ mod tests {
         "#;
 
         let others: OtherFields = serde_json::from_str(chain_info).unwrap();
-        let chain_info = OptimismChainInfo::extract_from(&others).unwrap();
+        let chain_info = OpChainInfo::extract_from(&others).unwrap();
 
         assert_eq!(
             chain_info,
-            OptimismChainInfo {
+            OpChainInfo {
                 genesis_info: Some(OptimismGenesisInfo {
                     bedrock_block: Some(10),
                     regolith_time: Some(12),
@@ -194,11 +194,11 @@ mod tests {
             }
         );
 
-        let chain_info = OptimismChainInfo::try_from(&others).unwrap();
+        let chain_info = OpChainInfo::try_from(&others).unwrap();
 
         assert_eq!(
             chain_info,
-            OptimismChainInfo {
+            OpChainInfo {
                 genesis_info: Some(OptimismGenesisInfo {
                     bedrock_block: Some(10),
                     regolith_time: Some(12),
@@ -232,11 +232,11 @@ mod tests {
         "#;
 
         let others: OtherFields = serde_json::from_str(chain_info).unwrap();
-        let chain_info = OptimismChainInfo::extract_from(&others).unwrap();
+        let chain_info = OpChainInfo::extract_from(&others).unwrap();
 
         assert_eq!(
             chain_info,
-            OptimismChainInfo {
+            OpChainInfo {
                 genesis_info: Some(OptimismGenesisInfo {
                     bedrock_block: Some(10),
                     regolith_time: Some(12),

--- a/crates/rpc-types/src/lib.rs
+++ b/crates/rpc-types/src/lib.rs
@@ -18,5 +18,5 @@ pub mod safe_head;
 pub mod sync;
 pub mod transaction;
 
-pub use receipt::{OpTransactionReceipt, OptimismTransactionReceiptFields};
-pub use transaction::{OptimismTransactionFields, Transaction};
+pub use receipt::{OpTransactionReceipt, OpTransactionReceiptFields};
+pub use transaction::{OpTransactionFields, Transaction};

--- a/crates/rpc-types/src/receipt.rs
+++ b/crates/rpc-types/src/receipt.rs
@@ -83,7 +83,7 @@ impl alloy_network_primitives::ReceiptResponse for OpTransactionReceipt {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[doc(alias = "OptimismTxReceiptFields")]
-pub struct OptimismTransactionReceiptFields {
+pub struct OpTransactionReceiptFields {
     /// L1 block info.
     #[serde(flatten)]
     pub l1_block_info: L1BlockInfo,
@@ -130,15 +130,15 @@ mod l1_fee_scalar_serde {
     }
 }
 
-impl From<OptimismTransactionReceiptFields> for OtherFields {
-    fn from(value: OptimismTransactionReceiptFields) -> Self {
+impl From<OpTransactionReceiptFields> for OtherFields {
+    fn from(value: OpTransactionReceiptFields) -> Self {
         serde_json::to_value(value).unwrap().try_into().unwrap()
     }
 }
 
 /// L1 block info extracted from inout of first transaction in every block.
 ///
-/// The subset of [`OptimismTransactionReceiptFields`], that encompasses L1 block
+/// The subset of [`OpTransactionReceiptFields`], that encompasses L1 block
 /// info:
 /// <https://github.com/ethereum-optimism/op-geth/blob/f2e69450c6eec9c35d56af91389a1c47737206ca/core/types/receipt.go#L87-L87>
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -224,7 +224,7 @@ mod tests {
 
     #[test]
     fn serialize_empty_optimism_transaction_receipt_fields_struct() {
-        let op_fields = OptimismTransactionReceiptFields::default();
+        let op_fields = OpTransactionReceiptFields::default();
 
         let json = serde_json::to_value(op_fields).unwrap();
         assert_eq!(json, json!({}));
@@ -232,7 +232,7 @@ mod tests {
 
     #[test]
     fn serialize_l1_fee_scalar() {
-        let op_fields = OptimismTransactionReceiptFields {
+        let op_fields = OpTransactionReceiptFields {
             l1_block_info: L1BlockInfo { l1_fee_scalar: Some(0.678), ..Default::default() },
             ..Default::default()
         };
@@ -248,19 +248,19 @@ mod tests {
             "l1FeeScalar": "0.678"
         });
 
-        let op_fields: OptimismTransactionReceiptFields = serde_json::from_value(json).unwrap();
+        let op_fields: OpTransactionReceiptFields = serde_json::from_value(json).unwrap();
         assert_eq!(op_fields.l1_block_info.l1_fee_scalar, Some(0.678f64));
 
         let json = json!({
             "l1FeeScalar": Value::Null
         });
 
-        let op_fields: OptimismTransactionReceiptFields = serde_json::from_value(json).unwrap();
+        let op_fields: OpTransactionReceiptFields = serde_json::from_value(json).unwrap();
         assert_eq!(op_fields.l1_block_info.l1_fee_scalar, None);
 
         let json = json!({});
 
-        let op_fields: OptimismTransactionReceiptFields = serde_json::from_value(json).unwrap();
+        let op_fields: OpTransactionReceiptFields = serde_json::from_value(json).unwrap();
         assert_eq!(op_fields.l1_block_info.l1_fee_scalar, None);
     }
 }

--- a/crates/rpc-types/src/transaction.rs
+++ b/crates/rpc-types/src/transaction.rs
@@ -127,7 +127,7 @@ impl alloy_network_primitives::TransactionResponse for Transaction {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[doc(alias = "OptimismTxFields")]
 #[serde(rename_all = "camelCase")]
-pub struct OptimismTransactionFields {
+pub struct OpTransactionFields {
     /// The ETH value to mint on L2
     #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub mint: Option<u128>,
@@ -143,8 +143,8 @@ pub struct OptimismTransactionFields {
     pub deposit_receipt_version: Option<u64>,
 }
 
-impl From<OptimismTransactionFields> for OtherFields {
-    fn from(value: OptimismTransactionFields) -> Self {
+impl From<OpTransactionFields> for OtherFields {
+    fn from(value: OpTransactionFields) -> Self {
         serde_json::to_value(value).unwrap().try_into().unwrap()
     }
 }


### PR DESCRIPTION
### Description

Modifies OP Stack types in `rpc-types` to use the `Op` prefix as opposed to `Optimism` prefix.

### Metadata

Makes progress on #150 