### PR TITLE
[wip] feat: bump alloy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,8 @@ alloy-network-primitives = { version = "0.5.4", default-features = false }
 alloy-rlp = { version = "0.3", default-features = false }
 
 # Alloy Core
-alloy-sol-types = { version = "0.8", default-features = false }
-alloy-primitives = { version = "0.8", default-features = false }
+alloy-sol-types = { version = "0.8.10", default-features = false }
+alloy-primitives = { version = "0.8.10", default-features = false }
 
 # Revm
 revm = "17.1.0"
@@ -116,15 +116,21 @@ rstest = "0.23.0"
 c-kzg = { version = "1.0", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 
-#[patch.crates-io]
-#alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
-#alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
-#alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
-#alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
-#alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
-#alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
-#alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
-#alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
-#alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
-#alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
-#alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+[patch.crates-io]
+alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "237cfc4" }
+alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "237cfc4" }
+
+alloy-eip7702 = { git = "https://github.com/alloy-rs/eips", rev = "9e6fcee" }
+
+revm-primitives = { git = "https://github.com/klkvr/revm", rev = "e552b1d" }
+
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,13 +122,13 @@ alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "17ae00a" }
 
 revm-primitives = { git = "https://github.com/klkvr/revm", rev = "e552b1d" }
 
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,20 +117,18 @@ c-kzg = { version = "1.0", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 
 [patch.crates-io]
-alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "237cfc4" }
-alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "237cfc4" }
-
-alloy-eip7702 = { git = "https://github.com/alloy-rs/eips", rev = "9e6fcee" }
+alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "17ae00a" }
+alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "17ae00a" }
 
 revm-primitives = { git = "https://github.com/klkvr/revm", rev = "e552b1d" }
 
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "708d0e3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,16 +46,16 @@ op-alloy-rpc-jsonrpsee = { version = "0.5.2", path = "crates/rpc-jsonrpsee", def
 op-alloy-rpc-types-engine = { version = "0.5.2", path = "crates/rpc-types-engine", default-features = false }
 
 # Alloy
-alloy-eips = { version = "0.5.4", default-features = false }
-alloy-serde = { version = "0.5.4", default-features = false }
-alloy-signer = { version = "0.5.4", default-features = false }
-alloy-network = { version = "0.5.4", default-features = false }
-alloy-provider = { version = "0.5.4", default-features = false }
-alloy-transport = { version = "0.5.4", default-features = false }
-alloy-consensus = { version = "0.5.4", default-features = false }
-alloy-rpc-types-eth = { version = "0.5.4", default-features = false }
-alloy-rpc-types-engine = { version = "0.5.4", default-features = false }
-alloy-network-primitives = { version = "0.5.4", default-features = false }
+alloy-eips = { version = "0.6.0", default-features = false }
+alloy-serde = { version = "0.6.0", default-features = false }
+alloy-signer = { version = "0.6.0", default-features = false }
+alloy-network = { version = "0.6.0", default-features = false }
+alloy-provider = { version = "0.6.0", default-features = false }
+alloy-transport = { version = "0.6.0", default-features = false }
+alloy-consensus = { version = "0.6.0", default-features = false }
+alloy-rpc-types-eth = { version = "0.6.0", default-features = false }
+alloy-rpc-types-engine = { version = "0.6.0", default-features = false }
+alloy-network-primitives = { version = "0.6.0", default-features = false }
 
 # Alloy RLP
 alloy-rlp = { version = "0.3", default-features = false }
@@ -65,7 +65,7 @@ alloy-sol-types = { version = "0.8.11", default-features = false }
 alloy-primitives = { version = "0.8.11", default-features = false }
 
 # Revm
-revm = "17.1.0"
+revm = "18.0.0"
 
 # Serde
 serde_repr = "0.1"
@@ -116,16 +116,15 @@ rstest = "0.23.0"
 c-kzg = { version = "1.0", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 
-[patch.crates-io]
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "4360ea1" }
-
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
+#[patch.crates-io]
+#alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }
+#alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "9e2510f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,13 +124,13 @@ alloy-eip7702 = { git = "https://github.com/alloy-rs/eips", rev = "9e6fcee" }
 
 revm-primitives = { git = "https://github.com/klkvr/revm", rev = "e552b1d" }
 
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "58d4cc4" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "215315bd" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,8 @@ alloy-network-primitives = { version = "0.5.4", default-features = false }
 alloy-rlp = { version = "0.3", default-features = false }
 
 # Alloy Core
-alloy-sol-types = { version = "0.8.10", default-features = false }
-alloy-primitives = { version = "0.8.10", default-features = false }
+alloy-sol-types = { version = "0.8.11", default-features = false }
+alloy-primitives = { version = "0.8.11", default-features = false }
 
 # Revm
 revm = "17.1.0"
@@ -117,18 +117,15 @@ c-kzg = { version = "1.0", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 
 [patch.crates-io]
-alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "17ae00a" }
-alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "17ae00a" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "4360ea1" }
 
-revm-primitives = { git = "https://github.com/klkvr/revm", rev = "82b99a0" }
-
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "2323ddb" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,13 +122,13 @@ alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "17ae00a" }
 
 revm-primitives = { git = "https://github.com/klkvr/revm", rev = "e552b1d" }
 
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "ff804cdc" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "17ae00a" }
 alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "17ae00a" }
 
-revm-primitives = { git = "https://github.com/klkvr/revm", rev = "e552b1d" }
+revm-primitives = { git = "https://github.com/klkvr/revm", rev = "82b99a0" }
 
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
 alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,13 +122,13 @@ alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "17ae00a" }
 
 revm-primitives = { git = "https://github.com/klkvr/revm", rev = "e552b1d" }
 
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "0eeee625" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "d99f09c" }

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -14,9 +14,9 @@ pub use receipt::{OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptEnvelope
 
 mod transaction;
 pub use transaction::{
-    optimism_deposit_tx_signature, DepositSourceDomain, DepositSourceDomainIdentifier,
-    DepositTransaction, L1InfoDepositSource, OpTxEnvelope, OpTxType, OpTypedTransaction, TxDeposit,
-    UpgradeDepositSource, UserDepositSource, DEPOSIT_TX_TYPE_ID,
+    DepositSourceDomain, DepositSourceDomainIdentifier, DepositTransaction, L1InfoDepositSource,
+    OpTxEnvelope, OpTxType, OpTypedTransaction, TxDeposit, UpgradeDepositSource, UserDepositSource,
+    DEPOSIT_TX_TYPE_ID,
 };
 
 pub mod hardforks;
@@ -24,6 +24,9 @@ pub use hardforks::Hardforks;
 
 mod block;
 pub use block::OpBlock;
+
+#[cfg(feature = "serde")]
+pub use transaction::serde_deposit_tx_rpc;
 
 /// Bincode-compatible serde implementations for consensus types.
 ///

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -14,9 +14,9 @@ pub use receipt::{OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptEnvelope
 
 mod transaction;
 pub use transaction::{
-    DepositSourceDomain, DepositSourceDomainIdentifier, DepositTransaction, L1InfoDepositSource,
-    OpTxEnvelope, OpTxType, OpTypedTransaction, TxDeposit, UpgradeDepositSource, UserDepositSource,
-    DEPOSIT_TX_TYPE_ID,
+    optimism_deposit_tx_signature, DepositSourceDomain, DepositSourceDomainIdentifier,
+    DepositTransaction, L1InfoDepositSource, OpTxEnvelope, OpTxType, OpTypedTransaction, TxDeposit,
+    UpgradeDepositSource, UserDepositSource, DEPOSIT_TX_TYPE_ID,
 };
 
 pub mod hardforks;

--- a/crates/consensus/src/transaction/deposit.rs
+++ b/crates/consensus/src/transaction/deposit.rs
@@ -37,7 +37,12 @@ pub struct TxDeposit {
     /// Field indicating if this transaction is exempt from the L2 gas limit.
     #[cfg_attr(
         feature = "serde",
-        serde(default, with = "alloy_serde::quantity", rename = "isSystemTx")
+        serde(
+            default,
+            with = "alloy_serde::quantity",
+            rename = "isSystemTx",
+            skip_serializing_if = "std::ops::Not::not"
+        )
     )]
     pub is_system_transaction: bool,
     /// Input has two uses depending if transaction is Create or Call (if `to` field is None or

--- a/crates/consensus/src/transaction/deposit.rs
+++ b/crates/consensus/src/transaction/deposit.rs
@@ -96,6 +96,27 @@ impl TxDeposit {
         })
     }
 
