### PR TITLE
feat(protocol): Span Batch Element

### DIFF
--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -37,6 +37,7 @@ serde = { workspace = true, optional = true }
 alloy-serde = { workspace = true, optional = true }
 
 [dev-dependencies]
+proptest.workspace = true
 arbitrary = { workspace = true, features = ["derive"] }
 rand.workspace = true
 serde_json.workspace = true

--- a/crates/protocol/src/batch/element.rs
+++ b/crates/protocol/src/batch/element.rs
@@ -1,0 +1,56 @@
+//! Span Batch Element
+
+use crate::SingleBatch;
+use alloc::vec::Vec;
+use alloy_primitives::Bytes;
+
+/// MAX_SPAN_BATCH_ELEMENTS is the maximum number of blocks, transactions in total,
+/// or transaction per block allowed in a span batch.
+pub const MAX_SPAN_BATCH_ELEMENTS: u64 = 10_000_000;
+
+/// A single batch element is similar to the [SingleBatch] type
+/// but does not contain the parent hash and epoch hash since spans
+/// do not contain this data for every block in the span.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct SpanBatchElement {
+    /// The epoch number of the L1 block
+    pub epoch_num: u64,
+    /// The timestamp of the L2 block
+    pub timestamp: u64,
+    /// The transactions in the L2 block
+    pub transactions: Vec<Bytes>,
+}
+
+impl From<SingleBatch> for SpanBatchElement {
+    fn from(batch: SingleBatch) -> Self {
+        Self {
+            epoch_num: batch.epoch_num,
+            timestamp: batch.timestamp,
+            transactions: batch.transactions,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::{collection::vec, prelude::any, proptest};
+
+    proptest! {
+        #[test]
+        fn test_span_batch_element_from_single_batch(epoch_num in 0u64..u64::MAX, timestamp in 0u64..u64::MAX, transactions in vec(any::<Bytes>(), 0..100)) {
+            let single_batch = SingleBatch {
+                epoch_num,
+                timestamp,
+                transactions: transactions.clone(),
+                ..Default::default()
+            };
+
+            let span_batch_element: SpanBatchElement = single_batch.into();
+
+            assert_eq!(span_batch_element.epoch_num, epoch_num);
+            assert_eq!(span_batch_element.timestamp, timestamp);
+            assert_eq!(span_batch_element.transactions, transactions);
+        }
+    }
+}

--- a/crates/protocol/src/batch/mod.rs
+++ b/crates/protocol/src/batch/mod.rs
@@ -6,6 +6,9 @@ pub use r#type::*;
 mod errors;
 pub use errors::{SpanBatchError, SpanDecodingError};
 
+mod element;
+pub use element::{SpanBatchElement, MAX_SPAN_BATCH_ELEMENTS};
+
 mod validity;
 pub use validity::BatchValidity;
 

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -11,8 +11,8 @@ extern crate alloc;
 
 mod batch;
 pub use batch::{
-    BatchType, BatchValidationProvider, BatchValidity, SingleBatch, SpanBatchError,
-    SpanDecodingError, SINGLE_BATCH_TYPE, SPAN_BATCH_TYPE,
+    BatchType, BatchValidationProvider, BatchValidity, SingleBatch, SpanBatchElement,
+    SpanBatchError, SpanDecodingError, MAX_SPAN_BATCH_ELEMENTS, SINGLE_BATCH_TYPE, SPAN_BATCH_TYPE,
 };
 
 mod block;

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -30,7 +30,10 @@ mod iter;
 pub use iter::FrameIter;
 
 mod utils;
-pub use utils::{starts_with_2718_deposit, to_system_config, OpBlockConversionError};
+pub use utils::{
+    convert_v_to_y_parity, is_protected_v, read_tx_data, starts_with_2718_deposit,
+    to_system_config, OpBlockConversionError,
+};
 
 mod channel;
 pub use channel::{

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -31,8 +31,8 @@ pub use iter::FrameIter;
 
 mod utils;
 pub use utils::{
-    convert_v_to_y_parity, is_protected_v, read_tx_data, starts_with_2718_deposit,
-    to_system_config, OpBlockConversionError,
+    is_protected_v, read_tx_data, starts_with_2718_deposit, to_system_config,
+    OpBlockConversionError,
 };
 
 mod channel;

--- a/crates/protocol/src/utils.rs
+++ b/crates/protocol/src/utils.rs
@@ -1,9 +1,16 @@
 //! Utility methods used by protocol types.
 
-use crate::{block_info::DecodeError, L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoTx};
+use alloc::vec::Vec;
+use alloy_consensus::{TxEnvelope, TxType};
 use alloy_primitives::B256;
+use alloy_rlp::{Buf, Header};
 use op_alloy_consensus::{OpBlock, OpTxEnvelope};
 use op_alloy_genesis::{RollupConfig, SystemConfig};
+
+use crate::{
+    block_info::DecodeError, L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoTx, SpanBatchError,
+    SpanDecodingError,
+};
 
 /// Returns if the given `value` is a deposit transaction.
 pub fn starts_with_2718_deposit<B>(value: &B) -> bool
@@ -224,9 +231,85 @@ fn u24(input: &[u8], idx: u32) -> u32 {
         + (u32::from(input[(idx + 2) as usize]) << 16)
 }
 
+/// Reads transaction data from a reader.
+#[allow(unused)]
+pub fn read_tx_data(r: &mut &[u8]) -> Result<(Vec<u8>, TxType), SpanBatchError> {
+    let mut tx_data = Vec::new();
+    let first_byte =
+        *r.first().ok_or(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData))?;
+    let mut tx_type = 0;
+    if first_byte <= 0x7F {
+        // EIP-2718: Non-legacy tx, so write tx type
+        tx_type = first_byte;
+        tx_data.push(tx_type);
+        r.advance(1);
+    }
+
+    // Read the RLP header with a different reader pointer. This prevents the initial pointer from
+    // being advanced in the case that what we read is invalid.
+    let rlp_header = Header::decode(&mut (**r).as_ref())
+        .map_err(|_| SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData))?;
+
+    let tx_payload = if rlp_header.list {
+        // Grab the raw RLP for the transaction data from `r`. It was unaffected since we copied it.
+        let payload_length_with_header = rlp_header.payload_length + rlp_header.length();
+        let payload = r[0..payload_length_with_header].to_vec();
+        r.advance(payload_length_with_header);
+        Ok(payload)
+    } else {
+        Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData))
+    }?;
+    tx_data.extend_from_slice(&tx_payload);
+
+    Ok((
+        tx_data,
+        tx_type
+            .try_into()
+            .map_err(|_| SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionType))?,
+    ))
+}
+
+/// Converts a `v` value to a y parity bit, from the transaaction type.
+#[allow(unused)]
+pub const fn convert_v_to_y_parity(v: u64, tx_type: TxType) -> Result<bool, SpanBatchError> {
+    match tx_type {
+        TxType::Legacy => {
+            if v != 27 && v != 28 {
+                // EIP-155: v = 2 * chain_id + 35 + yParity
+                Ok((v - 35) & 1 == 1)
+            } else {
+                // Unprotected legacy txs must have v = 27 or 28
+                Ok(v - 27 == 1)
+            }
+        }
+        TxType::Eip2930 | TxType::Eip1559 => Ok(v == 1),
+        _ => Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionType)),
+    }
+}
+
+/// Checks if the signature of the passed [TxEnvelope] is protected.
+#[allow(unused)]
+pub const fn is_protected_v(tx: &TxEnvelope) -> bool {
+    match tx {
+        TxEnvelope::Legacy(tx) => {
+            let v = tx.signature().v().to_u64();
+            if 64 - v.leading_zeros() <= 8 {
+                return v != 27 && v != 28 && v != 1 && v != 0;
+            }
+            // anything not 27 or 28 is considered protected
+            true
+        }
+        _ => true,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_consensus::{
+        Signed, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip7702, TxLegacy,
+    };
+    use alloy_primitives::{b256, Signature};
     use alloy_sol_types::{sol, SolCall};
     use revm::{
         db::BenchmarkDB,
@@ -236,6 +319,63 @@ mod tests {
     use std::vec::Vec;
 
     use rstest::rstest;
+
+    #[test]
+    fn test_convert_v_to_y_parity() {
+        assert_eq!(convert_v_to_y_parity(27, TxType::Legacy), Ok(false));
+        assert_eq!(convert_v_to_y_parity(28, TxType::Legacy), Ok(true));
+        assert_eq!(convert_v_to_y_parity(36, TxType::Legacy), Ok(true));
+        assert_eq!(convert_v_to_y_parity(37, TxType::Legacy), Ok(false));
+        assert_eq!(convert_v_to_y_parity(1, TxType::Eip2930), Ok(true));
+        assert_eq!(convert_v_to_y_parity(1, TxType::Eip1559), Ok(true));
+        assert_eq!(
+            convert_v_to_y_parity(1, TxType::Eip4844),
+            Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionType))
+        );
+        assert_eq!(
+            convert_v_to_y_parity(0, TxType::Eip7702),
+            Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionType))
+        );
+    }
+
+    #[test]
+    fn test_is_protected_v() {
+        let sig = Signature::test_signature();
+        assert!(!is_protected_v(&TxEnvelope::Legacy(Signed::new_unchecked(
+            TxLegacy::default(),
+            sig,
+            Default::default(),
+        ))));
+        let r = b256!("840cfc572845f5786e702984c2a582528cad4b49b2a10b9db1be7fca90058565");
+        let s = b256!("25e7109ceb98168d95b09b18bbf6b685130e0562f233877d492b94eee0c5b6d1");
+        let v = 27;
+        let valid_sig = Signature::from_scalars_and_parity(r, s, v).unwrap();
+        assert!(!is_protected_v(&TxEnvelope::Legacy(Signed::new_unchecked(
+            TxLegacy::default(),
+            valid_sig,
+            Default::default(),
+        ))));
+        assert!(is_protected_v(&TxEnvelope::Eip2930(Signed::new_unchecked(
+            TxEip2930::default(),
+            sig,
+            Default::default(),
+        ))));
+        assert!(is_protected_v(&TxEnvelope::Eip1559(Signed::new_unchecked(
+            TxEip1559::default(),
+            sig,
+            Default::default(),
+        ))));
+        assert!(is_protected_v(&TxEnvelope::Eip4844(Signed::new_unchecked(
+            TxEip4844Variant::TxEip4844(TxEip4844::default()),
+            sig,
+            Default::default(),
+        ))));
+        assert!(is_protected_v(&TxEnvelope::Eip7702(Signed::new_unchecked(
+            TxEip7702::default(),
+            sig,
+            Default::default(),
+        ))));
+    }
 
     #[rstest]
     #[case::empty(&[], 0)]

