### PR TITLE
fix(rpc-types-engine): Op Prefix Naming Convention

### DIFF
--- a/crates/provider/src/ext/engine.rs
+++ b/crates/provider/src/ext/engine.rs
@@ -8,8 +8,8 @@ use alloy_rpc_types_engine::{
 };
 use alloy_transport::{Transport, TransportResult};
 use op_alloy_rpc_types_engine::{
-    OptimismExecutionPayloadEnvelopeV3, OptimismExecutionPayloadEnvelopeV4,
-    OptimismPayloadAttributes, ProtocolVersion, SuperchainSignal,
+    OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpPayloadAttributes,
+    ProtocolVersion, SuperchainSignal,
 };
 
 /// Extension trait that gives access to Optimism engine API RPC methods.
@@ -71,7 +71,7 @@ pub trait OpEngineApi<N, T>: Send + Sync {
     async fn fork_choice_updated_v2(
         &self,
         fork_choice_state: ForkchoiceState,
-        payload_attributes: Option<OptimismPayloadAttributes>,
+        payload_attributes: Option<OpPayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated>;
 
     /// Updates the execution layer client with the given fork choice, as specified for the Cancun
@@ -87,7 +87,7 @@ pub trait OpEngineApi<N, T>: Send + Sync {
     async fn fork_choice_updated_v3(
         &self,
         fork_choice_state: ForkchoiceState,
-        payload_attributes: Option<OptimismPayloadAttributes>,
+        payload_attributes: Option<OpPayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated>;
 
     /// Retrieves an execution payload from a previously started build process, as specified for the
@@ -113,11 +113,11 @@ pub trait OpEngineApi<N, T>: Send + Sync {
     /// > Provider software MAY stop the corresponding build process after serving this call.
     ///
     /// OP modifications:
-    /// - the response type is extended to [`OptimismExecutionPayloadEnvelopeV3`].
+    /// - the response type is extended to [`OpExecutionPayloadEnvelopeV3`].
     async fn get_payload_v3(
         &self,
         payload_id: PayloadId,
-    ) -> TransportResult<OptimismExecutionPayloadEnvelopeV3>;
+    ) -> TransportResult<OpExecutionPayloadEnvelopeV3>;
 
     /// Returns the most recent version of the payload that is available in the corresponding
     /// payload build process at the time of receiving this call.
@@ -128,11 +128,11 @@ pub trait OpEngineApi<N, T>: Send + Sync {
     /// > Provider software MAY stop the corresponding build process after serving this call.
     ///
     /// OP modifications:
-    /// - the response type is extended to [`OptimismExecutionPayloadEnvelopeV4`].
+    /// - the response type is extended to [`OpExecutionPayloadEnvelopeV4`].
     async fn get_payload_v4(
         &self,
         payload_id: PayloadId,
-    ) -> TransportResult<OptimismExecutionPayloadEnvelopeV4>;
+    ) -> TransportResult<OpExecutionPayloadEnvelopeV4>;
 
     /// Returns the execution payload bodies by the given hash.
     ///
@@ -232,7 +232,7 @@ where
     async fn fork_choice_updated_v2(
         &self,
         fork_choice_state: ForkchoiceState,
-        payload_attributes: Option<OptimismPayloadAttributes>,
+        payload_attributes: Option<OpPayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated> {
         self.client()
             .request("engine_forkchoiceUpdatedV2", (fork_choice_state, payload_attributes))
@@ -242,7 +242,7 @@ where
     async fn fork_choice_updated_v3(
         &self,
         fork_choice_state: ForkchoiceState,
-        payload_attributes: Option<OptimismPayloadAttributes>,
+        payload_attributes: Option<OpPayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated> {
         self.client()
             .request("engine_forkchoiceUpdatedV3", (fork_choice_state, payload_attributes))
@@ -259,14 +259,14 @@ where
     async fn get_payload_v3(
         &self,
         payload_id: PayloadId,
-    ) -> TransportResult<OptimismExecutionPayloadEnvelopeV3> {
+    ) -> TransportResult<OpExecutionPayloadEnvelopeV3> {
         self.client().request("engine_getPayloadV3", (payload_id,)).await
     }
 
     async fn get_payload_v4(
         &self,
         payload_id: PayloadId,
-    ) -> TransportResult<OptimismExecutionPayloadEnvelopeV4> {
+    ) -> TransportResult<OpExecutionPayloadEnvelopeV4> {
         self.client().request("engine_getPayloadV4", (payload_id,)).await
     }
 

--- a/crates/rpc-types-engine/src/attributes.rs
+++ b/crates/rpc-types-engine/src/attributes.rs
@@ -9,7 +9,7 @@ use op_alloy_protocol::L2BlockInfo;
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct OptimismPayloadAttributes {
+pub struct OpPayloadAttributes {
     /// The payload attributes
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub payload_attributes: PayloadAttributes,
@@ -36,19 +36,19 @@ pub struct OptimismPayloadAttributes {
 /// Optimism Payload Attributes with parent block reference.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct OptimismAttributesWithParent {
+pub struct OpAttributesWithParent {
     /// The payload attributes.
-    pub attributes: OptimismPayloadAttributes,
+    pub attributes: OpPayloadAttributes,
     /// The parent block reference.
     pub parent: L2BlockInfo,
     /// Whether the current batch is the last in its span.
     pub is_last_in_span: bool,
 }
 
-impl OptimismAttributesWithParent {
-    /// Create a new [OptimismAttributesWithParent] instance.
+impl OpAttributesWithParent {
+    /// Create a new [OpAttributesWithParent] instance.
     pub const fn new(
-        attributes: OptimismPayloadAttributes,
+        attributes: OpPayloadAttributes,
         parent: L2BlockInfo,
         is_last_in_span: bool,
     ) -> Self {
@@ -56,7 +56,7 @@ impl OptimismAttributesWithParent {
     }
 
     /// Returns the payload attributes.
-    pub const fn attributes(&self) -> &OptimismPayloadAttributes {
+    pub const fn attributes(&self) -> &OpPayloadAttributes {
         &self.attributes
     }
 
@@ -79,7 +79,7 @@ mod test {
 
     #[test]
     fn test_serde_roundtrip_attributes_pre_holocene() {
-        let attributes = OptimismPayloadAttributes {
+        let attributes = OpPayloadAttributes {
             payload_attributes: PayloadAttributes {
                 timestamp: 0x1337,
                 prev_randao: B256::ZERO,
@@ -94,14 +94,14 @@ mod test {
         };
 
         let ser = serde_json::to_string(&attributes).unwrap();
-        let de: OptimismPayloadAttributes = serde_json::from_str(&ser).unwrap();
+        let de: OpPayloadAttributes = serde_json::from_str(&ser).unwrap();
 
         assert_eq!(attributes, de);
     }
 
     #[test]
     fn test_serde_roundtrip_attributes_post_holocene() {
-        let attributes = OptimismPayloadAttributes {
+        let attributes = OpPayloadAttributes {
             payload_attributes: PayloadAttributes {
                 timestamp: 0x1337,
                 prev_randao: B256::ZERO,
@@ -116,7 +116,7 @@ mod test {
         };
 
         let ser = serde_json::to_string(&attributes).unwrap();
-        let de: OptimismPayloadAttributes = serde_json::from_str(&ser).unwrap();
+        let de: OpPayloadAttributes = serde_json::from_str(&ser).unwrap();
 
         assert_eq!(attributes, de);
     }

--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -10,13 +10,13 @@
 extern crate alloc;
 
 mod attributes;
-pub use attributes::{OptimismAttributesWithParent, OptimismPayloadAttributes};
+pub use attributes::{OpAttributesWithParent, OpPayloadAttributes};
 
 mod payload_v3;
-pub use payload_v3::OptimismExecutionPayloadEnvelopeV3;
+pub use payload_v3::OpExecutionPayloadEnvelopeV3;
 
 mod payload_v4;
-pub use payload_v4::OptimismExecutionPayloadEnvelopeV4;
+pub use payload_v4::OpExecutionPayloadEnvelopeV4;
 
 mod superchain;
 pub use superchain::{

--- a/crates/rpc-types-engine/src/payload_v3.rs
+++ b/crates/rpc-types-engine/src/payload_v3.rs
@@ -11,7 +11,7 @@ use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV3};
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct OptimismExecutionPayloadEnvelopeV3 {
+pub struct OpExecutionPayloadEnvelopeV3 {
     /// Execution payload V3
     pub execution_payload: ExecutionPayloadV3,
     /// The expected value to be received by the feeRecipient in wei
@@ -35,7 +35,7 @@ mod tests {
         // pulled from a geth response getPayloadV3 in hive tests, modified to add a mock parent
         // beacon block root.
         let response = r#"{"executionPayload":{"parentHash":"0xe927a1448525fb5d32cb50ee1408461a945ba6c39bd5cf5621407d500ecc8de9","feeRecipient":"0x0000000000000000000000000000000000000000","stateRoot":"0x10f8a0830000e8edef6d00cc727ff833f064b1950afd591ae41357f97e543119","receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","prevRandao":"0xe0d8b4521a7da1582a713244ffb6a86aa1726932087386e2dc7973f43fc6cb24","blockNumber":"0x1","gasLimit":"0x2ffbd2","gasUsed":"0x0","timestamp":"0x1235","extraData":"0xd883010d00846765746888676f312e32312e30856c696e7578","baseFeePerGas":"0x342770c0","blockHash":"0x44d0fa5f2f73a938ebb96a2a21679eb8dea3e7b7dd8fd9f35aa756dda8bf0a8a","transactions":[],"withdrawals":[],"blobGasUsed":"0x0","excessBlobGas":"0x0"},"blockValue":"0x0","blobsBundle":{"commitments":[],"proofs":[],"blobs":[]},"shouldOverrideBuilder":false,"parentBeaconBlockRoot":"0xdead00000000000000000000000000000000000000000000000000000000beef"}"#;
-        let envelope: OptimismExecutionPayloadEnvelopeV3 = serde_json::from_str(response).unwrap();
+        let envelope: OpExecutionPayloadEnvelopeV3 = serde_json::from_str(response).unwrap();
         assert_eq!(serde_json::to_string(&envelope).unwrap(), response);
     }
 }

--- a/crates/rpc-types-engine/src/payload_v4.rs
+++ b/crates/rpc-types-engine/src/payload_v4.rs
@@ -11,7 +11,7 @@ use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV4};
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct OptimismExecutionPayloadEnvelopeV4 {
+pub struct OpExecutionPayloadEnvelopeV4 {
     /// Execution payload V4
     pub execution_payload: ExecutionPayloadV4,
     /// The expected value to be received by the feeRecipient in wei
@@ -35,7 +35,7 @@ mod tests {
         // modified execution payload envelope v3 with empty deposit, withdrawal, and consolidation
         // requests.
         let response = r#"{"executionPayload":{"parentHash":"0xe927a1448525fb5d32cb50ee1408461a945ba6c39bd5cf5621407d500ecc8de9","feeRecipient":"0x0000000000000000000000000000000000000000","stateRoot":"0x10f8a0830000e8edef6d00cc727ff833f064b1950afd591ae41357f97e543119","receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","prevRandao":"0xe0d8b4521a7da1582a713244ffb6a86aa1726932087386e2dc7973f43fc6cb24","blockNumber":"0x1","gasLimit":"0x2ffbd2","gasUsed":"0x0","timestamp":"0x1235","extraData":"0xd883010d00846765746888676f312e32312e30856c696e7578","baseFeePerGas":"0x342770c0","blockHash":"0x44d0fa5f2f73a938ebb96a2a21679eb8dea3e7b7dd8fd9f35aa756dda8bf0a8a","transactions":[],"withdrawals":[],"blobGasUsed":"0x0","excessBlobGas":"0x0","depositRequests":[],"withdrawalRequests":[],"consolidationRequests":[]},"blockValue":"0x0","blobsBundle":{"commitments":[],"proofs":[],"blobs":[]},"shouldOverrideBuilder":false,"parentBeaconBlockRoot":"0xdead00000000000000000000000000000000000000000000000000000000beef"}"#;
-        let envelope: OptimismExecutionPayloadEnvelopeV4 = serde_json::from_str(response).unwrap();
+        let envelope: OpExecutionPayloadEnvelopeV4 = serde_json::from_str(response).unwrap();
         assert_eq!(serde_json::to_string(&envelope).unwrap(), response);
     }
 }


### PR DESCRIPTION
### Description

Modifies OP Stack types in `rpc-types-engine` to use the `Op` prefix as opposed to `Optimism` prefix.

### Metadata

Makes progress on #150 