+    /// Decodes the transaction from RLP bytes.
+    pub fn rlp_decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let remaining = buf.len();
+
+        if header.payload_length > remaining {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+
+        let this = Self::rlp_decode_fields(buf)?;
+
+        if buf.len() + header.payload_length != remaining {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+
+        Ok(this)
+    }
+
     /// Outputs the length of the transaction's fields, without a RLP header or length of the
     /// eip155 fields.
     pub(crate) fn rlp_encoded_fields_length(&self) -> usize {

--- a/crates/consensus/src/transaction/deposit.rs
+++ b/crates/consensus/src/transaction/deposit.rs
@@ -41,7 +41,10 @@ pub struct TxDeposit {
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", rename = "gas"))]
     pub gas_limit: u64,
     /// Field indicating if this transaction is exempt from the L2 gas limit.
-    #[cfg_attr(feature = "serde", serde(default, with = "alloy_serde::quantity", rename = "isSystemTx"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, with = "alloy_serde::quantity", rename = "isSystemTx")
+    )]
     pub is_system_transaction: bool,
     /// Input has two uses depending if transaction is Create or Call (if `to` field is None or
     /// Some).

--- a/crates/consensus/src/transaction/deposit.rs
+++ b/crates/consensus/src/transaction/deposit.rs
@@ -4,7 +4,7 @@ use super::OpTxType;
 use crate::DepositTransaction;
 use alloy_consensus::Transaction;
 use alloy_eips::eip2930::AccessList;
-use alloy_primitives::{Address, Bytes, ChainId, Parity, Signature, TxKind, B256, U256};
+use alloy_primitives::{Address, Bytes, ChainId, TxKind, B256, U256};
 use alloy_rlp::{
     Buf, BufMut, Decodable, Encodable, Error as DecodeError, Header, EMPTY_STRING_CODE,
 };
@@ -72,7 +72,7 @@ impl TxDeposit {
     /// - `gas_limit`
     /// - `is_system_transaction`
     /// - `input`
-    pub fn decode_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+    pub fn rlp_decode_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         Ok(Self {
             source_hash: Decodable::decode(buf)?,
             from: Decodable::decode(buf)?,
@@ -92,7 +92,7 @@ impl TxDeposit {
 
     /// Outputs the length of the transaction's fields, without a RLP header or length of the
     /// eip155 fields.
-    pub(crate) fn fields_len(&self) -> usize {
+    pub(crate) fn rlp_encoded_fields_length(&self) -> usize {
         self.source_hash.length()
             + self.from.length()
             + self.to.length()
@@ -105,7 +105,7 @@ impl TxDeposit {
 
     /// Encodes only the transaction's fields into the desired buffer, without a RLP header.
     /// <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/deposits.md#the-deposited-transaction-type>
-    pub(crate) fn encode_fields(&self, out: &mut dyn alloy_rlp::BufMut) {
+    pub(crate) fn rlp_encode_fields(&self, out: &mut dyn alloy_rlp::BufMut) {
         self.source_hash.encode(out);
         self.from.encode(out);
         self.to.encode(out);
@@ -138,46 +138,49 @@ impl TxDeposit {
         OpTxType::Deposit
     }
 
-    /// Inner encoding function that is used for both rlp [`Encodable`] trait and for calculating
-    /// hash that for eip2718 does not require rlp header
-    pub fn encode_inner(&self, out: &mut dyn BufMut, with_header: bool) {
-        let payload_length = self.fields_len();
-        if with_header {
-            Header {
-                list: false,
-                payload_length: 1 + Header { list: true, payload_length }.length() + payload_length,
-            }
-            .encode(out);
-        }
+    /// Create an rlp header for the transaction.
+    fn rlp_header(&self) -> Header {
+        Header { list: true, payload_length: self.rlp_encoded_fields_length() }
+    }
+
+    /// RLP encodes the transaction.
+    pub fn rlp_encode(&self, out: &mut dyn BufMut) {
+        self.rlp_header().encode(out);
+        self.rlp_encode_fields(out);
+    }
+
+    /// Get the length of the transaction when RLP encoded.
+    pub fn rlp_encoded_length(&self) -> usize {
+        self.rlp_header().length_with_payload()
+    }
+
+    /// Get the length of the transaction when EIP-2718 encoded. This is the
+    /// 1 byte type flag + the length of the RLP encoded transaction.
+    pub fn eip2718_encoded_length(&self) -> usize {
+        self.rlp_encoded_length() + 1
+    }
+
+    /// EIP-2718 encode the transaction with the given signature and the default
+    /// type flag.
+    pub fn eip2718_encode(&self, out: &mut dyn BufMut) {
         out.put_u8(self.tx_type() as u8);
-        let header = Header { list: true, payload_length };
-        header.encode(out);
-        self.encode_fields(out);
+        self.rlp_encode(out);
     }
 
-    /// Output the length of the RLP signed transaction encoding.
-    ///
-    /// If `with_header` is true, the length includes the RLP header.
-    pub fn encoded_len(&self, with_header: bool) -> usize {
-        // Count the length of the payload
-        let payload_length = self.fields_len();
-
-        // 'transaction type byte length' + 'header length' + 'payload length'
-        let inner_payload_length =
-            1 + Header { list: true, payload_length }.length() + payload_length;
-
-        if with_header {
-            Header { list: true, payload_length: inner_payload_length }.length()
-                + inner_payload_length
-        } else {
-            inner_payload_length
-        }
+    fn network_header(&self) -> Header {
+        Header { list: false, payload_length: self.eip2718_encoded_length() }
     }
 
-    /// Returns the signature for the optimism deposit transactions, which don't include a
-    /// signature.
-    pub fn signature() -> Signature {
-        Signature::new(U256::ZERO, U256::ZERO, Parity::Parity(false))
+    /// Get the length of the transaction when network encoded. This is the
+    /// EIP-2718 encoded length with an outer RLP header.
+    pub fn network_encoded_length(&self) -> usize {
+        self.network_header().length_with_payload()
+    }
+
+    /// Network encode the transaction with the given signature.
+    pub fn network_encode(&self, out: &mut dyn BufMut) {
+        self.network_header().encode(out);
+        self.eip2718_encode(out);
     }
 }
 
@@ -245,12 +248,12 @@ impl Transaction for TxDeposit {
 
 impl Encodable for TxDeposit {
     fn encode(&self, out: &mut dyn BufMut) {
-        Header { list: true, payload_length: self.fields_len() }.encode(out);
-        self.encode_fields(out);
+        Header { list: true, payload_length: self.rlp_encoded_fields_length() }.encode(out);
+        self.rlp_encode_fields(out);
     }
 
     fn length(&self) -> usize {
-        let payload_length = self.fields_len();
+        let payload_length = self.rlp_encoded_fields_length();
         Header { list: true, payload_length }.length() + payload_length
     }
 }
@@ -264,7 +267,7 @@ impl Decodable for TxDeposit {
             return Err(alloy_rlp::Error::InputTooShort);
         }
 
-        Self::decode_fields(data)
+        Self::rlp_decode_fields(data)
     }
 }
 
@@ -356,8 +359,8 @@ mod tests {
         };
 
         let mut buffer = BytesMut::new();
-        original.encode_fields(&mut buffer);
-        let decoded = TxDeposit::decode_fields(&mut &buffer[..]).expect("Failed to decode");
+        original.rlp_encode_fields(&mut buffer);
+        let decoded = TxDeposit::rlp_decode_fields(&mut &buffer[..]).expect("Failed to decode");
 
         assert_eq!(original, decoded);
     }
@@ -379,7 +382,7 @@ mod tests {
         tx_deposit.encode(&mut buffer_with_header);
 
         let mut buffer_without_header = BytesMut::new();
-        tx_deposit.encode_fields(&mut buffer_without_header);
+        tx_deposit.rlp_encode_fields(&mut buffer_without_header);
 
         assert!(buffer_with_header.len() > buffer_without_header.len());
     }
@@ -397,7 +400,7 @@ mod tests {
             input: Bytes::default(),
         };
 
-        assert!(tx_deposit.size() > tx_deposit.fields_len());
+        assert!(tx_deposit.size() > tx_deposit.rlp_encoded_fields_length());
     }
 
     #[test]
@@ -414,10 +417,10 @@ mod tests {
         };
 
         let mut buffer_with_header = BytesMut::new();
-        tx_deposit.encode_inner(&mut buffer_with_header, true);
+        tx_deposit.network_encode(&mut buffer_with_header);
 
         let mut buffer_without_header = BytesMut::new();
-        tx_deposit.encode_inner(&mut buffer_without_header, false);
+        tx_deposit.eip2718_encode(&mut buffer_without_header);
 
         assert!(buffer_with_header.len() > buffer_without_header.len());
     }
@@ -435,8 +438,8 @@ mod tests {
             input: Bytes::default(),
         };
 
-        let total_len = tx_deposit.encoded_len(true);
-        let len_without_header = tx_deposit.encoded_len(false);
+        let total_len = tx_deposit.network_encoded_length();
+        let len_without_header = tx_deposit.eip2718_encoded_length();
 
         assert!(total_len > len_without_header);
     }

--- a/crates/consensus/src/transaction/deposit.rs
+++ b/crates/consensus/src/transaction/deposit.rs
@@ -4,11 +4,17 @@ use super::OpTxType;
 use crate::DepositTransaction;
 use alloy_consensus::Transaction;
 use alloy_eips::eip2930::AccessList;
-use alloy_primitives::{Address, Bytes, ChainId, TxKind, B256, U256};
+use alloy_primitives::{Address, Bytes, ChainId, Signature, TxKind, B256, U256};
 use alloy_rlp::{
     Buf, BufMut, Decodable, Encodable, Error as DecodeError, Header, EMPTY_STRING_CODE,
 };
 use core::mem;
+
+/// Pre-bedrock system transactions were sent from the zero address as legacy transactions with an
+/// empty signature. This method returns an instance of such signature.
+pub fn optimism_deposit_tx_signature() -> Signature {
+    Signature::new(U256::ZERO, U256::ZERO, false)
+}
 
 /// Deposit transactions, also known as deposits are initiated on L1, and executed on L2.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]

--- a/crates/consensus/src/transaction/deposit.rs
+++ b/crates/consensus/src/transaction/deposit.rs
@@ -41,7 +41,7 @@ pub struct TxDeposit {
             default,
             with = "alloy_serde::quantity",
             rename = "isSystemTx",
-            skip_serializing_if = "std::ops::Not::not"
+            skip_serializing_if = "core::ops::Not::not"
         )
     )]
     pub is_system_transaction: bool,

--- a/crates/consensus/src/transaction/deposit.rs
+++ b/crates/consensus/src/transaction/deposit.rs
@@ -297,14 +297,7 @@ impl Encodable for TxDeposit {
 
 impl Decodable for TxDeposit {
     fn decode(data: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        let header = Header::decode(data)?;
-        let remaining_len = data.len();
-
-        if header.payload_length > remaining_len {
-            return Err(alloy_rlp::Error::InputTooShort);
-        }
-
-        Self::rlp_decode_fields(data)
+        Self::rlp_decode(data)
     }
 }
 

--- a/crates/consensus/src/transaction/deposit.rs
+++ b/crates/consensus/src/transaction/deposit.rs
@@ -4,7 +4,9 @@ use super::OpTxType;
 use crate::DepositTransaction;
 use alloy_consensus::Transaction;
 use alloy_eips::eip2930::AccessList;
-use alloy_primitives::{Address, Bytes, ChainId, PrimitiveSignature as Signature, TxKind, B256, U256};
+use alloy_primitives::{
+    Address, Bytes, ChainId, PrimitiveSignature as Signature, TxKind, B256, U256,
+};
 use alloy_rlp::{
     Buf, BufMut, Decodable, Encodable, Error as DecodeError, Header, EMPTY_STRING_CODE,
 };
@@ -39,7 +41,7 @@ pub struct TxDeposit {
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", rename = "gas"))]
     pub gas_limit: u64,
     /// Field indicating if this transaction is exempt from the L2 gas limit.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", rename = "isSystemTx"))]
+    #[cfg_attr(feature = "serde", serde(default, with = "alloy_serde::quantity", rename = "isSystemTx"))]
     pub is_system_transaction: bool,
     /// Input has two uses depending if transaction is Create or Call (if `to` field is None or
     /// Some).

--- a/crates/consensus/src/transaction/deposit.rs
+++ b/crates/consensus/src/transaction/deposit.rs
@@ -4,7 +4,7 @@ use super::OpTxType;
 use crate::DepositTransaction;
 use alloy_consensus::Transaction;
 use alloy_eips::eip2930::AccessList;
-use alloy_primitives::{Address, Bytes, ChainId, Signature, TxKind, B256, U256};
+use alloy_primitives::{Address, Bytes, ChainId, PrimitiveSignature as Signature, TxKind, B256, U256};
 use alloy_rlp::{
     Buf, BufMut, Decodable, Encodable, Error as DecodeError, Header, EMPTY_STRING_CODE,
 };

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -495,7 +495,7 @@ mod serde_from {
         Eip1559(Signed<TxEip1559>),
         #[serde(rename = "0x4", alias = "0x04")]
         Eip7702(Signed<TxEip7702>),
-        #[serde(rename = "0x7e", alias = "0x7E")]
+        #[serde(rename = "0x7e", alias = "0x7E", serialize_with = "crate::serde_deposit_tx_rpc")]
         Deposit(TxDeposit),
     }
 

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -90,6 +90,7 @@ impl TryFrom<u8> for OpTxType {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[cfg_attr(all(any(test, feature = "arbitrary"), feature = "k256"), derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum OpTxEnvelope {
     /// An untagged [`TxLegacy`].
@@ -112,7 +113,7 @@ pub enum OpTxEnvelope {
     #[cfg_attr(feature = "serde", serde(rename = "0x4", alias = "0x04"))]
     Eip7702(Signed<TxEip7702>),
     /// A [`TxDeposit`] tagged with type 0x7E.
-    #[cfg_attr(feature = "serde", serde(rename = "0x7E", alias = "0x7E"))]
+    #[cfg_attr(feature = "serde", serde(rename = "0x7e", alias = "0x7E"))]
     Deposit(TxDeposit),
 }
 

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1,11 +1,13 @@
-use alloy_consensus::{Signed, Transaction, TxEip1559, TxEip2930, TxEip7702, TxLegacy};
+use alloy_consensus::{
+    transaction::RlpEcdsaTx, Signed, Transaction, TxEip1559, TxEip2930, TxEip7702, TxLegacy,
+};
 use alloy_eips::{
     eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718},
     eip2930::AccessList,
     eip7702::SignedAuthorization,
 };
 use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
-use alloy_rlp::{Decodable, Encodable, Header};
+use alloy_rlp::{Decodable, Encodable};
 use derive_more::Display;
 
 use crate::TxDeposit;
@@ -91,7 +93,14 @@ impl TryFrom<u8> for OpTxType {
 #[non_exhaustive]
 pub enum OpTxEnvelope {
     /// An untagged [`TxLegacy`].
-    #[cfg_attr(feature = "serde", serde(rename = "0x0", alias = "0x00"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            rename = "0x0",
+            alias = "0x00",
+            with = "alloy_consensus::transaction::signed_legacy_serde"
+        )
+    )]
     Legacy(Signed<TxLegacy>),
     /// A [`TxEip2930`] tagged with type 1.
     #[cfg_attr(feature = "serde", serde(rename = "0x1", alias = "0x01"))]
@@ -376,39 +385,15 @@ impl OpTxEnvelope {
         }
     }
 
-    /// Return the length of the inner txn, __without a type byte__.
-    pub fn inner_length(&self) -> usize {
+    /// Return the length of the inner txn, including type byte length
+    pub fn eip2718_encoded_length(&self) -> usize {
         match self {
-            Self::Legacy(t) => t.tx().fields_len() + t.signature().rlp_vrs_len(),
-            Self::Eip2930(t) => {
-                let payload_length = t.tx().fields_len() + t.signature().rlp_vrs_len();
-                Header { list: true, payload_length }.length() + payload_length
-            }
-            Self::Eip1559(t) => {
-                let payload_length = t.tx().fields_len() + t.signature().rlp_vrs_len();
-                Header { list: true, payload_length }.length() + payload_length
-            }
-            Self::Eip7702(t) => {
-                let payload_length = t.tx().fields_len() + t.signature().rlp_vrs_len();
-                Header { list: true, payload_length }.length() + payload_length
-            }
-            Self::Deposit(t) => {
-                let payload_length = t.fields_len();
-                Header { list: true, payload_length }.length() + payload_length
-            }
+            Self::Legacy(t) => t.eip2718_encoded_length(),
+            Self::Eip2930(t) => t.eip2718_encoded_length(),
+            Self::Eip1559(t) => t.eip2718_encoded_length(),
+            Self::Eip7702(t) => t.eip2718_encoded_length(),
+            Self::Deposit(t) => t.eip2718_encoded_length(),
         }
-    }
-
-    /// Return the RLP payload length of the network-serialized wrapper
-    fn rlp_payload_length(&self) -> usize {
-        if let Self::Legacy(t) = self {
-            let payload_length = t.tx().fields_len() + t.signature().rlp_vrs_len();
-            return Header { list: true, payload_length }.length() + payload_length;
-        }
-        // length of inner tx body
-        let inner_length = self.inner_length();
-        // with tx type byte
-        inner_length + 1
     }
 }
 
@@ -418,34 +403,22 @@ impl Encodable for OpTxEnvelope {
     }
 
     fn length(&self) -> usize {
-        let mut payload_length = self.rlp_payload_length();
-        if !self.is_legacy() {
-            payload_length += Header { list: false, payload_length }.length();
-        }
-
-        payload_length
+        self.network_len()
     }
 }
 
 impl Decodable for OpTxEnvelope {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        match Self::network_decode(buf) {
-            Ok(t) => Ok(t),
-            Err(Eip2718Error::RlpError(e)) => Err(e),
-            Err(Eip2718Error::UnexpectedType(_)) => {
-                Err(alloy_rlp::Error::Custom("unexpected tx type"))
-            }
-            _ => Err(alloy_rlp::Error::Custom("unknown error decoding tx envelope")),
-        }
+        Ok(Self::network_decode(buf)?)
     }
 }
 
 impl Decodable2718 for OpTxEnvelope {
     fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
         match ty.try_into().map_err(|_| Eip2718Error::UnexpectedType(ty))? {
-            OpTxType::Eip2930 => Ok(Self::Eip2930(TxEip2930::decode_signed_fields(buf)?)),
-            OpTxType::Eip1559 => Ok(Self::Eip1559(TxEip1559::decode_signed_fields(buf)?)),
-            OpTxType::Eip7702 => Ok(Self::Eip7702(TxEip7702::decode_signed_fields(buf)?)),
+            OpTxType::Eip2930 => Ok(Self::Eip2930(TxEip2930::rlp_decode_signed(buf)?)),
+            OpTxType::Eip1559 => Ok(Self::Eip1559(TxEip1559::rlp_decode_signed(buf)?)),
+            OpTxType::Eip7702 => Ok(Self::Eip7702(TxEip7702::rlp_decode_signed(buf)?)),
             OpTxType::Deposit => Ok(Self::Deposit(TxDeposit::decode(buf)?)),
             OpTxType::Legacy => {
                 Err(alloy_rlp::Error::Custom("type-0 eip2718 transactions are not supported")
@@ -455,7 +428,7 @@ impl Decodable2718 for OpTxEnvelope {
     }
 
     fn fallback_decode(buf: &mut &[u8]) -> Eip2718Result<Self> {
-        Ok(Self::Legacy(TxLegacy::decode_signed_fields(buf)?))
+        Ok(Self::Legacy(TxLegacy::rlp_decode_signed(buf)?))
     }
 }
 
@@ -471,24 +444,24 @@ impl Encodable2718 for OpTxEnvelope {
     }
 
     fn encode_2718_len(&self) -> usize {
-        self.inner_length() + !self.is_legacy() as usize
+        self.eip2718_encoded_length()
     }
 
     fn encode_2718(&self, out: &mut dyn alloy_rlp::BufMut) {
         match self {
             // Legacy transactions have no difference between network and 2718
-            Self::Legacy(tx) => tx.tx().encode_with_signature_fields(tx.signature(), out),
+            Self::Legacy(tx) => tx.eip2718_encode(out),
             Self::Eip2930(tx) => {
-                tx.tx().encode_with_signature(tx.signature(), out, false);
+                tx.eip2718_encode(out);
             }
             Self::Eip1559(tx) => {
-                tx.tx().encode_with_signature(tx.signature(), out, false);
+                tx.eip2718_encode(out);
             }
             Self::Eip7702(tx) => {
-                tx.tx().encode_with_signature(tx.signature(), out, false);
+                tx.eip2718_encode(out);
             }
             Self::Deposit(tx) => {
-                tx.encode_inner(out, false);
+                tx.eip2718_encode(out);
             }
         }
     }

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -1,7 +1,7 @@
 //! Tramsaction types for Optimism.
 
 mod deposit;
-pub use deposit::TxDeposit;
+pub use deposit::{optimism_deposit_tx_signature, TxDeposit};
 
 mod envelope;
 pub use envelope::{OpTxEnvelope, OpTxType, DEPOSIT_TX_TYPE_ID};

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -1,7 +1,7 @@
 //! Tramsaction types for Optimism.
 
 mod deposit;
-pub use deposit::{optimism_deposit_tx_signature, TxDeposit};
+pub use deposit::TxDeposit;
 
 mod envelope;
 pub use envelope::{OpTxEnvelope, OpTxType, DEPOSIT_TX_TYPE_ID};
@@ -14,6 +14,9 @@ pub use source::{
     DepositSourceDomain, DepositSourceDomainIdentifier, L1InfoDepositSource, UpgradeDepositSource,
     UserDepositSource,
 };
+
+#[cfg(feature = "serde")]
+pub use deposit::serde_deposit_tx_rpc;
 
 /// Bincode-compatible serde implementations for transaction types.
 #[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -14,22 +14,23 @@ use alloy_primitives::{Address, Bytes, TxKind};
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[cfg_attr(
+    feature = "serde",
+    serde(
+        from = "serde_from::MaybeTaggedTypedTransaction",
+        into = "serde_from::TaggedTypedTransaction"
+    )
+)]
 pub enum OpTypedTransaction {
     /// Legacy transaction
-    #[cfg_attr(feature = "serde", serde(rename = "0x00", alias = "0x0"))]
     Legacy(TxLegacy),
     /// EIP-2930 transaction
-    #[cfg_attr(feature = "serde", serde(rename = "0x01", alias = "0x1"))]
     Eip2930(TxEip2930),
     /// EIP-1559 transaction
-    #[cfg_attr(feature = "serde", serde(rename = "0x02", alias = "0x2"))]
     Eip1559(TxEip1559),
     /// EIP-7702 transaction
-    #[cfg_attr(feature = "serde", serde(rename = "0x04", alias = "0x4"))]
     Eip7702(TxEip7702),
     /// Optimism deposit transaction
-    #[cfg_attr(feature = "serde", serde(rename = "0x7e", alias = "0x7E"))]
     Deposit(TxDeposit),
 }
 
@@ -272,6 +273,82 @@ impl Transaction for OpTypedTransaction {
             Self::Eip1559(tx) => tx.authorization_list(),
             Self::Eip7702(tx) => tx.authorization_list(),
             Self::Deposit(tx) => tx.authorization_list(),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+mod serde_from {
+    //! NB: Why do we need this?
+    //!
+    //! Because the tag may be missing, we need an abstraction over tagged (with
+    //! type) and untagged (always legacy). This is
+    //! [`MaybeTaggedTypedTransaction`].
+    //!
+    //! The tagged variant is [`TaggedTypedTransaction`], which always has a
+    //! type tag.
+    //!
+    //! We serialize via [`TaggedTypedTransaction`] and deserialize via
+    //! [`MaybeTaggedTypedTransaction`].
+    use super::*;
+
+    #[derive(Debug, serde::Deserialize)]
+    #[serde(untagged)]
+    pub(crate) enum MaybeTaggedTypedTransaction {
+        Tagged(TaggedTypedTransaction),
+        Untagged(TxLegacy),
+    }
+
+    #[derive(Debug, serde::Serialize, serde::Deserialize)]
+    #[serde(tag = "type")]
+    pub(crate) enum TaggedTypedTransaction {
+        /// Legacy transaction
+        #[serde(rename = "0x00", alias = "0x0")]
+        Legacy(TxLegacy),
+        /// EIP-2930 transaction
+        #[serde(rename = "0x01", alias = "0x1")]
+        Eip2930(TxEip2930),
+        /// EIP-1559 transaction
+        #[serde(rename = "0x02", alias = "0x2")]
+        Eip1559(TxEip1559),
+        /// EIP-7702 transaction
+        #[serde(rename = "0x04", alias = "0x4")]
+        Eip7702(TxEip7702),
+        /// Deposit transaction
+        #[serde(rename = "0x7e", alias = "0x7E")]
+        Deposit(TxDeposit),
+    }
+
+    impl From<MaybeTaggedTypedTransaction> for OpTypedTransaction {
+        fn from(value: MaybeTaggedTypedTransaction) -> Self {
+            match value {
+                MaybeTaggedTypedTransaction::Tagged(tagged) => tagged.into(),
+                MaybeTaggedTypedTransaction::Untagged(tx) => Self::Legacy(tx),
+            }
+        }
+    }
+
+    impl From<TaggedTypedTransaction> for OpTypedTransaction {
+        fn from(value: TaggedTypedTransaction) -> Self {
+            match value {
+                TaggedTypedTransaction::Legacy(signed) => Self::Legacy(signed),
+                TaggedTypedTransaction::Eip2930(signed) => Self::Eip2930(signed),
+                TaggedTypedTransaction::Eip1559(signed) => Self::Eip1559(signed),
+                TaggedTypedTransaction::Eip7702(signed) => Self::Eip7702(signed),
+                TaggedTypedTransaction::Deposit(tx) => Self::Deposit(tx)
+            }
+        }
+    }
+
+    impl From<OpTypedTransaction> for TaggedTypedTransaction {
+        fn from(value: OpTypedTransaction) -> Self {
+            match value {
+                OpTypedTransaction::Legacy(signed) => Self::Legacy(signed),
+                OpTypedTransaction::Eip2930(signed) => Self::Eip2930(signed),
+                OpTypedTransaction::Eip1559(signed) => Self::Eip1559(signed),
+                OpTypedTransaction::Eip7702(signed) => Self::Eip7702(signed),
+                OpTypedTransaction::Deposit(tx) => Self::Deposit(tx),
+            }
         }
     }
 }

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -29,7 +29,7 @@ pub enum OpTypedTransaction {
     #[cfg_attr(feature = "serde", serde(rename = "0x04", alias = "0x4"))]
     Eip7702(TxEip7702),
     /// Optimism deposit transaction
-    #[cfg_attr(feature = "serde", serde(rename = "0x7E", alias = "0x7E"))]
+    #[cfg_attr(feature = "serde", serde(rename = "0x7e", alias = "0x7E"))]
     Deposit(TxDeposit),
 }
 

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -335,7 +335,7 @@ mod serde_from {
                 TaggedTypedTransaction::Eip2930(signed) => Self::Eip2930(signed),
                 TaggedTypedTransaction::Eip1559(signed) => Self::Eip1559(signed),
                 TaggedTypedTransaction::Eip7702(signed) => Self::Eip7702(signed),
-                TaggedTypedTransaction::Deposit(tx) => Self::Deposit(tx)
+                TaggedTypedTransaction::Deposit(tx) => Self::Deposit(tx),
             }
         }
     }

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -315,7 +315,7 @@ mod serde_from {
         #[serde(rename = "0x04", alias = "0x4")]
         Eip7702(TxEip7702),
         /// Deposit transaction
-        #[serde(rename = "0x7e", alias = "0x7E")]
+        #[serde(rename = "0x7e", alias = "0x7E", serialize_with = "crate::serde_deposit_tx_rpc")]
         Deposit(TxDeposit),
     }
 

--- a/crates/protocol/src/batch/raw.rs
+++ b/crates/protocol/src/batch/raw.rs
@@ -93,9 +93,6 @@ impl RawSpanBatch {
             }
         }
 
-        // Recover `v` values in transaction signatures within the batch.
-        self.payload.txs.recover_v(chain_id)?;
-
         // Get all transactions in the batch.
         let enveloped_txs = self.payload.txs.full_txs(chain_id)?;
 
@@ -165,8 +162,7 @@ mod test {
     fn test_decode_encode_raw_span_batch() {
         // Load in the raw span batch from the `op-node` derivation pipeline implementation.
         let raw_span_batch_hex = include_bytes!("./testdata/raw_batch.hex");
-        let mut raw_span_batch = RawSpanBatch::decode(&mut raw_span_batch_hex.as_slice()).unwrap();
-        raw_span_batch.payload.txs.recover_v(981).unwrap();
+        let raw_span_batch = RawSpanBatch::decode(&mut raw_span_batch_hex.as_slice()).unwrap();
 
         let mut encoding_buf = Vec::new();
         raw_span_batch.encode(&mut encoding_buf).unwrap();

--- a/crates/protocol/src/batch/transactions.rs
+++ b/crates/protocol/src/batch/transactions.rs
@@ -8,7 +8,7 @@ use crate::{
 use alloc::vec::Vec;
 use alloy_consensus::{Transaction, TxEnvelope, TxType};
 use alloy_eips::eip2718::Encodable2718;
-use alloy_primitives::{Address, Bytes, Signature, U256};
+use alloy_primitives::{Address, Bytes, PrimitiveSignature as Signature, U256};
 use alloy_rlp::{Buf, Decodable, Encodable};
 
 /// This struct contains the decoded information for transactions in a span batch.
@@ -342,7 +342,7 @@ impl SpanBatchTransactions {
 mod tests {
     use super::*;
     use alloy_consensus::{Signed, TxEip1559, TxEip2930};
-    use alloy_primitives::{address, Signature, TxKind};
+    use alloy_primitives::{address, PrimitiveSignature as Signature, TxKind};
 
     #[test]
     fn test_span_batch_transactions_add_empty_txs() {

--- a/crates/protocol/src/batch/transactions.rs
+++ b/crates/protocol/src/batch/transactions.rs
@@ -341,7 +341,7 @@ impl SpanBatchTransactions {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_consensus::{Signed, TxEip1559, TxEip2930, TxLegacy};
+    use alloy_consensus::{Signed, TxEip1559, TxEip2930};
     use alloy_primitives::{address, Signature, TxKind};
 
     #[test]

--- a/crates/protocol/src/batch/transactions.rs
+++ b/crates/protocol/src/batch/transactions.rs
@@ -355,24 +355,6 @@ mod tests {
     }
 
     #[test]
-    fn test_span_batch_transactions_add_invalid_legacy_parity_decoding() {
-        let sig = Signature::test_signature();
-        let to = address!("0123456789012345678901234567890123456789");
-        let tx = TxEnvelope::Legacy(Signed::new_unchecked(
-            TxLegacy { to: TxKind::Call(to), ..Default::default() },
-            sig,
-            Default::default(),
-        ));
-        let mut span_batch_txs = SpanBatchTransactions::default();
-        let mut buf = vec![];
-        tx.encode(&mut buf);
-        let txs = vec![Bytes::from(buf)];
-        let chain_id = 1;
-        let err = span_batch_txs.add_txs(txs, chain_id).unwrap_err();
-        assert_eq!(err, SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData));
-    }
-
-    #[test]
     fn test_span_batch_transactions_add_eip2930_tx_wrong_chain_id() {
         let sig = Signature::test_signature();
         let to = address!("0123456789012345678901234567890123456789");

--- a/crates/protocol/src/batch/transactions.rs
+++ b/crates/protocol/src/batch/transactions.rs
@@ -2,13 +2,13 @@
 //! transactions in a span batch.
 
 use crate::{
-    is_protected_v, read_tx_data, SpanBatchBits, SpanBatchError, SpanBatchTransactionData,
-    SpanDecodingError, MAX_SPAN_BATCH_ELEMENTS,
+    read_tx_data, SpanBatchBits, SpanBatchError, SpanBatchTransactionData, SpanDecodingError,
+    MAX_SPAN_BATCH_ELEMENTS,
 };
 use alloc::vec::Vec;
 use alloy_consensus::{Transaction, TxEnvelope, TxType};
 use alloy_eips::eip2718::Encodable2718;
-use alloy_primitives::{Address, Bytes, Parity, Signature, U256};
+use alloy_primitives::{Address, Bytes, Signature, U256};
 use alloy_rlp::{Buf, Decodable, Encodable};
 
 /// This struct contains the decoded information for transactions in a span batch.
@@ -18,8 +18,6 @@ pub struct SpanBatchTransactions {
     pub total_block_tx_count: u64,
     /// The contract creation bits, standard span-batch bitlist.
     pub contract_creation_bits: SpanBatchBits,
-    /// The y parity bits, standard span-batch bitlist.
-    pub y_parity_bits: SpanBatchBits,
     /// The transaction signatures.
     pub tx_sigs: Vec<Signature>,
     /// The transaction nonces
@@ -42,8 +40,7 @@ impl SpanBatchTransactions {
     /// Encodes the [SpanBatchTransactions] into a writer.
     pub fn encode(&self, w: &mut Vec<u8>) -> Result<(), SpanBatchError> {
         self.encode_contract_creation_bits(w)?;
-        self.encode_y_parity_bits(w)?;
-        self.encode_tx_sigs_rs(w)?;
+        self.encode_tx_sigs(w)?;
         self.encode_tx_tos(w)?;
         self.encode_tx_datas(w)?;
         self.encode_tx_nonces(w)?;
@@ -55,8 +52,7 @@ impl SpanBatchTransactions {
     /// Decodes the [SpanBatchTransactions] from a reader.
     pub fn decode(&mut self, r: &mut &[u8]) -> Result<(), SpanBatchError> {
         self.decode_contract_creation_bits(r)?;
-        self.decode_y_parity_bits(r)?;
-        self.decode_tx_sigs_rs(r)?;
+        self.decode_tx_sigs(r)?;
         self.decode_tx_tos(r)?;
         self.decode_tx_datas(r)?;
         self.decode_tx_nonces(r)?;
@@ -77,14 +73,14 @@ impl SpanBatchTransactions {
         Ok(())
     }
 
-    /// Encode the y parity bits into a writer.
-    pub fn encode_y_parity_bits(&self, w: &mut Vec<u8>) -> Result<(), SpanBatchError> {
-        SpanBatchBits::encode(w, self.total_block_tx_count as usize, &self.y_parity_bits)?;
-        Ok(())
-    }
-
     /// Encode the transaction signatures into a writer (excluding `v` field).
-    pub fn encode_tx_sigs_rs(&self, w: &mut Vec<u8>) -> Result<(), SpanBatchError> {
+    pub fn encode_tx_sigs(&self, w: &mut Vec<u8>) -> Result<(), SpanBatchError> {
+        let mut y_parity_bits = SpanBatchBits::default();
+        for (i, sig) in self.tx_sigs.iter().enumerate() {
+            y_parity_bits.set_bit(i, sig.v());
+        }
+
+        SpanBatchBits::encode(w, self.total_block_tx_count as usize, &y_parity_bits)?;
         for sig in &self.tx_sigs {
             w.extend_from_slice(&sig.r().to_be_bytes::<32>());
             w.extend_from_slice(&sig.s().to_be_bytes::<32>());
@@ -148,19 +144,14 @@ impl SpanBatchTransactions {
         Ok(())
     }
 
-    /// Decode the y parity bits from a reader.
-    pub fn decode_y_parity_bits(&mut self, r: &mut &[u8]) -> Result<(), SpanBatchError> {
-        self.y_parity_bits = SpanBatchBits::decode(r, self.total_block_tx_count as usize)?;
-        Ok(())
-    }
-
     /// Decode the transaction signatures from a reader (excluding `v` field).
-    pub fn decode_tx_sigs_rs(&mut self, r: &mut &[u8]) -> Result<(), SpanBatchError> {
+    pub fn decode_tx_sigs(&mut self, r: &mut &[u8]) -> Result<(), SpanBatchError> {
+        let y_parity_bits = SpanBatchBits::decode(r, self.total_block_tx_count as usize)?;
         let mut sigs = Vec::with_capacity(self.total_block_tx_count as usize);
-        for _ in 0..self.total_block_tx_count {
+        for y_parity in y_parity_bits.as_ref() {
             let r_val = U256::from_be_slice(&r[..32]);
             let s_val = U256::from_be_slice(&r[32..64]);
-            sigs.push(Signature::new(r_val, s_val, Parity::Eip155(0)));
+            sigs.push(Signature::new(r_val, s_val, *y_parity == 1));
             r.advance(64);
         }
         self.tx_sigs = sigs;
@@ -233,35 +224,6 @@ impl SpanBatchTransactions {
         self.contract_creation_bits.as_ref().iter().map(|b| b.count_ones() as u64).sum()
     }
 
-    /// Recover the `v` values of the transaction signatures.
-    pub fn recover_v(&mut self, chain_id: u64) -> Result<(), SpanBatchError> {
-        if self.tx_sigs.len() != self.tx_types.len() {
-            return Err(SpanBatchError::Decoding(SpanDecodingError::TypeSignatureLenMismatch));
-        }
-        let mut protected_bits_idx = 0;
-        for (i, tx_type) in self.tx_types.iter().enumerate() {
-            let bit = self.y_parity_bits.get_bit(i).ok_or(SpanBatchError::BitfieldTooLong)?;
-            let v = match tx_type {
-                TxType::Legacy => {
-                    // Legacy transaction
-                    let protected_bit = self.protected_bits.get_bit(protected_bits_idx);
-                    protected_bits_idx += 1;
-                    if protected_bit.is_none() || protected_bit.is_some_and(|b| b == 0) {
-                        Ok(27 + bit as u64)
-                    } else {
-                        // EIP-155
-                        Ok(chain_id * 2 + 35 + bit as u64)
-                    }
-                }
-                TxType::Eip2930 | TxType::Eip1559 => Ok(bit as u64),
-                _ => Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionType)),
-            }?;
-            self.tx_sigs[i] =
-                Signature::new(self.tx_sigs[i].r(), self.tx_sigs[i].s(), Parity::Eip155(v));
-        }
-        Ok(())
-    }
-
     /// Retrieve all of the raw transactions from the [SpanBatchTransactions].
     pub fn full_txs(&self, chain_id: u64) -> Result<Vec<Vec<u8>>, SpanBatchError> {
         let mut txs = Vec::new();
@@ -297,7 +259,12 @@ impl SpanBatchTransactions {
                 .tx_sigs
                 .get(idx as usize)
                 .ok_or(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData))?;
-            let tx_envelope = tx.to_enveloped_tx(*nonce, *gas, to, chain_id, sig)?;
+            let is_protected = self
+                .protected_bits
+                .get_bit(idx as usize)
+                .ok_or(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData))?
+                == 1;
+            let tx_envelope = tx.to_enveloped_tx(*nonce, *gas, to, chain_id, sig, is_protected)?;
             let mut buf = Vec::new();
             tx_envelope.encode_2718(&mut buf);
             txs.push(buf);
@@ -317,7 +284,7 @@ impl SpanBatchTransactions {
 
             let tx_type = tx_enveloped.tx_type();
             if matches!(tx_type, TxType::Legacy) {
-                let protected_bit = is_protected_v(&tx_enveloped);
+                let protected_bit = tx_enveloped.is_replay_protected();
                 self.protected_bits.set_bit(self.legacy_tx_count as usize, protected_bit);
                 self.legacy_tx_count += 1;
             }
@@ -340,7 +307,7 @@ impl SpanBatchTransactions {
                 }
             };
 
-            if is_protected_v(&tx_enveloped)
+            if tx_enveloped.is_replay_protected()
                 && tx_chain_id
                     .ok_or(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData))?
                     != chain_id
@@ -348,7 +315,6 @@ impl SpanBatchTransactions {
                 return Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData));
             }
 
-            let y_parity = signature.v().y_parity();
             let contract_creation_bit = match to {
                 Some(address) => {
                     self.tx_tos.push(address);
@@ -361,7 +327,6 @@ impl SpanBatchTransactions {
 
             self.tx_sigs.push(*signature);
             self.contract_creation_bits.set_bit((i + offset) as usize, contract_creation_bit == 1);
-            self.y_parity_bits.set_bit((i + offset) as usize, y_parity);
             self.tx_nonces.push(nonce);
             self.tx_datas.push(tx_data_buf);
             self.tx_gases.push(gas);

--- a/crates/protocol/src/batch/transactions.rs
+++ b/crates/protocol/src/batch/transactions.rs
@@ -148,10 +148,11 @@ impl SpanBatchTransactions {
     pub fn decode_tx_sigs(&mut self, r: &mut &[u8]) -> Result<(), SpanBatchError> {
         let y_parity_bits = SpanBatchBits::decode(r, self.total_block_tx_count as usize)?;
         let mut sigs = Vec::with_capacity(self.total_block_tx_count as usize);
-        for y_parity in y_parity_bits.as_ref() {
+        for i in 0..self.total_block_tx_count {
+            let y_parity = y_parity_bits.get_bit(i as usize).expect("same length");
             let r_val = U256::from_be_slice(&r[..32]);
             let s_val = U256::from_be_slice(&r[32..64]);
-            sigs.push(Signature::new(r_val, s_val, *y_parity == 1));
+            sigs.push(Signature::new(r_val, s_val, y_parity == 1));
             r.advance(64);
         }
         self.tx_sigs = sigs;

--- a/crates/protocol/src/batch/tx_data/eip1559.rs
+++ b/crates/protocol/src/batch/tx_data/eip1559.rs
@@ -3,7 +3,7 @@
 use crate::{SpanBatchError, SpanDecodingError};
 use alloy_consensus::{SignableTransaction, Signed, TxEip1559};
 use alloy_eips::eip2930::AccessList;
-use alloy_primitives::{Address, Signature, TxKind, U256};
+use alloy_primitives::{Address, PrimitiveSignature as Signature, TxKind, U256};
 use alloy_rlp::{Bytes, RlpDecodable, RlpEncodable};
 use op_alloy_consensus::OpTxEnvelope;
 

--- a/crates/protocol/src/batch/tx_data/eip2930.rs
+++ b/crates/protocol/src/batch/tx_data/eip2930.rs
@@ -3,7 +3,7 @@
 use crate::{SpanBatchError, SpanDecodingError};
 use alloy_consensus::{SignableTransaction, Signed, TxEip2930};
 use alloy_eips::eip2930::AccessList;
-use alloy_primitives::{Address, Signature, TxKind, U256};
+use alloy_primitives::{Address, PrimitiveSignature as Signature, TxKind, U256};
 use alloy_rlp::{Bytes, RlpDecodable, RlpEncodable};
 use op_alloy_consensus::OpTxEnvelope;
 

--- a/crates/protocol/src/batch/tx_data/legacy.rs
+++ b/crates/protocol/src/batch/tx_data/legacy.rs
@@ -2,7 +2,7 @@
 
 use crate::{SpanBatchError, SpanDecodingError};
 use alloy_consensus::{SignableTransaction, Signed, TxLegacy};
-use alloy_primitives::{Address, Signature, TxKind, U256};
+use alloy_primitives::{Address, PrimitiveSignature as Signature, TxKind, U256};
 use alloy_rlp::{Bytes, RlpDecodable, RlpEncodable};
 use op_alloy_consensus::OpTxEnvelope;
 

--- a/crates/protocol/src/batch/tx_data/legacy.rs
+++ b/crates/protocol/src/batch/tx_data/legacy.rs
@@ -26,9 +26,10 @@ impl SpanBatchLegacyTransactionData {
         to: Option<Address>,
         chain_id: u64,
         signature: Signature,
+        is_protected: bool,
     ) -> Result<OpTxEnvelope, SpanBatchError> {
         let legacy_tx = TxLegacy {
-            chain_id: Some(chain_id),
+            chain_id: is_protected.then_some(chain_id),
             nonce,
             gas_price: u128::from_be_bytes(
                 self.gas_price.to_be_bytes::<32>()[16..].try_into().map_err(|_| {

--- a/crates/protocol/src/batch/tx_data/wrapper.rs
+++ b/crates/protocol/src/batch/tx_data/wrapper.rs
@@ -122,9 +122,12 @@ impl SpanBatchTransactionData {
         to: Option<Address>,
         chain_id: u64,
         signature: Signature,
+        is_protected: bool,
     ) -> Result<OpTxEnvelope, SpanBatchError> {
         match self {
-            Self::Legacy(data) => data.to_enveloped_tx(nonce, gas, to, chain_id, signature),
+            Self::Legacy(data) => {
+                data.to_enveloped_tx(nonce, gas, to, chain_id, signature, is_protected)
+            }
             Self::Eip2930(data) => data.to_enveloped_tx(nonce, gas, to, chain_id, signature),
             Self::Eip1559(data) => data.to_enveloped_tx(nonce, gas, to, chain_id, signature),
         }

--- a/crates/protocol/src/batch/tx_data/wrapper.rs
+++ b/crates/protocol/src/batch/tx_data/wrapper.rs
@@ -1,7 +1,7 @@
 //! This module contains the top level span batch transaction data type.
 
 use alloy_consensus::{Transaction, TxEnvelope, TxType};
-use alloy_primitives::{Address, Signature, U256};
+use alloy_primitives::{Address, PrimitiveSignature as Signature, U256};
 use alloy_rlp::{Bytes, Decodable, Encodable};
 use op_alloy_consensus::OpTxEnvelope;
 

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -34,10 +34,7 @@ mod iter;
 pub use iter::FrameIter;
 
 mod utils;
-pub use utils::{
-    is_protected_v, read_tx_data, starts_with_2718_deposit, to_system_config,
-    OpBlockConversionError,
-};
+pub use utils::{read_tx_data, starts_with_2718_deposit, to_system_config, OpBlockConversionError};
 
 mod channel;
 pub use channel::{

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -55,6 +55,7 @@ arbitrary = [
   "dep:arbitrary",
   "alloy-primitives/arbitrary",
   "alloy-rpc-types-eth/arbitrary",
+  "op-alloy-consensus/arbitrary",
 ]
 k256 = [
   "alloy-rpc-types-eth/k256",

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -21,7 +21,6 @@ op-alloy-consensus = { workspace = true, features = ["serde"] }
 # Alloy
 alloy-serde.workspace = true
 alloy-consensus.workspace = true
-alloy-network.workspace = true
 alloy-network-primitives.workspace = true
 alloy-eips = { workspace = true, features = ["serde"] }
 alloy-rpc-types-eth = { workspace = true, features = ["serde"] }
@@ -59,4 +58,5 @@ arbitrary = [
 ]
 k256 = [
   "alloy-consensus/k256",
+  "alloy-rpc-types-eth/k256",
 ]

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -57,6 +57,6 @@ arbitrary = [
   "alloy-rpc-types-eth/arbitrary",
 ]
 k256 = [
-  "alloy-consensus/k256",
   "alloy-rpc-types-eth/k256",
+  "op-alloy-consensus/k256",
 ]

--- a/crates/rpc-types/src/transaction.rs
+++ b/crates/rpc-types/src/transaction.rs
@@ -162,6 +162,7 @@ mod tx_serde {
     /// field if inner [`OpTxEnvelope`] did not consume it.
     #[derive(Serialize, Deserialize)]
     struct MaybeFrom {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         from: Option<Address>,
     }
 

--- a/crates/rpc-types/src/transaction.rs
+++ b/crates/rpc-types/src/transaction.rs
@@ -1,9 +1,8 @@
 //! Optimism specific types related to transactions.
 
-use alloc::string::{String, ToString};
 use alloy_consensus::{
-    SignableTransaction, Transaction as ConsensusTransaction, TxEip1559, TxEip2930, TxEip7702,
-    TxLegacy,
+    Transaction as ConsensusTransaction, TxEip1559, TxEip2930, TxEip7702,
+
 };
 use alloy_eips::{eip2718::Eip2718Error, eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{Address, BlockHash, Bytes, ChainId, SignatureError, TxKind, B256, U256};
@@ -15,23 +14,13 @@ mod request;
 pub use request::OpTransactionRequest;
 
 /// OP Transaction type
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Transaction {
     /// Ethereum Transaction Types
     #[serde(flatten)]
-    pub inner: alloy_rpc_types_eth::Transaction,
-    /// The ETH value to mint on L2
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
-    pub mint: Option<u128>,
-    /// Hash that uniquely identifies the source of the deposit.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source_hash: Option<B256>,
-    /// Field indicating whether the transaction is a system transaction, and therefore
-    /// exempt from the L2 gas limit.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub is_system_tx: Option<bool>,
+    pub inner: alloy_rpc_types_eth::Transaction<OpTxEnvelope>,
+
     /// Deposit receipt version for deposit transactions post-canyon
     #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub deposit_receipt_version: Option<u64>,
@@ -155,149 +144,8 @@ impl From<OpTransactionFields> for OtherFields {
     }
 }
 
-/// Errors that can occur when converting a [Transaction] to an [OpTxEnvelope].
-#[derive(Debug)]
-pub enum TransactionConversionError {
-    /// The transaction type is not supported.
-    UnsupportedTransactionType(Eip2718Error),
-    /// The transaction's signature could not be converted to the consensus type.
-    SignatureConversionError(SignatureError),
-    /// The transaction is missing a required field.
-    MissingRequiredField(String),
-    /// The transaction's signature is missing.
-    MissingSignature,
-}
-
-impl core::fmt::Display for TransactionConversionError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::UnsupportedTransactionType(e) => {
-                write!(f, "Unsupported transaction type: {}", e)
-            }
-            Self::SignatureConversionError(e) => {
-                write!(f, "Signature conversion error: {}", e)
-            }
-            Self::MissingRequiredField(field) => {
-                write!(f, "Missing required field for conversion: {}", field)
-            }
-            Self::MissingSignature => {
-                write!(f, "Missing signature")
-            }
-        }
-    }
-}
-
-impl core::error::Error for TransactionConversionError {}
-
-impl TryFrom<Transaction> for OpTxEnvelope {
-    type Error = TransactionConversionError;
-
-    fn try_from(value: Transaction) -> Result<Self, Self::Error> {
-        /// Helper function to extract the signature from an RPC [Transaction].
-        #[inline(always)]
-        fn extract_signature(
-            value: &Transaction,
-        ) -> Result<alloy_primitives::Signature, TransactionConversionError> {
-            value
-                .inner
-                .signature
-                .ok_or(TransactionConversionError::MissingSignature)?
-                .try_into()
-                .map_err(TransactionConversionError::SignatureConversionError)
-        }
-
-        let ty = OpTxType::try_from(value.ty())
-            .map_err(TransactionConversionError::UnsupportedTransactionType)?;
-        match ty {
-            OpTxType::Legacy => {
-                let signature = extract_signature(&value)?;
-                let legacy = TxLegacy {
-                    chain_id: value.chain_id(),
-                    nonce: value.nonce(),
-                    gas_price: value.gas_price().unwrap_or_default(),
-                    gas_limit: value.gas_limit(),
-                    to: value.inner.to.map(TxKind::Call).unwrap_or(TxKind::Create),
-                    value: value.value(),
-                    input: value.inner.input,
-                };
-                Ok(Self::Legacy(legacy.into_signed(signature)))
-            }
-            OpTxType::Eip2930 => {
-                let signature = extract_signature(&value)?;
-                let access_list_tx = TxEip2930 {
-                    chain_id: value.chain_id().ok_or_else(|| {
-                        TransactionConversionError::MissingRequiredField("chain_id".to_string())
-                    })?,
-                    nonce: value.nonce(),
-                    gas_price: value.gas_price().unwrap_or_default(),
-                    gas_limit: value.gas_limit(),
-                    to: value.inner.to.map(TxKind::Call).unwrap_or(TxKind::Create),
-                    value: value.value(),
-                    input: value.inner.input,
-                    access_list: value.inner.access_list.unwrap_or_default(),
-                };
-                Ok(Self::Eip2930(access_list_tx.into_signed(signature)))
-            }
-            OpTxType::Eip1559 => {
-                let signature = extract_signature(&value)?;
-                let dynamic_fee_tx = TxEip1559 {
-                    chain_id: value.chain_id().ok_or_else(|| {
-                        TransactionConversionError::MissingRequiredField("chain_id".to_string())
-                    })?,
-                    nonce: value.nonce(),
-                    gas_limit: value.gas_limit(),
-                    to: value.inner.to.map(TxKind::Call).unwrap_or(TxKind::Create),
-                    value: value.value(),
-                    input: value.inner.input,
-                    access_list: value.inner.access_list.unwrap_or_default(),
-                    max_fee_per_gas: value.inner.max_fee_per_gas.unwrap_or_default(),
-                    max_priority_fee_per_gas: value
-                        .inner
-                        .max_priority_fee_per_gas
-                        .unwrap_or_default(),
-                };
-                Ok(Self::Eip1559(dynamic_fee_tx.into_signed(signature)))
-            }
-            OpTxType::Eip7702 => {
-                let signature = extract_signature(&value)?;
-                let set_code_tx = TxEip7702 {
-                    chain_id: value.chain_id().ok_or_else(|| {
-                        TransactionConversionError::MissingRequiredField("chain_id".to_string())
-                    })?,
-                    nonce: value.nonce(),
-                    gas_limit: value.gas_limit(),
-                    to: value.inner.to.ok_or_else(|| {
-                        TransactionConversionError::MissingRequiredField("to".to_string())
-                    })?,
-                    value: value.value(),
-                    input: value.inner.input,
-                    access_list: value.inner.access_list.unwrap_or_default(),
-                    max_fee_per_gas: value.inner.max_fee_per_gas.unwrap_or_default(),
-                    max_priority_fee_per_gas: value
-                        .inner
-                        .max_priority_fee_per_gas
-                        .unwrap_or_default(),
-                    authorization_list: value.inner.authorization_list.unwrap_or_default(),
-                };
-                Ok(Self::Eip7702(set_code_tx.into_signed(signature)))
-            }
-            OpTxType::Deposit => {
-                let deposit_tx = TxDeposit {
-                    source_hash: value.source_hash.ok_or_else(|| {
-                        TransactionConversionError::MissingRequiredField("source_hash".to_string())
-                    })?,
-                    from: value.inner.from,
-                    to: value.inner.to.map(TxKind::Call).unwrap_or(TxKind::Create),
-                    mint: value.mint,
-                    value: value.inner.value,
-                    gas_limit: value.gas_limit(),
-                    is_system_transaction: value.is_system_tx.ok_or_else(|| {
-                        TransactionConversionError::MissingRequiredField("is_system_tx".to_string())
-                    })?,
-                    input: value.inner.input,
-                };
-                Ok(Self::Deposit(deposit_tx))
-            }
-        }
+impl AsRef<OpTxEnvelope> for Transaction {
+    fn as_ref(&self) -> &OpTxEnvelope {
+        self.inner.as_ref()
     }
 }

--- a/crates/rpc-types/src/transaction.rs
+++ b/crates/rpc-types/src/transaction.rs
@@ -1,28 +1,26 @@
 //! Optimism specific types related to transactions.
 
-use alloy_consensus::{
-    Transaction as ConsensusTransaction, TxEip1559, TxEip2930, TxEip7702,
-
-};
-use alloy_eips::{eip2718::Eip2718Error, eip2930::AccessList, eip7702::SignedAuthorization};
-use alloy_primitives::{Address, BlockHash, Bytes, ChainId, SignatureError, TxKind, B256, U256};
+use alloy_consensus::Transaction as ConsensusTransaction;
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
+use alloy_primitives::{Address, BlockHash, Bytes, ChainId, TxKind, B256, U256};
 use alloy_serde::OtherFields;
-use op_alloy_consensus::{OpTxEnvelope, OpTxType, TxDeposit};
+use op_alloy_consensus::OpTxEnvelope;
 use serde::{Deserialize, Serialize};
 
 mod request;
 pub use request::OpTransactionRequest;
 
 /// OP Transaction type
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, derive_more::Deref, derive_more::DerefMut)]
+#[serde(try_from = "tx_serde::TransactionSerdeHelper", into = "tx_serde::TransactionSerdeHelper")]
+#[cfg_attr(all(any(test, feature = "arbitrary"), feature = "k256"), derive(arbitrary::Arbitrary))]
 pub struct Transaction {
     /// Ethereum Transaction Types
-    #[serde(flatten)]
+    #[deref]
+    #[deref_mut]
     pub inner: alloy_rpc_types_eth::Transaction<OpTxEnvelope>,
 
     /// Deposit receipt version for deposit transactions post-canyon
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub deposit_receipt_version: Option<u64>,
 }
 
@@ -147,5 +145,106 @@ impl From<OpTransactionFields> for OtherFields {
 impl AsRef<OpTxEnvelope> for Transaction {
     fn as_ref(&self) -> &OpTxEnvelope {
         self.inner.as_ref()
+    }
+}
+
+mod tx_serde {
+    use serde::de::Error;
+    use super::*;
+
+    #[derive(Serialize, Deserialize)]
+    struct MaybeFrom {
+        from: Option<Address>,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub(crate) struct TransactionSerdeHelper {
+        #[serde(flatten)]
+        inner: OpTxEnvelope,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        block_hash: Option<BlockHash>,
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )]
+        block_number: Option<u64>,
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )]
+        transaction_index: Option<u64>,
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )]
+        deposit_receipt_version: Option<u64>,
+
+        #[serde(flatten)]
+        from: MaybeFrom,
+    }
+
+    impl From<Transaction> for TransactionSerdeHelper {
+        fn from(value: Transaction) -> Self {
+            let Transaction {
+                inner:
+                    alloy_rpc_types_eth::Transaction {
+                        inner,
+                        block_hash,
+                        block_number,
+                        transaction_index,
+                        from,
+                    },
+                deposit_receipt_version,
+            } = value;
+
+            let from = if matches!(inner, OpTxEnvelope::Deposit(_)) { None } else { Some(from) };
+
+            Self {
+                inner,
+                block_hash,
+                block_number,
+                transaction_index,
+                deposit_receipt_version,
+                from: MaybeFrom { from },
+            }
+        }
+    }
+
+    impl TryFrom<TransactionSerdeHelper> for Transaction {
+        type Error = serde_json::Error;
+
+        fn try_from(value: TransactionSerdeHelper) -> Result<Self, Self::Error> {
+            let TransactionSerdeHelper {
+                inner,
+                block_hash,
+                block_number,
+                transaction_index,
+                deposit_receipt_version,
+                from,
+            } = value;
+
+            let from = if let Some(from) = from.from {
+                from
+            } else if let OpTxEnvelope::Deposit(tx) = &inner {
+                tx.from
+            } else {
+                return Err(serde_json::Error::custom("missing `from` field"));
+            };
+
+            Ok(Self {
+                inner: alloy_rpc_types_eth::Transaction {
+                    inner,
+                    block_hash,
+                    block_number,
+                    transaction_index,
+                    from,
+                },
+                deposit_receipt_version,
+            })
+        }
     }
 }

--- a/crates/rpc-types/src/transaction/request.rs
+++ b/crates/rpc-types/src/transaction/request.rs
@@ -1,8 +1,8 @@
 use alloc::vec::Vec;
 use alloy_consensus::{SignableTransaction, Signed, TxEip1559, TxEip4844, TypedTransaction};
 use alloy_eips::eip7702::SignedAuthorization;
-use alloy_network::TransactionBuilder7702;
-use alloy_primitives::{Address, Signature, TxKind, U256};
+use alloy_network_primitives::TransactionBuilder7702;
+use alloy_primitives::{Address, PrimitiveSignature as Signature, TxKind, U256};
 use alloy_rpc_types_eth::{AccessList, TransactionInput, TransactionRequest};
 use op_alloy_consensus::{OpTxEnvelope, OpTypedTransaction, TxDeposit};
 use serde::{Deserialize, Serialize};

--- a/scripts/check_no_std.sh
+++ b/scripts/check_no_std.sh
@@ -5,6 +5,7 @@ no_std_packages=(
   op-alloy-consensus
   op-alloy-protocol
   op-alloy-genesis
+  op-alloy-rpc-types
   op-alloy-rpc-types-engine
 )
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Bumps alloy, alloy-core and alloy-eip7702.

Code changes: 
- https://github.com/alloy-rs/alloy/pull/1496 changed transaction encoding API, encoding functions are now prefixed with `rlp`,`eip2718` or `network`. I've updated `TxDeposit` to have methods following this pattern
- https://github.com/alloy-rs/core/pull/776 updated signature type to avoid using `Parity` generic and instead just keep a boolean for parity byte. The motivation is to have more correctness in encoding and data structure. Before that it was possible to construct `Signed<TxLegacy>` where transaction chain_id is `Some`, but the parity would not follow EIP-155.
    
   This required a few changes to `SpanBatchTransactions` type:
     - `encode_y_parity_bits` and `encode_tx_sigs_rs` are merged into single `encode_tx_sigs` which firstly encodes parity bits and then `rs` values. Same was done for decoding methods
     - `recover_v` method is removed. instead, we now pass the `is_protected` flag down to `SpanBatchLegacyTransactionData` and only set `chain_id` to `Some` when `is_protected` is true

Blocked by minor releases for alloy, core and revm

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
