### PR TITLE
chore(protocol): Re-organizes Modules and Errors

### DIFF
--- a/crates/protocol/src/errors.rs
+++ b/crates/protocol/src/errors.rs
@@ -1,0 +1,44 @@
+//! Error types for protocol conversions.
+
+use crate::DecodeError;
+use alloy_primitives::B256;
+
+/// An error encountered during [OpBlock] conversion.
+///
+/// [OpBlock]: op_alloy_consensus::OpBlock
+#[derive(Debug, derive_more::Display)]
+pub enum OpBlockConversionError {
+    /// Invalid genesis hash.
+    #[display("Invalid genesis hash. Expected {_0}, got {_1}")]
+    InvalidGenesisHash(B256, B256),
+    /// Invalid transaction type.
+    #[display("First payload transaction has unexpected type: {_0}")]
+    InvalidTxType(u8),
+    /// L1 Info error
+    #[display("Failed to decode L1 info: {_0}")]
+    L1InfoError(DecodeError),
+    /// Missing system config in genesis block.
+    #[display("Missing system config in genesis block")]
+    MissingSystemConfigGenesis,
+    /// Empty transactions.
+    #[display("Empty transactions in payload. Block hash: {_0}")]
+    EmptyTransactions(B256),
+    /// EIP-1559 parameter decoding error.
+    #[display("Failed to decode EIP-1559 parameters from header's `nonce` field.")]
+    Eip1559DecodeError,
+}
+
+impl core::error::Error for OpBlockConversionError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::L1InfoError(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<DecodeError> for OpBlockConversionError {
+    fn from(e: DecodeError) -> Self {
+        Self::L1InfoError(e)
+    }
+}

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -19,6 +19,9 @@ pub use batch::{
     SINGLE_BATCH_TYPE, SPAN_BATCH_TYPE,
 };
 
+mod errors;
+pub use errors::OpBlockConversionError;
+
 mod block;
 pub use block::{BlockInfo, FromBlockError, L2BlockInfo};
 
@@ -34,7 +37,7 @@ mod iter;
 pub use iter::FrameIter;
 
 mod utils;
-pub use utils::{read_tx_data, starts_with_2718_deposit, to_system_config, OpBlockConversionError};
+pub use utils::{read_tx_data, starts_with_2718_deposit, to_system_config};
 
 mod channel;
 pub use channel::{
@@ -42,16 +45,19 @@ pub use channel::{
     FJORD_MAX_RLP_BYTES_PER_CHANNEL, MAX_RLP_BYTES_PER_CHANNEL,
 };
 
-pub mod deposits;
+mod deposits;
 pub use deposits::{
     decode_deposit, DepositError, DepositSourceDomain, DepositSourceDomainIdentifier,
-    L1InfoDepositSource, UpgradeDepositSource, UserDepositSource, DEPOSIT_EVENT_ABI_HASH,
+    L1InfoDepositSource, UpgradeDepositSource, UserDepositSource, DEPOSIT_EVENT_ABI,
+    DEPOSIT_EVENT_ABI_HASH, DEPOSIT_EVENT_VERSION_0,
 };
 
-pub mod block_info;
-pub use block_info::{L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoTx};
+mod block_info;
+pub use block_info::{
+    BlockInfoError, DecodeError, L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoTx,
+};
 
-pub mod fee;
+mod fee;
 pub use fee::{
     calculate_tx_l1_cost_bedrock, calculate_tx_l1_cost_ecotone, calculate_tx_l1_cost_fjord,
     calculate_tx_l1_cost_regolith, data_gas_bedrock, data_gas_fjord, data_gas_regolith,

--- a/crates/protocol/src/utils.rs
+++ b/crates/protocol/src/utils.rs
@@ -8,7 +8,7 @@ use op_alloy_consensus::{OpBlock, OpTxEnvelope};
 use op_alloy_genesis::{RollupConfig, SystemConfig};
 
 use crate::{
-    block_info::DecodeError, L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoTx, SpanBatchError,
+    L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoTx, OpBlockConversionError, SpanBatchError,
     SpanDecodingError,
 };
 
@@ -18,44 +18,6 @@ where
     B: AsRef<[u8]>,
 {
     value.as_ref().first() == Some(&0x7E)
-}
-
-/// An error encountered during [OpBlock] conversion.
-#[derive(Debug, derive_more::Display)]
-pub enum OpBlockConversionError {
-    /// Invalid genesis hash.
-    #[display("Invalid genesis hash. Expected {_0}, got {_1}")]
-    InvalidGenesisHash(B256, B256),
-    /// Invalid transaction type.
-    #[display("First payload transaction has unexpected type: {_0}")]
-    InvalidTxType(u8),
-    /// L1 Info error
-    #[display("Failed to decode L1 info: {_0}")]
-    L1InfoError(DecodeError),
-    /// Missing system config in genesis block.
-    #[display("Missing system config in genesis block")]
-    MissingSystemConfigGenesis,
-    /// Empty transactions.
-    #[display("Empty transactions in payload. Block hash: {_0}")]
-    EmptyTransactions(B256),
-    /// EIP-1559 parameter decoding error.
-    #[display("Failed to decode EIP-1559 parameters from header's `nonce` field.")]
-    Eip1559DecodeError,
-}
-
-impl core::error::Error for OpBlockConversionError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::L1InfoError(err) => Some(err),
-            _ => None,
-        }
-    }
-}
-
-impl From<DecodeError> for OpBlockConversionError {
-    fn from(e: DecodeError) -> Self {
-        Self::L1InfoError(e)
-    }
 }
 
 /// Converts the [OpBlock] to a partial [SystemConfig].


### PR DESCRIPTION
### Description

Removes public visibility from modules so crate docs don't show all the `pub use mod::*` types as re-exported.

Also moves error types from `utils` into a new `errors` module.