### PR TITLE
feat: add signature function to TxDeposit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
           cache-on-failure: true
       - run: cargo +stable clippy --workspace --all-targets --all-features
         env:
-          RUSTFLAGS: -Dwarnings
+          RUSTFLAGS: -D warnings
 
   docs:
     runs-on: ubuntu-latest

--- a/crates/consensus/src/transaction/deposit.rs
+++ b/crates/consensus/src/transaction/deposit.rs
@@ -1,7 +1,7 @@
 use super::OpTxType;
 use alloy_consensus::Transaction;
 use alloy_eips::eip2930::AccessList;
-use alloy_primitives::{Address, Bytes, ChainId, TxKind, B256, U256};
+use alloy_primitives::{Address, Bytes, ChainId, Parity, Signature, TxKind, B256, U256};
 use alloy_rlp::{
     Buf, BufMut, Decodable, Encodable, Error as DecodeError, Header, EMPTY_STRING_CODE,
 };
@@ -151,6 +151,12 @@ impl TxDeposit {
         } else {
             inner_payload_length
         }
+    }
+
+    /// Returns the signature for the optimism deposit transactions, which don't include a
+    /// signature.
+    pub fn signature() -> Signature {
+        Signature::new(U256::ZERO, U256::ZERO, Parity::Parity(false))
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
`optimism_deposit_tx_signature` function in `reth`  should be moved to `op-alloy` as part of an [issue](https://github.com/paradigmxyz/reth/issues/11781).

https://github.com/paradigmxyz/reth/issues/11781

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
An associated function `signature` is added to the `TxDeposit` struct.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
