### PR TITLE
chore(protocol): Remove TryFrom

### DIFF
--- a/crates/protocol/src/batch/core.rs
+++ b/crates/protocol/src/batch/core.rs
@@ -62,7 +62,7 @@ impl Batch {
             Self::Span(sb) => {
                 out.put_u8(BatchType::Span as u8);
                 let raw_span_batch =
-                    RawSpanBatch::try_from(sb).map_err(BatchEncodingError::SpanBatchError)?;
+                    sb.to_raw_span_batch().map_err(BatchEncodingError::SpanBatchError)?;
                 raw_span_batch.encode(out).map_err(BatchEncodingError::SpanBatchError)?;
             }
         }


### PR DESCRIPTION
### Description

Removes the `TryFrom` span batch for `RawSpanBatch`, inlining the coercion into a `to_raw_span_batch` method.

Closes #266.