### PR TITLE
chore: Remove Error Impls

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -21,6 +21,11 @@ alloy-eips.workspace = true
 alloy-consensus.workspace = true
 alloy-primitives = { workspace = true, features = ["rlp"] }
 
+# misc
+spin.workspace = true
+thiserror.workspace = true
+derive_more = { workspace = true, features = ["display"] }
+
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 
@@ -28,10 +33,6 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 serde_with = { workspace = true, optional = true }
 alloy-serde = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
-
-# misc
-spin.workspace = true
-derive_more = { workspace = true, features = ["display"] }
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/consensus/src/eip1559.rs
+++ b/crates/consensus/src/eip1559.rs
@@ -45,7 +45,7 @@ pub fn decode_holocene_extra_data(
 }
 
 /// Error type for EIP-1559 parameters
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
 pub enum EIP1559ParamError {
     /// No EIP-1559 parameters provided
     NoEIP1559Params,
@@ -68,8 +68,6 @@ impl core::fmt::Display for EIP1559ParamError {
         }
     }
 }
-
-impl core::error::Error for EIP1559ParamError {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/genesis/Cargo.toml
+++ b/crates/genesis/Cargo.toml
@@ -21,6 +21,9 @@ alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
 
+# Misc
+thiserror.workspace = true
+
 # `arbitrary` feature
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 

--- a/crates/genesis/src/system.rs
+++ b/crates/genesis/src/system.rs
@@ -325,7 +325,7 @@ impl SystemConfig {
 }
 
 /// An error for processing the [SystemConfig] update log.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SystemConfigUpdateError {
     /// An error occurred while processing the update log.
@@ -353,7 +353,7 @@ impl core::fmt::Display for SystemConfigUpdateError {
 }
 
 /// An error occurred while processing the update log.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum LogProcessingError {
     /// Received an incorrect number of log topics.
@@ -389,7 +389,7 @@ impl core::fmt::Display for LogProcessingError {
 }
 
 /// An error for updating the batcher address on the [SystemConfig].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BatcherUpdateError {
     /// Invalid data length.
@@ -432,7 +432,7 @@ impl core::fmt::Display for BatcherUpdateError {
 }
 
 /// An error for updating the gas config on the [SystemConfig].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum GasConfigUpdateError {
     /// Invalid data length.
@@ -480,7 +480,7 @@ impl core::fmt::Display for GasConfigUpdateError {
 }
 
 /// An error for updating the gas limit on the [SystemConfig].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum GasLimitUpdateError {
     /// Invalid data length.
@@ -522,10 +522,8 @@ impl core::fmt::Display for GasLimitUpdateError {
     }
 }
 
-impl core::error::Error for GasLimitUpdateError {}
-
 /// An error for updating the EIP-1559 parameters on the [SystemConfig].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum EIP1559UpdateError {
     /// Invalid data length.
@@ -569,8 +567,6 @@ impl core::fmt::Display for EIP1559UpdateError {
         }
     }
 }
-
-impl core::error::Error for EIP1559UpdateError {}
 
 /// System accounts
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/protocol/src/block_info.rs
+++ b/crates/protocol/src/block_info.rs
@@ -122,7 +122,7 @@ pub struct L1BlockInfoEcotone {
 }
 
 /// An error type for parsing L1 block info transactions.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, thiserror::Error, Copy, Clone)]
 pub enum BlockInfoError {
     /// Failed to parse the L1 blob base fee scalar.
     L1BlobBaseFeeScalar,
@@ -151,11 +151,14 @@ impl core::fmt::Display for BlockInfoError {
     }
 }
 
-#[allow(missing_docs)]
-#[derive(Debug)]
+/// An error decoding an L1 block info transaction.
+#[derive(Debug, thiserror::Error)]
 pub enum DecodeError {
+    /// Invalid selector for the L1 info transaction
     InvalidSelector,
+    /// Parse error for the L1 info transaction
     ParseError(String),
+    /// Invalid length for the L1 info transaction
     InvalidLength(String),
 }
 
@@ -168,8 +171,6 @@ impl core::fmt::Display for DecodeError {
         }
     }
 }
-
-impl core::error::Error for DecodeError {}
 
 impl L1BlockInfoTx {
     /// Creates a new [L1BlockInfoTx] from the given information.

--- a/crates/protocol/src/deposits.rs
+++ b/crates/protocol/src/deposits.rs
@@ -19,7 +19,7 @@ pub const DEPOSIT_EVENT_ABI_HASH: B256 =
 pub const DEPOSIT_EVENT_VERSION_0: B256 = B256::ZERO;
 
 /// An [op_alloy_consensus::TxDeposit] validation error.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum DepositError {
     /// Unexpected number of deposit event log topics.
     UnexpectedTopicsLen(usize),
@@ -52,8 +52,6 @@ pub enum DepositError {
     /// Failed to decode the deposit gas value.
     GasDecode(Bytes),
 }
-
-impl core::error::Error for DepositError {}
 
 impl Display for DepositError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {


### PR DESCRIPTION
### Description

Removes error impls using `thiserror` instead.