### PR TITLE
Rename `TxDeposit::signature` to `pre_bedrock_signature`

### DIFF
--- a/crates/consensus/src/transaction/deposit.rs
+++ b/crates/consensus/src/transaction/deposit.rs
@@ -174,9 +174,9 @@ impl TxDeposit {
         }
     }
 
-    /// Returns the signature for the optimism deposit transactions, which don't include a
-    /// signature.
-    pub fn signature() -> Signature {
+    /// Returns the OVM signature for the optimism deposit transactions. Below bedrock, the deposit
+    /// transaction didn't include a signature.
+    pub fn pre_bedrock_signature() -> Signature {
         Signature::new(U256::ZERO, U256::ZERO, Parity::Parity(false))
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Fixes semantics of `TxDeposit` to differentiate between ovm and evm chain

## Solution

Renames `TxDeposit::signature` to `pre_bedrock_signature`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
