### PR TITLE
chore: bump alloy and remove `OpExecutionPayloadV4`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,18 +47,18 @@ alloy-rlp = { version = "0.3", default-features = false }
 alloy-primitives = { version = "0.8", default-features = false }
 alloy-sol-types = { version = "0.8", default-features = false }
 
-alloy = { version = "0.4.2" }
-alloy-consensus = { version = "0.4.2", default-features = false }
-alloy-network = { version = "0.4.2", default-features = false }
-alloy-network-primitives = { version = "0.4.2", default-features = false }
-alloy-rpc-types = { version = "0.4.2" }
-alloy-rpc-types-engine = { version = "0.4.2", default-features = false }
-alloy-rpc-types-eth = { version = "0.4.2", default-features = false }
-alloy-eips = { version = "0.4.2", default-features = false }
-alloy-serde = { version = "0.4.2", default-features = false }
-alloy-signer = { version = "0.4.2", default-features = false }
-alloy-provider = { version = "0.4.2", default-features = false }
-alloy-transport = { version = "0.4.2", default-features = false }
+alloy = { version = "0.5.0" }
+alloy-consensus = { version = "0.5.0", default-features = false }
+alloy-network = { version = "0.5.0", default-features = false }
+alloy-network-primitives = { version = "0.5.0", default-features = false }
+alloy-rpc-types = { version = "0.5.0" }
+alloy-rpc-types-engine = { version = "0.5.0", default-features = false }
+alloy-rpc-types-eth = { version = "0.5.0", default-features = false }
+alloy-eips = { version = "0.5.0", default-features = false }
+alloy-serde = { version = "0.5.0", default-features = false }
+alloy-signer = { version = "0.5.0", default-features = false }
+alloy-provider = { version = "0.5.0", default-features = false }
+alloy-transport = { version = "0.5.0", default-features = false }
 
 # Serde
 serde_repr = "0.1"
@@ -100,15 +100,15 @@ tokio = "1"
 c-kzg = { version = "1.0", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 
-[patch.crates-io]
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
+#[patch.crates-io]
+#alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,15 +100,15 @@ tokio = "1"
 c-kzg = { version = "1.0", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 
-#[patch.crates-io]
-#alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-#alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-#alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-#alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-#alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-#alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-#alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-#alloy-serde = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-#alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-#alloy-provider = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-#alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+[patch.crates-io]
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "b63a2c7" }

--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -147,7 +147,10 @@ impl OpReceiptEnvelope {
     }
 }
 