--- a/crates/protocol/src/utils.rs
+++ b/crates/protocol/src/utils.rs
@@ -232,7 +232,6 @@ fn u24(input: &[u8], idx: u32) -> u32 {
 }
 
 /// Reads transaction data from a reader.
-#[allow(unused)]
 pub fn read_tx_data(r: &mut &[u8]) -> Result<(Vec<u8>, TxType), SpanBatchError> {
     let mut tx_data = Vec::new();
     let first_byte =
@@ -269,26 +268,7 @@ pub fn read_tx_data(r: &mut &[u8]) -> Result<(Vec<u8>, TxType), SpanBatchError> 
     ))
 }
 
-/// Converts a `v` value to a y parity bit, from the transaaction type.
-#[allow(unused)]
-pub const fn convert_v_to_y_parity(v: u64, tx_type: TxType) -> Result<bool, SpanBatchError> {
-    match tx_type {
-        TxType::Legacy => {
-            if v != 27 && v != 28 {
-                // EIP-155: v = 2 * chain_id + 35 + yParity
-                Ok((v - 35) & 1 == 1)
-            } else {
-                // Unprotected legacy txs must have v = 27 or 28
-                Ok(v - 27 == 1)
-            }
-        }
-        TxType::Eip2930 | TxType::Eip1559 => Ok(v == 1),
-        _ => Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionType)),
-    }
-}
-
 /// Checks if the signature of the passed [TxEnvelope] is protected.
