### PR TITLE
chore(protocol): Cleanup Examples

### DIFF
--- a/book/src/examples/batch-to-frames.md
+++ b/book/src/examples/batch-to-frames.md
@@ -34,8 +34,8 @@ need to then be compressed prior to adding them to the
 > the [`Batch`][batch] itself, handling encoding and compression, but
 > this method is not available yet.
 
-Once compressed using the helper `compress_brotli` method, the compressed
-bytes can be added to a newly constructed [`ChannelOut`][channel-out].
+Once compressed using the [`compress_brotli`][compress-brotli] method, the
+compressed bytes can be added to a newly constructed [`ChannelOut`][channel-out].
 As long as the [`ChannelOut`][channel-out] has [`ready_bytes()`][ready-bytes],
 [`Frame`][frame]s can be constructed using the
 [`ChannelOut::output_frame()`][output-frame] method, specifying the maximum
@@ -44,12 +44,6 @@ frame size.
 Once [`Frame`][frame]s are returned from the [`ChannelOut`][channel-out],
 they can be [`Frame::encode`][encode-frame] into raw, serialized data
 ready to be batch-submitted to the data-availability layer.
-
-
-> [!Note]
->
-> In the example below, the additional `example_transactions()` and `compress_brotli()`
-> methods are helper functions that can be ignored for the sake of the example.
 
 
 ## Running this example:

--- a/book/src/examples/frames-to-batch.md
+++ b/book/src/examples/frames-to-batch.md
@@ -41,13 +41,6 @@ brotli bytes can then be passed right into [`Batch::decode`][decode-batch]
 to wind up with the example's desired [`Batch`][batch].
 
 
-> [!Note]
->
-> In the example below, the additional `example_transactions()` and `decompress_brotli()`
-> methods are helper functions that can be ignored for the sake of the example.
-
-
-
 ## Running this example:
 
 - Clone the examples repository: `git clone git@github.com:alloy-rs/op-alloy.git`

--- a/book/src/links.md
+++ b/book/src/links.md
@@ -25,6 +25,7 @@
 
 <!-- op-alloy-protocol -->
 
+[compress-brotli]: https://docs.rs/op-alloy-protocol/latest/op_alloy_protocol/fn.compress_brotli.html
 [encode-batch]: https://docs.rs/op-alloy-protocol/latest/op_alloy_protocol/struct.SingleBatch.html#method.encode
 [encode-frame]: https://docs.rs/op-alloy-protocol/latest/op_alloy_protocol/struct.Frame.html#method.encode
 [add-frame]: https://docs.rs/op-alloy-protocol/latest/op_alloy_protocol/struct.Channel.html#method.add_frame


### PR DESCRIPTION
### Description

Cleans up `op-alloy-protocol` examples using the exported `decompress_brotli` method.