-impl<T> TxReceipt<T> for OpReceiptEnvelope<T> {
+impl<T> TxReceipt<T> for OpReceiptEnvelope<T>
+where
+    T: Clone + core::fmt::Debug + PartialEq + Eq + Send + Sync,
+{
     fn status_or_post_state(&self) -> Eip658Value {
         self.as_receipt().unwrap().status
     }

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -61,7 +61,7 @@ impl<T> AsRef<Receipt<T>> for OpDepositReceipt<T> {
 
 impl<T> TxReceipt<T> for OpDepositReceipt<T>
 where
-    T: Borrow<Log>,
+    T: Borrow<Log> + Clone + core::fmt::Debug + PartialEq + Eq + Send + Sync,
 {
     fn status_or_post_state(&self) -> Eip658Value {
         self.inner.status_or_post_state()

--- a/crates/consensus/src/traits.rs
+++ b/crates/consensus/src/traits.rs
@@ -108,6 +108,6 @@ mod tests {
         assert_eq!(tx.mint(), Some(200));
         assert!(!tx.is_system_transaction());
         assert!(tx.is_deposit());
-        assert_eq!(tx.to(), TxKind::Call(contract_address));
+        assert_eq!(tx.kind(), TxKind::Call(contract_address));
     }
 }

--- a/crates/consensus/src/transaction/deposit.rs
+++ b/crates/consensus/src/transaction/deposit.rs
@@ -193,7 +193,11 @@ impl Transaction for TxDeposit {
         0
     }
 
-    fn to(&self) -> TxKind {
+    fn to(&self) -> Option<Address> {
+        self.to.into()
+    }
+
+    fn kind(&self) -> TxKind {
         self.to
     }
 
@@ -201,7 +205,7 @@ impl Transaction for TxDeposit {
         self.value
     }
 
-    fn input(&self) -> &[u8] {
+    fn input(&self) -> &Bytes {
         &self.input
     }
 

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -4,7 +4,7 @@ use alloy_eips::{
     eip2930::AccessList,
     eip7702::SignedAuthorization,
 };
-use alloy_primitives::{TxKind, B256, U256};
+use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
 use alloy_rlp::{Decodable, Encodable, Header};
 use derive_more::Display;
 
@@ -218,13 +218,23 @@ impl Transaction for OpTxEnvelope {
         }
     }
 
-    fn to(&self) -> TxKind {
+    fn to(&self) -> Option<Address> {
         match self {
             Self::Legacy(tx) => tx.tx().to(),
             Self::Eip2930(tx) => tx.tx().to(),
             Self::Eip1559(tx) => tx.tx().to(),
             Self::Eip7702(tx) => tx.tx().to(),
             Self::Deposit(tx) => tx.to(),
+        }
+    }
+
+    fn kind(&self) -> TxKind {
+        match self {
+            Self::Legacy(tx) => tx.tx().kind(),
+            Self::Eip2930(tx) => tx.tx().kind(),
+            Self::Eip1559(tx) => tx.tx().kind(),
+            Self::Eip7702(tx) => tx.tx().kind(),
+            Self::Deposit(tx) => tx.kind(),
         }
     }
 
@@ -238,7 +248,7 @@ impl Transaction for OpTxEnvelope {
         }
     }
 
-    fn input(&self) -> &[u8] {
+    fn input(&self) -> &Bytes {
         match self {
             Self::Legacy(tx) => tx.tx().input(),
             Self::Eip2930(tx) => tx.tx().input(),

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -1,7 +1,7 @@
 use crate::{OpTxEnvelope, OpTxType, TxDeposit};
 use alloy_consensus::{Transaction, TxEip1559, TxEip2930, TxEip7702, TxLegacy};
 use alloy_eips::eip2930::AccessList;
-use alloy_primitives::TxKind;
+use alloy_primitives::{Address, Bytes, TxKind};
 
 /// The TypedTransaction enum represents all Ethereum transaction request types, modified for the OP
 /// Stack.
@@ -194,13 +194,23 @@ impl Transaction for OpTypedTransaction {
         }
     }
 
-    fn to(&self) -> TxKind {
+    fn to(&self) -> Option<Address> {
         match self {
             Self::Legacy(tx) => tx.to(),
             Self::Eip2930(tx) => tx.to(),
             Self::Eip1559(tx) => tx.to(),
             Self::Eip7702(tx) => tx.to(),
             Self::Deposit(tx) => tx.to(),
+        }
+    }
+
+    fn kind(&self) -> TxKind {
+        match self {
+            Self::Legacy(tx) => tx.kind(),
+            Self::Eip2930(tx) => tx.kind(),
+            Self::Eip1559(tx) => tx.kind(),
+            Self::Eip7702(tx) => tx.kind(),
+            Self::Deposit(tx) => tx.kind(),
         }
     }
 
@@ -214,7 +224,7 @@ impl Transaction for OpTypedTransaction {
         }
     }
 
-    fn input(&self) -> &[u8] {
+    fn input(&self) -> &Bytes {
         match self {
             Self::Legacy(tx) => tx.input(),
             Self::Eip2930(tx) => tx.input(),

--- a/crates/provider/src/ext/engine.rs
+++ b/crates/provider/src/ext/engine.rs
@@ -1,10 +1,9 @@
 use alloy_network::Network;
-use alloy_primitives::{BlockHash, B256};
+use alloy_primitives::{BlockHash, Bytes, B256};
 use alloy_provider::Provider;
 use alloy_rpc_types_engine::{
     ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadEnvelopeV2, ExecutionPayloadInputV2,
-    ExecutionPayloadV3, ExecutionPayloadV4, ForkchoiceState, ForkchoiceUpdated, PayloadId,
-    PayloadStatus,
+    ExecutionPayloadV3, ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus,
 };
 use alloy_transport::{Transport, TransportResult};
 use op_alloy_rpc_types_engine::{
@@ -54,8 +53,9 @@ pub trait OpEngineApi<N, T>: Send + Sync {
     /// OP modifications: TODO
     async fn new_payload_v4(
         &self,
-        payload: ExecutionPayloadV4,
+        payload: ExecutionPayloadV3,
         parent_beacon_block_root: B256,
+        execution_requests: Vec<Bytes>,
     ) -> TransportResult<PayloadStatus>;
 
     /// Updates the execution layer client with the given fork choice, as specified for the Shanghai
@@ -218,14 +218,18 @@ where
 
     async fn new_payload_v4(
         &self,
-        payload: ExecutionPayloadV4,
+        payload: ExecutionPayloadV3,
         parent_beacon_block_root: B256,
+        execution_requests: Vec<Bytes>,
     ) -> TransportResult<PayloadStatus> {
         // Note: The `versioned_hashes` parameter is always an empty array for OP chains.
         let versioned_hashes: Vec<B256> = vec![];
 
         self.client()
-            .request("engine_newPayloadV4", (payload, versioned_hashes, parent_beacon_block_root))
+            .request(
+                "engine_newPayloadV4",
+                (payload, versioned_hashes, parent_beacon_block_root, execution_requests),
+            )
             .await
     }
 

--- a/crates/rpc-types-engine/src/payload_v4.rs
+++ b/crates/rpc-types-engine/src/payload_v4.rs
@@ -1,7 +1,8 @@
 //! Optimism execution payload envelope V3.
 
-use alloy_primitives::{B256, U256};
-use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV4};
+use alloc::vec::Vec;
+use alloy_primitives::{Bytes, B256, U256};
+use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV3};
 
 /// This structure maps for the return value of `engine_getPayload` of the beacon chain spec, for
 /// V4.
@@ -13,7 +14,7 @@ use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV4};
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct OpExecutionPayloadEnvelopeV4 {
     /// Execution payload V4
-    pub execution_payload: ExecutionPayloadV4,
+    pub execution_payload: ExecutionPayloadV3,
     /// The expected value to be received by the feeRecipient in wei
     pub block_value: U256,
     /// The blobs, commitments, and proofs associated with the executed payload.
@@ -23,6 +24,10 @@ pub struct OpExecutionPayloadEnvelopeV4 {
     pub should_override_builder: bool,
     /// Ecotone parent beacon block root
     pub parent_beacon_block_root: B256,
+    /// A list of opaque [EIP-7685][eip7685] requests.
+    ///
+    /// [eip7685]: https://eips.ethereum.org/EIPS/eip-7685
+    pub execution_requests: Vec<Bytes>,
 }
 
 #[cfg(test)]
@@ -34,7 +39,7 @@ mod tests {
     fn serde_roundtrip_execution_payload_envelope_v4() {
         // modified execution payload envelope v3 with empty deposit, withdrawal, and consolidation
         // requests.
-        let response = r#"{"executionPayload":{"parentHash":"0xe927a1448525fb5d32cb50ee1408461a945ba6c39bd5cf5621407d500ecc8de9","feeRecipient":"0x0000000000000000000000000000000000000000","stateRoot":"0x10f8a0830000e8edef6d00cc727ff833f064b1950afd591ae41357f97e543119","receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","prevRandao":"0xe0d8b4521a7da1582a713244ffb6a86aa1726932087386e2dc7973f43fc6cb24","blockNumber":"0x1","gasLimit":"0x2ffbd2","gasUsed":"0x0","timestamp":"0x1235","extraData":"0xd883010d00846765746888676f312e32312e30856c696e7578","baseFeePerGas":"0x342770c0","blockHash":"0x44d0fa5f2f73a938ebb96a2a21679eb8dea3e7b7dd8fd9f35aa756dda8bf0a8a","transactions":[],"withdrawals":[],"blobGasUsed":"0x0","excessBlobGas":"0x0","depositRequests":[],"withdrawalRequests":[],"consolidationRequests":[]},"blockValue":"0x0","blobsBundle":{"commitments":[],"proofs":[],"blobs":[]},"shouldOverrideBuilder":false,"parentBeaconBlockRoot":"0xdead00000000000000000000000000000000000000000000000000000000beef"}"#;
+        let response = r#"{"executionPayload":{"parentHash":"0xe927a1448525fb5d32cb50ee1408461a945ba6c39bd5cf5621407d500ecc8de9","feeRecipient":"0x0000000000000000000000000000000000000000","stateRoot":"0x10f8a0830000e8edef6d00cc727ff833f064b1950afd591ae41357f97e543119","receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","prevRandao":"0xe0d8b4521a7da1582a713244ffb6a86aa1726932087386e2dc7973f43fc6cb24","blockNumber":"0x1","gasLimit":"0x2ffbd2","gasUsed":"0x0","timestamp":"0x1235","extraData":"0xd883010d00846765746888676f312e32312e30856c696e7578","baseFeePerGas":"0x342770c0","blockHash":"0x44d0fa5f2f73a938ebb96a2a21679eb8dea3e7b7dd8fd9f35aa756dda8bf0a8a","transactions":[],"withdrawals":[],"blobGasUsed":"0x0","excessBlobGas":"0x0"},"blockValue":"0x0","blobsBundle":{"commitments":[],"proofs":[],"blobs":[]},"shouldOverrideBuilder":false,"parentBeaconBlockRoot":"0xdead00000000000000000000000000000000000000000000000000000000beef","executionRequests":["0xdeadbeef"]}"#;
         let envelope: OpExecutionPayloadEnvelopeV4 = serde_json::from_str(response).unwrap();
         assert_eq!(serde_json::to_string(&envelope).unwrap(), response);
     }

--- a/crates/rpc-types/src/transaction.rs
+++ b/crates/rpc-types/src/transaction.rs
@@ -1,8 +1,7 @@
 //! Optimism specific types related to transactions.
 
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
-use alloy_primitives::{BlockHash, ChainId, TxKind, B256, U256};
-use alloy_rpc_types_eth::Signature;
+use alloy_primitives::{Address, BlockHash, Bytes, ChainId, TxKind, B256, U256};
 use alloy_serde::OtherFields;
 use serde::{Deserialize, Serialize};
 
@@ -62,15 +61,19 @@ impl alloy_consensus::Transaction for Transaction {
         self.inner.priority_fee_or_price()
     }
 
-    fn to(&self) -> TxKind {
+    fn to(&self) -> Option<Address> {
         self.inner.to()
+    }
+
+    fn kind(&self) -> TxKind {
+        self.inner.kind()
     }
 
     fn value(&self) -> U256 {
         self.inner.value()
     }
 
-    fn input(&self) -> &[u8] {
+    fn input(&self) -> &Bytes {
         self.inner.input()
     }
 
@@ -92,8 +95,6 @@ impl alloy_consensus::Transaction for Transaction {
 }
 
 impl alloy_network_primitives::TransactionResponse for Transaction {
-    type Signature = Signature;
-
     fn tx_hash(&self) -> alloy_primitives::TxHash {
         self.inner.tx_hash()
     }
@@ -116,10 +117,6 @@ impl alloy_network_primitives::TransactionResponse for Transaction {
 
     fn to(&self) -> Option<alloy_primitives::Address> {
         self.inner.to()
-    }
-
-    fn signature(&self) -> Option<Self::Signature> {
-        self.inner.signature()
     }
 }
 


### PR DESCRIPTION
## Motivation

There is no longer a V4 execution payload in Pectra, so it does not make sense that there would be one for Optimism. The v4 payload envelope still exists, but it now wraps a v3 payload.

See also https://github.com/alloy-rs/alloy/pull/1383

Based on https://github.com/alloy-rs/op-alloy/pull/175

## Solution

Remove the V4 payload.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