-#[allow(unused)]
 pub const fn is_protected_v(tx: &TxEnvelope) -> bool {
     match tx {
         TxEnvelope::Legacy(tx) => {
@@ -316,27 +296,8 @@ mod tests {
         primitives::{address, bytes, Bytecode, Bytes, TxKind, U256},
         Evm,
     };
-    use std::vec::Vec;
-
     use rstest::rstest;
-
-    #[test]
-    fn test_convert_v_to_y_parity() {
-        assert_eq!(convert_v_to_y_parity(27, TxType::Legacy), Ok(false));
-        assert_eq!(convert_v_to_y_parity(28, TxType::Legacy), Ok(true));
-        assert_eq!(convert_v_to_y_parity(36, TxType::Legacy), Ok(true));
-        assert_eq!(convert_v_to_y_parity(37, TxType::Legacy), Ok(false));
-        assert_eq!(convert_v_to_y_parity(1, TxType::Eip2930), Ok(true));
-        assert_eq!(convert_v_to_y_parity(1, TxType::Eip1559), Ok(true));
-        assert_eq!(
-            convert_v_to_y_parity(1, TxType::Eip4844),
-            Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionType))
-        );
-        assert_eq!(
-            convert_v_to_y_parity(0, TxType::Eip7702),
-            Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionType))
-        );
-    }
+    use std::vec::Vec;
 
     #[test]
     fn test_is_protected_v() {


### PR DESCRIPTION
### Description

Ports the span batch element type to `op-alloy-protocol`.

### Provenance

Part of a port migrating the batch types from `kona-derive` to `op-alloy`. See [`kona#695`](https://github.com/anton-rs/kona/issues/695).