### PR TITLE
fix(ci): Remove Docs gh-page publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,13 +154,6 @@ jobs:
           RUSTDOCFLAGS:
             --cfg docsrs -D warnings --show-type-layout --generate-link-to-definition
             --enable-index-page -Zunstable-options
-      - name: Deploy documentation
-        uses: peaceiris/actions-gh-pages@v3
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: target/doc
-          force_orphan: true
 
   fmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Removes the publishing of basic docs to gh-pages. There's now a nice mdbook that's published by the books.yml workflow.