### PR TITLE
feat(protocol): Batch Error Types

### DIFF
--- a/crates/protocol/src/batch/errors.rs
+++ b/crates/protocol/src/batch/errors.rs
@@ -1,0 +1,77 @@
+//! Span Batch Errors
+
+/// Span Batch Errors
+#[derive(Debug, derive_more::Display, Clone, PartialEq, Eq)]
+pub enum SpanBatchError {
+    /// The span batch is too big
+    #[display("The span batch is too big.")]
+    TooBigSpanBatchSize,
+    /// The bit field is too long
+    #[display("The bit field is too long")]
+    BitfieldTooLong,
+    /// Empty Span Batch
+    #[display("Empty span batch")]
+    EmptySpanBatch,
+    /// Missing L1 origin
+    #[display("Missing L1 origin")]
+    MissingL1Origin,
+    /// Decoding errors
+    #[display("Span batch decoding error: {_0}")]
+    Decoding(SpanDecodingError),
+}
+
+impl From<SpanDecodingError> for SpanBatchError {
+    fn from(err: SpanDecodingError) -> Self {
+        Self::Decoding(err)
+    }
+}
+
+impl core::error::Error for SpanBatchError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Decoding(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+/// Decoding Error
+#[derive(Debug, derive_more::Display, Clone, PartialEq, Eq)]
+pub enum SpanDecodingError {
+    /// Failed to decode relative timestamp
+    #[display("Failed to decode relative timestamp")]
+    RelativeTimestamp,
+    /// Failed to decode L1 origin number
+    #[display("Failed to decode L1 origin number")]
+    L1OriginNumber,
+    /// Failed to decode parent check
+    #[display("Failed to decode parent check")]
+    ParentCheck,
+    /// Failed to decode L1 origin check
+    #[display("Failed to decode L1 origin check")]
+    L1OriginCheck,
+    /// Failed to decode block count
+    #[display("Failed to decode block count")]
+    BlockCount,
+    /// Failed to decode block tx counts
+    #[display("Failed to decode block tx counts")]
+    BlockTxCounts,
+    /// Failed to decode transaction nonces
+    #[display("Failed to decode transaction nonces")]
+    TxNonces,
+    /// Mismatch in length between the transaction type and signature arrays in a span batch
+    /// transaction payload.
+    #[display("Mismatch in length between the transaction type and signature arrays")]
+    TypeSignatureLenMismatch,
+    /// Invalid transaction type
+    #[display("Invalid transaction type")]
+    InvalidTransactionType,
+    /// Invalid transaction data
+    #[display("Invalid transaction data")]
+    InvalidTransactionData,
+    /// Invalid transaction signature
+    #[display("Invalid transaction signature")]
+    InvalidTransactionSignature,
+}
+
+impl core::error::Error for SpanDecodingError {}

--- a/crates/protocol/src/batch/mod.rs
+++ b/crates/protocol/src/batch/mod.rs
@@ -3,6 +3,9 @@
 mod r#type;
 pub use r#type::*;
 
+mod errors;
+pub use errors::{SpanBatchError, SpanDecodingError};
+
 mod validity;
 pub use validity::BatchValidity;
 

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -11,8 +11,8 @@ extern crate alloc;
 
 mod batch;
 pub use batch::{
-    BatchType, BatchValidationProvider, BatchValidity, SingleBatch, SINGLE_BATCH_TYPE,
-    SPAN_BATCH_TYPE,
+    BatchType, BatchValidationProvider, BatchValidity, SingleBatch, SpanBatchError,
+    SpanDecodingError, SINGLE_BATCH_TYPE, SPAN_BATCH_TYPE,
 };
 
 mod block;


### PR DESCRIPTION
### Description

Ports batch error types to `op-alloy-protocol`.

### Provenance

Part of a port migrating the batch types from `kona-derive` to `op-alloy`. See [`kona#695`](https://github.com/anton-rs/kona/issues/695).