### PR TITLE
feat: Introduce op-alloy-registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ jobs:
           - rust: "1.81" # MSRV
             flags: "--all-features"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -57,6 +59,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@nextest
@@ -69,7 +73,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: wasm32-unknown-unknown
@@ -85,7 +91,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: wasm32-wasi
@@ -101,7 +109,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: riscv32imac-unknown-none-elf
@@ -116,7 +126,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
@@ -130,6 +142,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -144,7 +158,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
         with:
@@ -159,7 +175,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@nightly
         with:
@@ -170,7 +188,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@nightly
         with:
@@ -185,6 +205,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-hack

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "crates/registry/superchain-registry"]
+	path = crates/registry/superchain-registry
+	url = https://github.com/ethereum-optimism/superchain-registry

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ cfg-if = "1"
 async-trait = "0.1.83"
 unsigned-varint = "0.8.0"
 spin = { version = "0.9.8", features = ["mutex"] }
+lazy_static = { version = "1.5.0", default-features = false }
 derive_more = { version = "1.0", default-features = false }
 thiserror = { version = "2.0", default-features = false }
 similar-asserts = "1.6"

--- a/Justfile
+++ b/Justfile
@@ -54,3 +54,11 @@ check:
 # Runs `cargo hack check` against the workspace
 hack:
   cargo hack check --feature-powerset --no-dev-deps --exclude op-alloy --workspace
+
+# Updates the git submodule source
+source:
+  git submodule update --remote
+
+# Generate file bindings for super-registry
+bind:
+  @just --justfile ./crates/registry/Justfile bind

--- a/crates/registry/Cargo.toml
+++ b/crates/registry/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "op-alloy-registry"
+description = "A registry of superchain configs"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+alloy-primitives = { workspace = true, features = ["map"] }
+op-alloy-genesis = { workspace = true, features = ["serde"] }
+lazy_static = { workspace = true, features = ["spin_no_std"] }
+serde = { workspace = true, features = ["derive", "alloc"] }
+serde_json = { workspace = true, features = ["raw_value"] }
+
+[dev-dependencies]
+alloy-eips.workspace = true
+
+[features]
+default = ["std", "map-foldhash"]
+map-hashbrown = ["alloy-primitives/map-hashbrown"]
+map-foldhash = ["alloy-primitives/map-foldhash"]
+std = ["op-alloy-genesis/std", "serde_json/std"]

--- a/crates/registry/Justfile
+++ b/crates/registry/Justfile
@@ -1,0 +1,9 @@
+set positional-arguments
+
+# default recipe to display help information
+default:
+  @just --list
+
+# Generate file bindings
+bind:
+  ./etc/bind.sh

--- a/crates/registry/README.md
+++ b/crates/registry/README.md
@@ -1,0 +1,99 @@
+## `op-alloy-registry`
+
+<a href="https://github.com/alloy-rs/op-alloy/actions/workflows/ci.yml"><img src="https://github.com/alloy-rs/op-alloy/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
+<a href="https://crates.io/crates/op-alloy-registry"><img src="https://img.shields.io/crates/v/op-alloy-registry.svg?label=op-alloy-registry&labelColor=2a2f35" alt="op-alloy-registry"></a>
+<a href="https://github.com/alloy-rs/op-alloy/blob/main/LICENSE-MIT"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="MIT License"></a>
+<a href="https://github.com/alloy-rs/op-alloy/blob/main/LICENSE-APACHE"><img src="https://img.shields.io/badge/License-APACHE-d1d1f6.svg?label=license&labelColor=2a2f35" alt="Apache License"></a>
+
+
+[`op-alloy-registry`][sc] is a `no_std` crate that exports rust type definitions for chains
+in the [`superchain-registry`][osr]. Since it reads static files to read configurations for
+various chains into instantiated objects, the [`op-alloy-registry`][sc] crate requires
+[`serde`][serde] as a dependency. To use the [`op-alloy-registry`][sc] crate, add the crate
+as a dependency to a `Cargo.toml`.
+
+```toml
+op-alloy-registry = "0.6.7"
+```
+
+[`op-alloy-registry`][sc] declares lazy evaluated statics that expose `ChainConfig`s, `RollupConfig`s,
+and `Chain` objects for all chains with static definitions in the superchain registry. The way this works
+is the the golang side of the superchain registry contains an "internal code generation" script that has
+been modified to output configuration files to the [`crates/registry`][s] directory in the
+`etc` folder that are read by the [`op-alloy-registry`][sc] rust crate. These static config files
+contain an up-to-date list of all superchain configurations with their chain configs.
+
+There are three core statics exposed by the [`op-alloy-registry`][sc].
+- `CHAINS`: A list of chain objects containing the superchain metadata for this chain.
+- `OPCHAINS`: A map from chain id to `ChainConfig`.
+- `ROLLUP_CONFIGS`: A map from chain id to `RollupConfig`.
+
+While the [`op-alloy-genesis`][oag] crate contains a few hardcoded `RollupConfig` objects, the
+[`op-alloy-registry`][sc] exports the _complete_ list of superchains and their chain's `RollupConfig`s
+and `ChainConfig`s.
+
+
+### Usage
+
+Add the following to your `Cargo.toml`.
+
+```toml
+[dependencies]
+op-alloy-registry = "0.6.7"
+```
+
+To make `op-alloy-registry` `no_std`, toggle `default-features` off like so.
+
+```toml
+[dependencies]
+op-alloy-registry = { version = "0.6.7", default-features = false }
+```
+
+Below demonstrates getting the `RollupConfig` for OP Mainnet (Chain ID `10`).
+
+```rust
+use op_alloy_registry::ROLLUP_CONFIGS;
+
+let op_chain_id = 10;
+let op_rollup_config = ROLLUP_CONFIGS.get(&op_chain_id);
+println!("OP Mainnet Rollup Config: {:?}", op_rollup_config);
+```
+
+A mapping from chain id to `ChainConfig` is also available.
+
+```rust
+use op_alloy_registry::OPCHAINS;
+
+let op_chain_id = 10;
+let op_chain_config = OPCHAINS.get(&op_chain_id);
+println!("OP Mainnet Chain Config: {:?}", op_chain_config);
+```
+
+
+### Feature Flags
+
+- `std`: Uses the standard library to pull in environment variables.
+
+
+### Credits
+
+[superchain-registry][osr] contributors for building and maintaining superchain types.
+
+[alloy] and [op-alloy] for creating and maintaining high quality Ethereum and Optimism types in rust.
+
+
+<!-- Hyperlinks -->
+
+[serde]: https://crates.io/crates/serde
+[alloy]: https://github.com/alloy-rs/alloy
+[op-alloy]: https://github.com/alloy-rs/op-alloy
+[op-superchain]: https://docs.optimism.io/stack/explainer
+[osr]: https://github.com/ethereum-optimism/superchain-registry
+
+[s]: ./crates/registry
+[sc]: https://crates.io/crates/op-alloy-registry
+
+[oag]: https://crates.io/crates/op-alloy-genesis
+[chains]: https://docs.rs/op-alloy-registry/latest/superchain/struct.CHAINS.html
+[opchains]: https://docs.rs/op-alloy-registry/latest/superchain/struct.OPCHAINS.html
+[rollups]: https://docs.rs/op-alloy-registry/latest/superchain/struct.ROLLUP_CONFIGS.html

--- a/crates/registry/etc/bind.sh
+++ b/crates/registry/etc/bind.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+CURRENT_SOURE=${BASH_SOURCE[0]}
+CURRENT_DIR=$(dirname $CURRENT_SOURE)
+REPO_ROOT=$( cd $CURRENT_DIR >/dev/null 2>&1 && pwd )
+REPO_ROOT=$(dirname $REPO_ROOT)
+CHAINLIST_JSON=${REPO_ROOT}/superchain-registry/chainList.json
+CONFIGS_JSON=${REPO_ROOT}/superchain-registry/superchain/configs/configs.json
+
+# Attempt to copy over the chainList.json file to etc/chainList.json
+if [ -f ${CHAINLIST_JSON} ]; then
+    cp "${CHAINLIST_JSON}" "${REPO_ROOT}/etc/chainList.json"
+else
+    echo "[ERROR] ${CHAINLIST_JSON} does not exist"
+    exit 1
+fi
+
+# Attempt to copy over the configs.json file to etc/configs.json
+if [ -f ${CONFIGS_JSON} ]; then
+    cp "${CONFIGS_JSON}" "${REPO_ROOT}/etc/configs.json"
+else
+    echo "[WARN] ${CONFIGS_JSON} does not exist"
+    exit 1
+fi

--- a/crates/registry/etc/chainList.json
+++ b/crates/registry/etc/chainList.json
@@ -1,0 +1,583 @@
+[
+  {
+    "name": "OP Mainnet",
+    "identifier": "mainnet/op",
+    "chainId": 10,
+    "rpc": [
+      "https://mainnet.optimism.io"
+    ],
+    "explorers": [
+      "https://explorer.optimism.io"
+    ],
+    "superchainLevel": 1,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "mainnet"
+    }
+  },
+  {
+    "name": "Automata Mainnet",
+    "identifier": "mainnet/automata",
+    "chainId": 65536,
+    "rpc": [
+      "https://rpc.ata.network"
+    ],
+    "explorers": [
+      "https://explorer.ata.network"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "alt-da",
+    "parent": {
+      "type": "L2",
+      "chain": "mainnet"
+    },
+    "gasPayingToken": "0xA2120b9e674d3fC3875f415A7DF52e382F141225"
+  },
+  {
+    "name": "Base",
+    "identifier": "mainnet/base",
+    "chainId": 8453,
+    "rpc": [
+      "https://mainnet.base.org"
+    ],
+    "explorers": [
+      "https://explorer.base.org"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "mainnet"
+    }
+  },
+  {
+    "name": "Cyber Mainnet",
+    "identifier": "mainnet/cyber",
+    "chainId": 7560,
+    "rpc": [
+      "https://rpc.cyber.co"
+    ],
+    "explorers": [
+      "https://cyberscan.co/"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "alt-da",
+    "parent": {
+      "type": "L2",
+      "chain": "mainnet"
+    }
+  },
+  {
+    "name": "Ethernity",
+    "identifier": "mainnet/ethernity",
+    "chainId": 183,
+    "rpc": [
+      "https://mainnet.ethernitychain.io"
+    ],
+    "explorers": [
+      "https://ernscan.io"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "mainnet"
+    }
+  },
+  {
+    "name": "Funki",
+    "identifier": "mainnet/funki",
+    "chainId": 33979,
+    "rpc": [
+      "https://rpc-mainnet.funkichain.com"
+    ],
+    "explorers": [
+      "https://funki.superscan.network"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "alt-da",
+    "parent": {
+      "type": "L2",
+      "chain": "mainnet"
+    }
+  },
+  {
+    "name": "Lisk",
+    "identifier": "mainnet/lisk",
+    "chainId": 1135,
+    "rpc": [
+      "https://rpc.api.lisk.com"
+    ],
+    "explorers": [
+      "https://blockscout.lisk.com"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "mainnet"
+    }
+  },
+  {
+    "name": "Lyra Chain",
+    "identifier": "mainnet/lyra",
+    "chainId": 957,
+    "rpc": [
+      "https://rpc.lyra.finance"
+    ],
+    "explorers": [
+      "https://explorer.lyra.finance"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "alt-da",
+    "parent": {
+      "type": "L2",
+      "chain": "mainnet"
+    }
+  },
+  {
+    "name": "Metal L2",
+    "identifier": "mainnet/metal",
+    "chainId": 1750,
+    "rpc": [
+      "https://rpc.metall2.com"
+    ],
+    "explorers": [
+      "https://explorer.metall2.com"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "mainnet"
+    }
+  },
+  {
+    "name": "Mode",
+    "identifier": "mainnet/mode",
+    "chainId": 34443,
+    "rpc": [
+      "https://mainnet.mode.network"
+    ],
+    "explorers": [
+      "https://explorer.mode.network"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "mainnet"
+    }
+  },
+  {
+    "name": "Orderly Mainnet",
+    "identifier": "mainnet/orderly",
+    "chainId": 291,
+    "rpc": [
+      "https://rpc.orderly.network"
+    ],
+    "explorers": [
+      "https://explorer.orderly.network"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "alt-da",
+    "parent": {
+      "type": "L2",
+      "chain": "mainnet"
+    }
+  },
+  {
+    "name": "RACE Mainnet",
+    "identifier": "mainnet/race",
+    "chainId": 6805,
+    "rpc": [
+      "https://racemainnet.io"
+    ],
+    "explorers": [
+      "https://racescan.io/"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "mainnet"
+    }
+  },
+  {
+    "name": "Shape",
+    "identifier": "mainnet/shape",
+    "chainId": 360,
+    "rpc": [
+      "https://mainnet.shape.network/"
+    ],
+    "explorers": [
+      "https://shape-mainnet.explorer.alchemy.com/"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "mainnet"
+    }
+  },
+  {
+    "name": "Swan Chain Mainnet",
+    "identifier": "mainnet/swan",
+    "chainId": 254,
+    "rpc": [
+      "https://mainnet-rpc.swanchain.org"
+    ],
+    "explorers": [
+      "https://swanscan.io"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "mainnet"
+    }
+  },
+  {
+    "name": "Binary Mainnet",
+    "identifier": "mainnet/tbn",
+    "chainId": 624,
+    "rpc": [
+      "https://rpc.zero.thebinaryholdings.com"
+    ],
+    "explorers": [
+      "https://explorer.thebinaryholdings.com"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "mainnet"
+    },
+    "gasPayingToken": "0x04E9D7e336f79Cdab911b06133D3Ca2Cd0721ce3"
+  },
+  {
+    "name": "World Chain",
+    "identifier": "mainnet/worldchain",
+    "chainId": 480,
+    "rpc": [
+      "https://worldchain-mainnet.g.alchemy.com/public"
+    ],
+    "explorers": [
+      "https://worldchain-mainnet.explorer.alchemy.com/"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "mainnet"
+    }
+  },
+  {
+    "name": "Zora",
+    "identifier": "mainnet/zora",
+    "chainId": 7777777,
+    "rpc": [
+      "https://rpc.zora.energy"
+    ],
+    "explorers": [
+      "https://explorer.zora.energy"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "mainnet"
+    }
+  },
+  {
+    "name": "OP Sepolia Testnet",
+    "identifier": "sepolia/op",
+    "chainId": 11155420,
+    "rpc": [
+      "https://sepolia.optimism.io"
+    ],
+    "explorers": [
+      "https://sepolia-optimistic.etherscan.io"
+    ],
+    "superchainLevel": 1,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "sepolia"
+    }
+  },
+  {
+    "name": "Base Sepolia Testnet",
+    "identifier": "sepolia/base",
+    "chainId": 84532,
+    "rpc": [
+      "https://sepolia.base.org"
+    ],
+    "explorers": [
+      "https://sepolia-explorer.base.org"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "sepolia"
+    }
+  },
+  {
+    "name": "Cyber Testnet",
+    "identifier": "sepolia/cyber",
+    "chainId": 111557560,
+    "rpc": [
+      "https://rpc.testnet.cyber.co"
+    ],
+    "explorers": [
+      "https://testnet.cyberscan.co/"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "sepolia"
+    }
+  },
+  {
+    "name": "Ethernity Testnet",
+    "identifier": "sepolia/ethernity",
+    "chainId": 233,
+    "rpc": [
+      "https://testnet.ethernitychain.io"
+    ],
+    "explorers": [
+      "https://testnet.ernscan.io"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "sepolia"
+    }
+  },
+  {
+    "name": "Funki Sepolia Testnet",
+    "identifier": "sepolia/funki",
+    "chainId": 3397901,
+    "rpc": [
+      "https://funki-testnet.alt.technology"
+    ],
+    "explorers": [
+      "https://sepolia-sandbox.funkichain.com/"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "alt-da",
+    "parent": {
+      "type": "L2",
+      "chain": "sepolia"
+    }
+  },
+  {
+    "name": "Lisk Sepolia Testnet",
+    "identifier": "sepolia/lisk",
+    "chainId": 4202,
+    "rpc": [
+      "https://rpc.sepolia-api.lisk.com"
+    ],
+    "explorers": [
+      "https://sepolia-blockscout.lisk.com"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "sepolia"
+    }
+  },
+  {
+    "name": "Metal L2 Testnet",
+    "identifier": "sepolia/metal",
+    "chainId": 1740,
+    "rpc": [
+      "https://testnet.rpc.metall2.com"
+    ],
+    "explorers": [
+      "https://testnet.explorer.metall2.com"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "sepolia"
+    }
+  },
+  {
+    "name": "Minato",
+    "identifier": "sepolia/minato",
+    "chainId": 1946,
+    "rpc": [
+      "https://rpc.minato.soneium.org"
+    ],
+    "explorers": [
+      "https://soneium-minato.blockscout.com/"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "sepolia"
+    }
+  },
+  {
+    "name": "Mode Testnet",
+    "identifier": "sepolia/mode",
+    "chainId": 919,
+    "rpc": [
+      "https://sepolia.mode.network"
+    ],
+    "explorers": [
+      "https://sepolia.explorer.mode.network"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "sepolia"
+    }
+  },
+  {
+    "name": "RACE Testnet",
+    "identifier": "sepolia/race",
+    "chainId": 6806,
+    "rpc": [
+      "https://racetestnet.io"
+    ],
+    "explorers": [
+      "https://testnet.racescan.io/"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "sepolia"
+    }
+  },
+  {
+    "name": "Shape Sepolia Testnet",
+    "identifier": "sepolia/shape",
+    "chainId": 11011,
+    "rpc": [
+      "https://sepolia.shape.network/"
+    ],
+    "explorers": [
+      "https://shape-sepolia.explorer.alchemy.com/"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "sepolia"
+    }
+  },
+  {
+    "name": "Binary Sepolia",
+    "identifier": "sepolia/tbn",
+    "chainId": 625,
+    "rpc": [
+      "https://rpc.testnet.thebinaryholdings.com"
+    ],
+    "explorers": [
+      "https://explorer.sepolia.thebinaryholdings.com"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "sepolia"
+    },
+    "gasPayingToken": "0x46d878bf7BF62Ec542953CB89Ac0bF58d991181e"
+  },
+  {
+    "name": "Unichain Sepolia Testnet",
+    "identifier": "sepolia/unichain",
+    "chainId": 1301,
+    "rpc": [
+      "https://sepolia.unichain.org"
+    ],
+    "explorers": [
+      "https://sepolia.uniscan.xyz"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "sepolia"
+    }
+  },
+  {
+    "name": "World Chain Sepolia Testnet",
+    "identifier": "sepolia/worldchain",
+    "chainId": 4801,
+    "rpc": [
+      "https://worldchain-sepolia.g.alchemy.com/public"
+    ],
+    "explorers": [
+      "https://worldchain-sepolia.explorer.alchemy.com/"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "sepolia"
+    }
+  },
+  {
+    "name": "Zora Sepolia Testnet",
+    "identifier": "sepolia/zora",
+    "chainId": 999999999,
+    "rpc": [
+      "https://sepolia.rpc.zora.energy"
+    ],
+    "explorers": [
+      "https://sepolia.explorer.zora.energy"
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "sepolia"
+    }
+  },
+  {
+    "name": "Base devnet 0",
+    "identifier": "sepolia-dev-0/base-devnet-0",
+    "chainId": 11763072,
+    "rpc": [
+      ""
+    ],
+    "explorers": [
+      ""
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "sepolia-dev-0"
+    }
+  },
+  {
+    "name": "OP Labs Sepolia devnet 0",
+    "identifier": "sepolia-dev-0/oplabs-devnet-0",
+    "chainId": 11155421,
+    "rpc": [
+      ""
+    ],
+    "explorers": [
+      ""
+    ],
+    "superchainLevel": 0,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "sepolia-dev-0"
+    }
+  }
+]

--- a/crates/registry/etc/configs.json
+++ b/crates/registry/etc/configs.json
@@ -1,0 +1,2336 @@
+{
+  "superchains": [
+    {
+      "name": "mainnet",
+      "config": {
+        "Name": "Mainnet",
+        "L1": {
+          "ChainID": 1,
+          "PublicRPC": "https://ethereum-rpc.publicnode.com",
+          "Explorer": "https://etherscan.io"
+        },
+        "ProtocolVersionsAddr": "0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935",
+        "SuperchainConfigAddr": "0x95703e0982140D16f8ebA6d158FccEde42f04a4C",
+        "OPContractsManagerProxyAddr": "0x18CeC91779995AD14c880e4095456B9147160790"
+      },
+      "chains": [
+        {
+          "Name": "OP Mainnet",
+          "l2_chain_id": 10,
+          "PublicRPC": "https://mainnet.optimism.io",
+          "SequencerRPC": "https://mainnet-sequencer.optimism.io",
+          "Explorer": "https://explorer.optimism.io",
+          "SuperchainLevel": 1,
+          "StandardChainCandidate": false,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0xFF00000000000000000000000000000000000010",
+          "Superchain": "mainnet",
+          "Chain": "op",
+          "canyon_time": 1704992401,
+          "delta_time": 1708560000,
+          "ecotone_time": 1710374401,
+          "fjord_time": 1720627201,
+          "granite_time": 1726070401,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108",
+              "number": 17422590
+            },
+            "l2": {
+              "hash": "0xdbf6a80fef073de06add9b0d14026d6e5a86c85f6d102c36d3d8e9cf89c2afd3",
+              "number": 105235063
+            },
+            "l2_time": 1686068903,
+            "system_config": {
+              "batcherAddr": "0x6887246668a3b87F54DeB3b94Ba47a6f63F32985",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xdE1FCfB0851916CA5101820A69b13a4E276bd81F",
+            "AnchorStateRegistryProxy": "0x18DAc71c228D1C32c99489B7323d441E1175e443",
+            "BatchSubmitter": "0x6887246668a3b87F54DeB3b94Ba47a6f63F32985",
+            "Challenger": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
+            "DelayedWETHProxy": "0x82511d494B5C942BE57498a70Fdd7184Ee33B975",
+            "DisputeGameFactoryProxy": "0xe5965Ab5962eDc7477C8520243A95517CD252fA9",
+            "FaultDisputeGame": "0xA6f3DFdbf4855a43c529bc42EDE96797252879af",
+            "Guardian": "0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2",
+            "L1CrossDomainMessengerProxy": "0x25ace71c97B33Cc4729CF772ae268934F7ab5fA1",
+            "L1ERC721BridgeProxy": "0x5a7749f83b81B301cAb5f48EB8516B986DAef23D",
+            "L1StandardBridgeProxy": "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1",
+            "MIPS": "0x16e83cE5Ce29BF90AD9Da06D2fE6a15d5f344ce4",
+            "OptimismMintableERC20FactoryProxy": "0x75505a97BD334E7BD3C476893285569C4136Fa0F",
+            "OptimismPortalProxy": "0xbEb5Fc579115071764c7423A4f12eDde41f106Ed",
+            "PermissionedDisputeGame": "0x050ed6F6273c7D836a111E42153BC00D0380b87d",
+            "PreimageOracle": "0x9c065e11870B891D214Bc2Da7EF1f9DDFA1BE277",
+            "Proposer": "0x473300df21D047806A082244b417f96b32f13A33",
+            "ProxyAdmin": "0x543bA4AADBAb8f9025686Bd03993043599c6fB04",
+            "ProxyAdminOwner": "0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A",
+            "SystemConfigOwner": "0x847B5c174615B1B7fDF770882256e2D3E95b9D92",
+            "SystemConfigProxy": "0x229047fed2591dbec1eF1118d64F7aF3dB9EB290",
+            "UnsafeBlockSigner": "0xAAAA45d9549EDA09E70937013520214382Ffc4A2"
+          }
+        },
+        {
+          "Name": "Ethernity",
+          "l2_chain_id": 183,
+          "PublicRPC": "https://mainnet.ethernitychain.io",
+          "SequencerRPC": "https://mainnet.ethernitychain.io",
+          "Explorer": "https://ernscan.io",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": true,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xfF00000000000000000000000000000000000183",
+          "Superchain": "mainnet",
+          "Chain": "ethernity",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "fjord_time": 0,
+          "granite_time": 1726070401,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 20,
+            "eip1559Denominator": 1000,
+            "eip1559DenominatorCanyon": 1000
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0xbb7ad201b0ab296465865642878e9256e0fa4a3f8d06bca1f3e5c5b54be6be90",
+              "number": 20519340
+            },
+            "l2": {
+              "hash": "0xa5e974a6ace39285b42f92316a9e040e58f8ffc24e3aac124ff6243c28323607",
+              "number": 0
+            },
+            "l2_time": 1723547735,
+            "system_config": {
+              "batcherAddr": "0x43Ca061Ea80FBB4A2b5515F4be4e953b191147aF",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000f4240",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x464Ca56D40f94E8A50eFa7F5b90c59D956a0efC9",
+            "AnchorStateRegistryProxy": "0x31EE18F4dbCa6A9C8599508Ec70aB98cb1118e9e",
+            "BatchSubmitter": "0x43Ca061Ea80FBB4A2b5515F4be4e953b191147aF",
+            "Challenger": "0xBeA2Bc852a160B8547273660E22F4F08C2fa9Bbb",
+            "DelayedWETHProxy": "0xde1999df1f225D638ad3ca2C9EB5b2E52730D950",
+            "DisputeGameFactoryProxy": "0xFcdb270B674911D321F1014c347EaBB1c55134FB",
+            "Guardian": "0xBeA2Bc852a160B8547273660E22F4F08C2fa9Bbb",
+            "L1CrossDomainMessengerProxy": "0x226A1e4A3D8e64A9De8423F9344348c179C72CB2",
+            "L1ERC721BridgeProxy": "0x00050ae93fBFaf5823A4ae229E4651F7F7A02FfA",
+            "L1StandardBridgeProxy": "0x908C324c35fF36F64236A7CDa4D50f3003E9C5C3",
+            "L2OutputOracleProxy": "0x0eB331B615030819464225Ecd373e5FFBE502DC4",
+            "MIPS": "0x94cE3d0B2243250d3f33dF45FAaEac273CA945fE",
+            "OptimismMintableERC20FactoryProxy": "0x45BEaf3Bd26b76796692b1Ef1E67469B84ADB914",
+            "OptimismPortalProxy": "0xDA29f0B4da6c23f6c1aF273945c290C0268c4ea9",
+            "PreimageOracle": "0xA0455F010561671c640d80f51851D51318aC32aB",
+            "Proposer": "0xF49212F977986347b73345D382a811e148751eED",
+            "ProxyAdmin": "0x0bc380347A0B7aF5453492CAF20e1E38bc0Abc2f",
+            "ProxyAdminOwner": "0xB68361AAac2Bc8a4b8BFe36B8C6d0B429b5930ea",
+            "SuperchainConfig": "0x14B768F93f256Ad8D2d018930DBdAe61306c4752",
+            "SystemConfigOwner": "0xBeA2Bc852a160B8547273660E22F4F08C2fa9Bbb",
+            "SystemConfigProxy": "0x20c3035C92bdB4C461242571EeAc59EeD03Df931",
+            "UnsafeBlockSigner": "0xD1705B4FFFc540EDeD73046ee1F3A8Db10d143f8"
+          }
+        },
+        {
+          "Name": "Swan Chain Mainnet",
+          "l2_chain_id": 254,
+          "PublicRPC": "https://mainnet-rpc.swanchain.org",
+          "SequencerRPC": "https://sequencer-mainnet.swanchain.org",
+          "Explorer": "https://swanscan.io",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xfF00000000000000000000000000000000000254",
+          "Superchain": "mainnet",
+          "Chain": "swan",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "block_time": 5,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x90dafe09640e2858bce2675c66da6b0f136215a179d49f5c9274252bd5a1f8a2",
+              "number": 20112576
+            },
+            "l2": {
+              "hash": "0x834c39d79eb75c4c52d745e624750b817b66eb13e483b035c42ec3aa5cfa7429",
+              "number": 0
+            },
+            "l2_time": 1718640215,
+            "system_config": {
+              "batcherAddr": "0xde794bEc196832474f2F218135bFd0f7cA7fb038",
+              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000834",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000f4240",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x55Aec4EE11dA7d655565cCc2EB3bF21a46C94e6f",
+            "BatchSubmitter": "0xde794bEc196832474f2F218135bFd0f7cA7fb038",
+            "Challenger": "0x3FcB6E08A960EF52Ec3101A444f71A2Fd964b248",
+            "DisputeGameFactoryProxy": "0x2069FC7097b7784FCA21aa459e57E95C0046EeCD",
+            "Guardian": "0x3FcB6E08A960EF52Ec3101A444f71A2Fd964b248",
+            "L1CrossDomainMessengerProxy": "0x15567C4FfD9109795dFf1D9A5233D10aef0738D2",
+            "L1ERC721BridgeProxy": "0x1Ccf7e62889E6A93413DEAFC4e390Bd4047bDC32",
+            "L1StandardBridgeProxy": "0xed7525946A09056C6AaE29941b8323017382050e",
+            "L2OutputOracleProxy": "0x1c22740A0B4511E11D76434A424487862b593901",
+            "OptimismMintableERC20FactoryProxy": "0xE9614162C6128ABD7790C65D711CfC43ea842153",
+            "OptimismPortalProxy": "0xBa50434BC5fCC07406b1baD9AC72a4CDf776db15",
+            "Proposer": "0xb2a5571C23d13Ce16EF3e993FbE8d225D3f67366",
+            "ProxyAdmin": "0xCc8c55Ec2Ea3F3001C049eC934e72b55cf52fBf3",
+            "ProxyAdminOwner": "0x6197f64902b9275e6815F9A5b641Ed2291A5d39c",
+            "SuperchainConfig": "0xadE916De67511E5C24af4174Be67143d0dA94959",
+            "SystemConfigOwner": "0x3FcB6E08A960EF52Ec3101A444f71A2Fd964b248",
+            "SystemConfigProxy": "0x504D56cf68f791B45E3A2e895B0e1562f3431328",
+            "UnsafeBlockSigner": "0x05a220507e8F4c73a446DbAfC5607016A7D5Eab0"
+          }
+        },
+        {
+          "Name": "Orderly Mainnet",
+          "l2_chain_id": 291,
+          "PublicRPC": "https://rpc.orderly.network",
+          "SequencerRPC": "https://rpc.orderly.network",
+          "Explorer": "https://explorer.orderly.network",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": false,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0x08aA34cC843CeEBcC88A627F18430294aA9780be",
+          "Superchain": "mainnet",
+          "Chain": "orderly",
+          "canyon_time": 1704992401,
+          "delta_time": 1708560000,
+          "ecotone_time": 1710374401,
+          "fjord_time": 1720627201,
+          "granite_time": 1726070401,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "alt-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x787d5dd296d63bc6e7a4158d4f109e1260740ee115f5ed5124b35dece1fa3968",
+              "number": 18292529
+            },
+            "l2": {
+              "hash": "0xe53c94ddd42714239429bd132ba2fa080c7e5cc7dca816ec6e482ec0418e6d7f",
+              "number": 0
+            },
+            "l2_time": 1696608227,
+            "system_config": {
+              "batcherAddr": "0xf8dB8Aba597fF36cCD16fECfbb1B816B3236E9b8",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x87630a802a3789463eC4b00f89b27b1e9f6b92e9",
+            "BatchSubmitter": "0xf8dB8Aba597fF36cCD16fECfbb1B816B3236E9b8",
+            "Challenger": "0xcE10372313Ca39Fbf75A09e7f4c0E57F070259f4",
+            "Guardian": "0xcE10372313Ca39Fbf75A09e7f4c0E57F070259f4",
+            "L1CrossDomainMessengerProxy": "0xc76543A64666d9a073FaEF4e75F651c88e7DBC08",
+            "L1ERC721BridgeProxy": "0x934Ab59Ef14b638653b1C0FEf7aB9a72186393DC",
+            "L1StandardBridgeProxy": "0xe07eA0436100918F157DF35D01dCE5c11b16D1F1",
+            "L2OutputOracleProxy": "0x5e76821C3c1AbB9fD6E310224804556C61D860e0",
+            "OptimismMintableERC20FactoryProxy": "0x7a69a90d8ea11E9618855da55D09E6F953730686",
+            "OptimismPortalProxy": "0x91493a61ab83b62943E6dCAa5475Dd330704Cc84",
+            "Proposer": "0x74BaD482a7f73C8286F50D8Aa03e53b7d24A5f3B",
+            "ProxyAdmin": "0xb570F4aD27e7De879A2E4F2F3DE27dBaBc20E9B9",
+            "ProxyAdminOwner": "0x4a4962275DF8C60a80d3a25faEc5AA7De116A746",
+            "SystemConfigOwner": "0x4a4962275DF8C60a80d3a25faEc5AA7De116A746",
+            "SystemConfigProxy": "0x886B187C3D293B1449A3A0F23Ca9e2269E0f2664",
+            "UnsafeBlockSigner": "0xceED24B1Fd4A4393f6A9D2B137D9597dd5482569"
+          }
+        },
+        {
+          "Name": "Shape",
+          "l2_chain_id": 360,
+          "PublicRPC": "https://mainnet.shape.network/",
+          "SequencerRPC": "https://shape-mainnet-sequencer.g.alchemy.com",
+          "Explorer": "https://shape-mainnet.explorer.alchemy.com/",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": true,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xfF00000000000000000000000000000000000360",
+          "Superchain": "mainnet",
+          "Chain": "shape",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "fjord_time": 0,
+          "granite_time": 1727370000,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 1800,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x64772c7ca14e37ca9f0662b7d16b250f486218656012c0da994396608584b2b1",
+              "number": 20369793
+            },
+            "l2": {
+              "hash": "0xf17c665ffdebe214ec214bcd798c725141e7b5c29799500abd6a8738d15bdebe",
+              "number": 0
+            },
+            "l2_time": 1721744471,
+            "system_config": {
+              "batcherAddr": "0xF7ca543d652E38692fD12f989eb55b5327eC9A20",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xcee78437aE9e15cee9c78E63757E0153c0FD7479",
+            "AnchorStateRegistryProxy": "0x02987E7294379B9DDa99d593b0C94c68266222D1",
+            "BatchSubmitter": "0xF7ca543d652E38692fD12f989eb55b5327eC9A20",
+            "Challenger": "0xee1Af3f99AF8C5b93512FbE2A3f0dD5568CE087f",
+            "DelayedWETHProxy": "0xfEc7865DAc5139886585F03146Ff61D9b31c2d57",
+            "DisputeGameFactoryProxy": "0x575Aecd84083f93877291901907698F7db0Bd8b0",
+            "Guardian": "0xee1Af3f99AF8C5b93512FbE2A3f0dD5568CE087f",
+            "L1CrossDomainMessengerProxy": "0x2b18602877181C3cB72C687E2A771E123A3788E3",
+            "L1ERC721BridgeProxy": "0xe9d3E49b0636016c5fE9eaA2347948D0bA9f15Af",
+            "L1StandardBridgeProxy": "0x62Edd5f4930Ea92dCa3fB81689bDD9b9d076b57B",
+            "L2OutputOracleProxy": "0x6Ef8c69CfE4635d866e3E02732068022c06e724D",
+            "MIPS": "0xD30c2Cd3cd6112E61FDfb03e4b232564d7e5C91f",
+            "OptimismMintableERC20FactoryProxy": "0x319322906beAdf69dF5d4607169c63D692B1aDC1",
+            "OptimismPortalProxy": "0xEB06fFa16011B5628BaB98E29776361c83741dd3",
+            "PreimageOracle": "0xDF6a16a71d0BC7a1Bbe8FffB33700eC3d9448A5B",
+            "Proposer": "0x0D8a607F3d2de86adD04Df00f06794cB339A40de",
+            "ProxyAdmin": "0x11B190Ae661c6d6884dFEE48E215691E0DdB842e",
+            "ProxyAdminOwner": "0xacAF178b5048CB56712dc59E95fBA72F7990A005",
+            "SuperchainConfig": "0x125664BEf08177ca43f6f301E63118b1e4cCDe09",
+            "SystemConfigOwner": "0xee1Af3f99AF8C5b93512FbE2A3f0dD5568CE087f",
+            "SystemConfigProxy": "0xfF11e41D5C4F522E423Ff6C064Ff8D55AF8f7355",
+            "UnsafeBlockSigner": "0x9C66333c504F3A4f5593D0e9739434744cCC5B5d"
+          }
+        },
+        {
+          "Name": "World Chain",
+          "l2_chain_id": 480,
+          "PublicRPC": "https://worldchain-mainnet.g.alchemy.com/public",
+          "SequencerRPC": "https://worldchain-mainnet-sequencer.g.alchemy.com",
+          "Explorer": "https://worldchain-mainnet.explorer.alchemy.com/",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000000000480",
+          "Superchain": "mainnet",
+          "Chain": "worldchain",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "fjord_time": 1721826000,
+          "granite_time": 1727780400,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 1800,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 10,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x793daed4743301e00143be5533cd1dce0a741519e9e9c96588a9ad7dbb4d8db4",
+              "number": 20170118
+            },
+            "l2": {
+              "hash": "0x70d316d2e0973b62332ba2e9768dd7854298d7ffe77f0409ffdb8d859f2d3fa3",
+              "number": 0
+            },
+            "l2_time": 1719335639,
+            "system_config": {
+              "batcherAddr": "0xdBBE3D8c2d2b22A2611c5A94A9a12C2fCD49Eb29",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 100000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x5891090d5085679714cb0e62f74950a3c19146a8",
+            "AnchorStateRegistryProxy": "0x1325C4966d17038C5592fb38416AeE85EE73c0cb",
+            "BatchSubmitter": "0xdBBE3D8c2d2b22A2611c5A94A9a12C2fCD49Eb29",
+            "Challenger": "0xB2aa0C2C4fD6BFCBF699d4c787CD6Cc0dC461a9d",
+            "DelayedWETHProxy": "0xF9adF7c9502C5C60352C20a4d22683422DbD061F",
+            "DisputeGameFactoryProxy": "0x0E90dCAFBC242D2C861A20Bb20EC8E7182965a52",
+            "Guardian": "0xB2aa0C2C4fD6BFCBF699d4c787CD6Cc0dC461a9d",
+            "L1CrossDomainMessengerProxy": "0xf931a81D18B1766d15695ffc7c1920a62b7e710a",
+            "L1ERC721BridgeProxy": "0x1Df436AfDb2fBB40F1fE8bEd4Fc89A0D0990a8E9",
+            "L1StandardBridgeProxy": "0x470458C91978D2d929704489Ad730DC3E3001113",
+            "L2OutputOracleProxy": "0x19A6d1E9034596196295CF148509796978343c5D",
+            "MIPS": "0x267b2FFfA613c246Ef995390Ea0a2BaAA16a80Ba",
+            "OptimismMintableERC20FactoryProxy": "0x82Cb528466cF22412d89bdBE9bCF04856790dD0e",
+            "OptimismPortalProxy": "0xd5ec14a83B7d95BE1E2Ac12523e2dEE12Cbeea6C",
+            "PreimageOracle": "0x3941778243E3E80a6a46D149F083825dEdc534BB",
+            "Proposer": "0x2307278fC8aB0005974A6DeD2FA6d1187333a223",
+            "ProxyAdmin": "0xd7405BE7f3e63b094Af6C7C23D5eE33Fd82F872D",
+            "ProxyAdminOwner": "0xA4fB12D15Eb85dc9284a7df0AdBC8B696EdbbF1d",
+            "SuperchainConfig": "0xa231f8be37e583f276f93dF516D88a043bfe47E3",
+            "SystemConfigOwner": "0xB2aa0C2C4fD6BFCBF699d4c787CD6Cc0dC461a9d",
+            "SystemConfigProxy": "0x6ab0777fD0e609CE58F939a7F70Fe41F5Aa6300A",
+            "UnsafeBlockSigner": "0x2270d6eC8E760daA317DD978cFB98C8f144B1f3A"
+          }
+        },
+        {
+          "Name": "Binary Mainnet",
+          "l2_chain_id": 624,
+          "PublicRPC": "https://rpc.zero.thebinaryholdings.com",
+          "SequencerRPC": "https://sequencer.bnry.mainnet.zeeve.net",
+          "Explorer": "https://explorer.thebinaryholdings.com",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xFF00000000000000000000000000000000000624",
+          "Superchain": "mainnet",
+          "Chain": "tbn",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "fjord_time": 1725536344,
+          "granite_time": 1726070401,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": "0x04E9D7e336f79Cdab911b06133D3Ca2Cd0721ce3",
+          "genesis": {
+            "l1": {
+              "hash": "0xdcc5838ee3dd0af995c87bec9614a09f08dd8979014876b42fd7e3ae044dd8c4",
+              "number": 20175246
+            },
+            "l2": {
+              "hash": "0xe222b4b07ee9c885d13ee341823c92aa449f9769ac68fb5f1e1d4e602a990a4a",
+              "number": 0
+            },
+            "l2_time": 1719397463,
+            "system_config": {
+              "batcherAddr": "0x7f9D9c1BCE1062E1077845eA39a0303429600a06",
+              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "scalar": "0x010000000000000000000000000000000000000000000000000c5fc500000558",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x8173904703995c6BbA59a42B8bBf8405F978758a",
+            "AnchorStateRegistryProxy": "0x275Abd1eB1FBaAB40Dcef5f3A588e2dF65801edc",
+            "BatchSubmitter": "0x7f9D9c1BCE1062E1077845eA39a0303429600a06",
+            "Challenger": "0x79DdF0745D14783cDC2a05624c585Ddce07F4A02",
+            "DelayedWETHProxy": "0x161914F701d090824c1A8a0f4e5666938f12848d",
+            "DisputeGameFactoryProxy": "0x0D7e0590c58e4aC9B14B3eD6163CF55223931699",
+            "Guardian": "0x87aab081Ac9F8ce80fb048f23280DF019036BA1d",
+            "L1CrossDomainMessengerProxy": "0x807d21e416434ae92c8E5bcA4d506781aFbBa380",
+            "L1ERC721BridgeProxy": "0x1b396e4dC6ECB0be33CF01C5a34E1a3a7D03c378",
+            "L1StandardBridgeProxy": "0xD1B30378CBF968E5525e8835219A5726A1e71D10",
+            "L2OutputOracleProxy": "0x012f4baa6e0F5Ac4dFDF47BDdd9CF68a2B17821e",
+            "MIPS": "0x4e66D89DDF5A9d86836ABb1d05Ff8fDb5aD32c9A",
+            "OptimismMintableERC20FactoryProxy": "0xa641e14B685b5E652865e14A4fBc07e51371D124",
+            "OptimismPortalProxy": "0x5ff88fcF8e9947f45F4cAf8FFd5231B5DdF05e0A",
+            "PreimageOracle": "0xB9fF3A5835144b0d2F4267A21e0c74458907c870",
+            "Proposer": "0x2b6cD940ABE0CAF2fd89155b99522548c00EBaB1",
+            "ProxyAdmin": "0x38593Cce8FaB9887Ef9760f5F6aB3d6C595143cF",
+            "ProxyAdminOwner": "0x48EC051349dDc7E8baBafCBfe27696ECF2A8a8B3",
+            "SuperchainConfig": "0x34bb53D7C525114A27F0FE2aF91bdDAd186abb12",
+            "SystemConfigOwner": "0x25A6E7c6f3d0fE89A656Fcf065614B74E55099fF",
+            "SystemConfigProxy": "0x7aC7e5989EaC278B7BbfeF560871a2026baD472c",
+            "UnsafeBlockSigner": "0xDbad225D1C0DaBc27f6a9d250dBb136413C0DFb4"
+          }
+        },
+        {
+          "Name": "Lyra Chain",
+          "l2_chain_id": 957,
+          "PublicRPC": "https://rpc.lyra.finance",
+          "SequencerRPC": "https://rpc.lyra.finance",
+          "Explorer": "https://explorer.lyra.finance",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": false,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0x5f7f7f6DB967F0ef10BdA0678964DBA185d16c50",
+          "Superchain": "mainnet",
+          "Chain": "lyra",
+          "canyon_time": 1704992401,
+          "delta_time": 1708560000,
+          "ecotone_time": 1710374401,
+          "fjord_time": 1720627201,
+          "granite_time": 1726070401,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "alt-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x00b06b23108483a0b6af8ff726b5ed3f508b7986f72c12679b10d72c05839716",
+              "number": 18574841
+            },
+            "l2": {
+              "hash": "0x047f535b3da7ad4f96d353b5a439740b7591413daee0e2f27dd3aabb24581af2",
+              "number": 0
+            },
+            "l2_time": 1700021615,
+            "system_config": {
+              "batcherAddr": "0x14e4E97bDc195d399Ad8E7FC14451C279FE04c8e",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xC845F9C4004EB35a8bde8ad89C4760a9c0e65CAB",
+            "BatchSubmitter": "0x14e4E97bDc195d399Ad8E7FC14451C279FE04c8e",
+            "Challenger": "0x91F4be0C264FAFA1fEd75c4440910Cba2cAd98e8",
+            "Guardian": "0x91F4be0C264FAFA1fEd75c4440910Cba2cAd98e8",
+            "L1CrossDomainMessengerProxy": "0x5456f02c08e9A018E42C39b351328E5AA864174A",
+            "L1ERC721BridgeProxy": "0x6CC3268794c5d3E3d9d52adEfC748B59d536cb22",
+            "L1StandardBridgeProxy": "0x61E44dC0dae6888B5a301887732217d5725B0bFf",
+            "L2OutputOracleProxy": "0x1145E7848c8B64c6cab86Fd6D378733385c5C3Ba",
+            "OptimismMintableERC20FactoryProxy": "0x08Dea366F26C25a08C8D1C3568ad07d1e587136d",
+            "OptimismPortalProxy": "0x85eA9c11cf3D4786027F7FD08F4406b15777e5f8",
+            "Proposer": "0x03e820562ffd2e0390787caD706EaF1FF98C2608",
+            "ProxyAdmin": "0x35d5D43271548c984662d4879FBc8e041Bc1Ff93",
+            "ProxyAdminOwner": "0x4a4962275DF8C60a80d3a25faEc5AA7De116A746",
+            "SystemConfigOwner": "0x4a4962275DF8C60a80d3a25faEc5AA7De116A746",
+            "SystemConfigProxy": "0x0e4C4CDd01ceCB01070E9Fdfe7600871e4ae996e",
+            "UnsafeBlockSigner": "0xB71B58FfE538628557433dbBfA08d45ee5a69B44"
+          }
+        },
+        {
+          "Name": "Lisk",
+          "l2_chain_id": 1135,
+          "PublicRPC": "https://rpc.api.lisk.com",
+          "SequencerRPC": "https://rpc.api.lisk.com",
+          "Explorer": "https://blockscout.lisk.com",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": true,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xFf00000000000000000000000000000000001135",
+          "Superchain": "mainnet",
+          "Chain": "lisk",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "fjord_time": 1720627201,
+          "granite_time": 1726070401,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 20,
+            "eip1559Denominator": 1000,
+            "eip1559DenominatorCanyon": 1000
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0xd580bdbd001908860f225c16ddaa08ada64471a68435694760c111253d97ffce",
+              "number": 19788720
+            },
+            "l2": {
+              "hash": "0x5a693d1d8ee27b8e62868d0349af430a2d2e173c8c8988e7b0c9ef91893cbf00",
+              "number": 0
+            },
+            "l2_time": 1714728791,
+            "system_config": {
+              "batcherAddr": "0xa6Ea2f3299b63c53143c993d2d5E60A69Cd6Fe24",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000f4240",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x2dF7057d3F25212E51aFEA8dA628668229Ea423f",
+            "BatchSubmitter": "0xa6Ea2f3299b63c53143c993d2d5E60A69Cd6Fe24",
+            "Challenger": "0xBeA2Bc852a160B8547273660E22F4F08C2fa9Bbb",
+            "DisputeGameFactoryProxy": "0x0479e6757eb4743843b309DDDF78E6bA242F38BE",
+            "Guardian": "0xBeA2Bc852a160B8547273660E22F4F08C2fa9Bbb",
+            "L1CrossDomainMessengerProxy": "0x31B72D76FB666844C41EdF08dF0254875Dbb7edB",
+            "L1ERC721BridgeProxy": "0x3A44A3b263FB631cdbf25f339e2D29497511A81f",
+            "L1StandardBridgeProxy": "0x2658723Bf70c7667De6B25F99fcce13A16D25d08",
+            "L2OutputOracleProxy": "0x113cB99283AF242Da0A0C54347667edF531Aa7d6",
+            "OptimismMintableERC20FactoryProxy": "0xc1dA06CC5DD5cE23bABa924463de7F762039252d",
+            "OptimismPortalProxy": "0x26dB93F8b8b4f7016240af62F7730979d353f9A7",
+            "Proposer": "0x0AbD6da1cE10D1cD6c7C9C14b905786D20f3EB23",
+            "ProxyAdmin": "0xeC432c4F1d0E12737f3a42a459B84848Af979b2d",
+            "ProxyAdminOwner": "0xECd4150ABbb1EBff13f74e42Fb43C3d78B4E0b45",
+            "SuperchainConfig": "0x26C7bFB430d68Bf74d2d52497836d4336b555dE7",
+            "SystemConfigOwner": "0xBeA2Bc852a160B8547273660E22F4F08C2fa9Bbb",
+            "SystemConfigProxy": "0x05f23282FFDCA8286E4738C1aF79079f3d843750",
+            "UnsafeBlockSigner": "0xb9DE90a90c5E441C483e754FE7341100D5fbaEcA"
+          }
+        },
+        {
+          "Name": "Metal L2",
+          "l2_chain_id": 1750,
+          "PublicRPC": "https://rpc.metall2.com",
+          "SequencerRPC": "https://rpc.metall2.com",
+          "Explorer": "https://explorer.metall2.com",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": true,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0xc83f7D9F2D4A76E81145849381ABA02602373723",
+          "Superchain": "mainnet",
+          "Chain": "metal",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "fjord_time": 1720627201,
+          "granite_time": 1726070401,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x2493565ce8472656b7c22377c8d4d8ef5d17f78392c799ca5f2429b01e2c159c",
+              "number": 19527340
+            },
+            "l2": {
+              "hash": "0xd31c12ffff2d563897ad9a041c0d26790d635911bdbbfa589347fa955f75281e",
+              "number": 0
+            },
+            "l2_time": 1711563515,
+            "system_config": {
+              "batcherAddr": "0xC94C243f8fb37223F3EB2f7961F7072602A51B8B",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xd4b1EC0DEc3C7F12abD3ec27B7514880ae1C3a37",
+            "BatchSubmitter": "0xC94C243f8fb37223F3EB2f7961F7072602A51B8B",
+            "Challenger": "0x4a4962275DF8C60a80d3a25faEc5AA7De116A746",
+            "Guardian": "0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2",
+            "L1CrossDomainMessengerProxy": "0x0a47A44f1B2bb753474f8c830322554A96C9934D",
+            "L1ERC721BridgeProxy": "0x50D700e97967F9115e3f999bDB263d69F6704680",
+            "L1StandardBridgeProxy": "0x6d0f65D59b55B0FEC5d2d15365154DcADC140BF3",
+            "L2OutputOracleProxy": "0x3B1F7aDa0Fcc26B13515af752Dd07fB1CAc11426",
+            "OptimismMintableERC20FactoryProxy": "0x1aaab4E20d2e4Bb992b5BCA2125e8bd3588c8730",
+            "OptimismPortalProxy": "0x3F37aBdE2C6b5B2ed6F8045787Df1ED1E3753956",
+            "Proposer": "0xC8187d40AD440328104A52BBed2D8Efc5ab1F1F6",
+            "ProxyAdmin": "0x37Ff0ae34dadA1A95A4251d10ef7Caa868c7AC99",
+            "ProxyAdminOwner": "0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A",
+            "SystemConfigOwner": "0x4a4962275DF8C60a80d3a25faEc5AA7De116A746",
+            "SystemConfigProxy": "0x7BD909970B0EEdcF078De6Aeff23ce571663b8aA",
+            "UnsafeBlockSigner": "0x4a65F5da5e80DEFfEA844eAa15CE130e80605dc5"
+          }
+        },
+        {
+          "Name": "RACE Mainnet",
+          "l2_chain_id": 6805,
+          "PublicRPC": "https://racemainnet.io",
+          "SequencerRPC": "https://racemainnet.io",
+          "Explorer": "https://racescan.io/",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xFF00000000000000000000000000000000006805",
+          "Superchain": "mainnet",
+          "Chain": "race",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0xb6fd41e6c3515172c36d3912046264475eaad84c2c56e99d74f4abd1a75b63c9",
+              "number": 20260129
+            },
+            "l2": {
+              "hash": "0xa864791943836c37b40ea688f3853f2198afb683a3e168d48bfa76c9896e3e65",
+              "number": 0
+            },
+            "l2_time": 1720421591,
+            "system_config": {
+              "batcherAddr": "0x8CDa8351236199AF7532baD53D683Ddd9B275d89",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x3d2BdE87466Cae97011702D2C305fd40EEBbbF0a",
+            "BatchSubmitter": "0x8CDa8351236199AF7532baD53D683Ddd9B275d89",
+            "Challenger": "0x2E7B9465B25C081c07274A31DbD05C6146f67961",
+            "Guardian": "0x2E7B9465B25C081c07274A31DbD05C6146f67961",
+            "L1CrossDomainMessengerProxy": "0xf54B2BAEF894cfF5511A5722Acaac0409F2F2d89",
+            "L1ERC721BridgeProxy": "0x0f33D824d74180598311b3025095727BeA61f219",
+            "L1StandardBridgeProxy": "0x680969A6c58183987c8126ca4DE6b59C6540Cd2a",
+            "L2OutputOracleProxy": "0x8bF8442d49d52377d735a90F19657a29f29aA83c",
+            "OptimismMintableERC20FactoryProxy": "0x1d1c4C89AD5FF486c3C67E3DD84A22CF05420711",
+            "OptimismPortalProxy": "0x0485Ca8A73682B3D3f5ae98cdca1E5b512E728e9",
+            "Proposer": "0x88D58BFbCD70c25409b67117fC1CDfeFDA113a78",
+            "ProxyAdmin": "0x9B3C6D1d33F1fd82Ebb8dFbE38dA162B329De191",
+            "ProxyAdminOwner": "0x5A669B2193718F189b0576c0cdcedfEd6f40F9Ea",
+            "SuperchainConfig": "0xCB73B7348705a9F925643150Eb00350719380FF8",
+            "SystemConfigOwner": "0xBac1ad52745162c0aA3711fe88Df1Cc67034a3B9",
+            "SystemConfigProxy": "0xCf6A32dB8b3313b3d439CE6909511c2c3415fa32",
+            "UnsafeBlockSigner": "0x9b5639D472D6764b70F5046Ac0B13438718398E0"
+          }
+        },
+        {
+          "Name": "Cyber Mainnet",
+          "l2_chain_id": 7560,
+          "PublicRPC": "https://rpc.cyber.co",
+          "SequencerRPC": "https://cyber.alt.technology/",
+          "Explorer": "https://cyberscan.co/",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xfF00000000000000000000000000000000001d88",
+          "Superchain": "mainnet",
+          "Chain": "cyber",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "alt-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "alt_da": {
+            "da_challenge_contract_address": "0x10E34EfE14E4D270C0f77Bf1aF01b6C832161B49",
+            "da_challenge_window": 3600,
+            "da_resolve_window": 3600,
+            "da_commitment_type": "KeccakCommitment"
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x8fa2a34b37420b863aa33da7661a8929af8bd7a436b9e612c727eb5e63da3879",
+              "number": 19681125
+            },
+            "l2": {
+              "hash": "0x0bbf36c47db3b42b40b2e6cadc183612337d1ac8602eb9e57071ae0043e70fc7",
+              "number": 0
+            },
+            "l2_time": 1713428567,
+            "system_config": {
+              "batcherAddr": "0xf0748C52EDC23135d9845CDFB91279Cf61ee14b4",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000b4",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x19b5804B88F10262A55ac731f28A3BbC4209853a",
+            "BatchSubmitter": "0xf0748C52EDC23135d9845CDFB91279Cf61ee14b4",
+            "Challenger": "0x87bD2cFf3b59d615b1Eac7A7f809B5e5f0Ee6752",
+            "DAChallengeAddress": "0x10E34EfE14E4D270C0f77Bf1aF01b6C832161B49",
+            "DelayedWETHProxy": "0x588dAd44201885ff23068f1142e303D52d103919",
+            "DisputeGameFactoryProxy": "0xbF4676f21a7889E0Fd61BcDc9b98E60b01C1B36F",
+            "Guardian": "0x0C883f622b4ccbF1e8ce86217998f87e6d36BCE4",
+            "L1CrossDomainMessengerProxy": "0x3c01ebF22e9c111528c1E027D68944eDaB08Dfc9",
+            "L1ERC721BridgeProxy": "0x4F4B716627D2Ba0439327Ce8B563b4443aF47Dbd",
+            "L1StandardBridgeProxy": "0x12a580c05466eefb2c467C6b115844cDaF55B255",
+            "L2OutputOracleProxy": "0xa669A743b065828682eE16109273F5CFeF5e676d",
+            "MIPS": "0x0048defcA9F0Da952CFD1Ae9F8e962937d3E4143",
+            "OptimismMintableERC20FactoryProxy": "0x51A00470Eb50D758EcFF3B96DB0bF4A8e86268F4",
+            "OptimismPortalProxy": "0x1d59bc9fcE6B8E2B1bf86D4777289FFd83D24C99",
+            "PreimageOracle": "0x0747ef2570e3dbF65F0a12B371F19ca4a66a8DdE",
+            "Proposer": "0xF2987f0A626c8D29dFB2E0A21144ca3026d6F1E1",
+            "ProxyAdmin": "0x7E54107731EC43e78DA678DFa5fB6222Ad036e03",
+            "ProxyAdminOwner": "0xc2259E7Fb719411f97aBdCdf449f6Ba3B9D75398",
+            "SuperchainConfig": "0x1aeC4c3BE47C30d0BEfa7514Cf9D99EaC596959D",
+            "SystemConfigOwner": "0xc76C563185d01284AdbC9cF5bb909162dD2F15e7",
+            "SystemConfigProxy": "0x5D1F4bbaF6D484fA9D5D9705f92dE6063bff6055",
+            "UnsafeBlockSigner": "0xa7A4D6d5920b93D0FE590f9524Ef17f24EE1F5B8"
+          }
+        },
+        {
+          "Name": "Base",
+          "l2_chain_id": 8453,
+          "PublicRPC": "https://mainnet.base.org",
+          "SequencerRPC": "https://mainnet-sequencer.base.org",
+          "Explorer": "https://explorer.base.org",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": true,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0xFf00000000000000000000000000000000008453",
+          "Superchain": "mainnet",
+          "Chain": "base",
+          "canyon_time": 1704992401,
+          "delta_time": 1708560000,
+          "ecotone_time": 1710374401,
+          "fjord_time": 1720627201,
+          "granite_time": 1726070401,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x5c13d307623a926cd31415036c8b7fa14572f9dac64528e857a470511fc30771",
+              "number": 17481768
+            },
+            "l2": {
+              "hash": "0xf712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd",
+              "number": 0
+            },
+            "l2_time": 1686789347,
+            "system_config": {
+              "batcherAddr": "0x5050F69a9786F081509234F1a7F4684b5E5b76C9",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x8EfB6B5c4767B09Dc9AA6Af4eAA89F749522BaE2",
+            "AnchorStateRegistryProxy": "0xdB9091e48B1C42992A1213e6916184f9eBDbfEDf",
+            "BatchSubmitter": "0x5050F69a9786F081509234F1a7F4684b5E5b76C9",
+            "Challenger": "0x6F8C5bA3F59ea3E76300E3BEcDC231D656017824",
+            "DelayedWETHProxy": "0xa2f2aC6F5aF72e494A227d79Db20473Cf7A1FFE8",
+            "DisputeGameFactoryProxy": "0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e",
+            "FaultDisputeGame": "0xCd3c0194db74C23807D4B90A5181e1B28cF7007C",
+            "Guardian": "0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2",
+            "L1CrossDomainMessengerProxy": "0x866E82a600A1414e583f7F13623F1aC5d58b0Afa",
+            "L1ERC721BridgeProxy": "0x608d94945A64503E642E6370Ec598e519a2C1E53",
+            "L1StandardBridgeProxy": "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
+            "L2OutputOracleProxy": "0x56315b90c40730925ec5485cf004d835058518A0",
+            "MIPS": "0x16e83cE5Ce29BF90AD9Da06D2fE6a15d5f344ce4",
+            "OptimismMintableERC20FactoryProxy": "0x05cc379EBD9B30BbA19C6fA282AB29218EC61D84",
+            "OptimismPortalProxy": "0x49048044D57e1C92A77f79988d21Fa8fAF74E97e",
+            "PermissionedDisputeGame": "0x19009dEBF8954B610f207D5925EEDe827805986e",
+            "PreimageOracle": "0x9c065e11870B891D214Bc2Da7EF1f9DDFA1BE277",
+            "Proposer": "0x642229f238fb9dE03374Be34B0eD8D9De80752c5",
+            "ProxyAdmin": "0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E",
+            "ProxyAdminOwner": "0x7bB41C3008B3f03FE483B28b8DB90e19Cf07595c",
+            "SystemConfigOwner": "0x14536667Cd30e52C0b458BaACcB9faDA7046E056",
+            "SystemConfigProxy": "0x73a79Fab69143498Ed3712e519A88a918e1f4072",
+            "UnsafeBlockSigner": "0xAf6E19BE0F9cE7f8afd49a1824851023A8249e8a"
+          }
+        },
+        {
+          "Name": "Funki",
+          "l2_chain_id": 33979,
+          "PublicRPC": "https://rpc-mainnet.funkichain.com",
+          "SequencerRPC": "https://rpc-mainnet.funkichain.com",
+          "Explorer": "https://funki.superscan.network",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xfF00000000000000000000000000000084BB84Bb",
+          "Superchain": "mainnet",
+          "Chain": "funki",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "fjord_time": 0,
+          "block_time": 2,
+          "seq_window_size": 8400,
+          "max_sequencer_drift": 1800,
+          "DataAvailabilityType": "alt-da",
+          "optimism": {
+            "eip1559Elasticity": 10,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "alt_da": {
+            "da_challenge_contract_address": "0xF40b807c2407e1d7dabb85f3ceefd5EACc7bF3CD",
+            "da_challenge_window": 3600,
+            "da_resolve_window": 3600,
+            "da_commitment_type": "KeccakCommitment"
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0xa0768467271297b618c4306469577fd14ba5b0c0488d6e9710a24762cbfe2928",
+              "number": 20325568
+            },
+            "l2": {
+              "hash": "0x7d2831dd811c616d073342a3074f2ce737c6b200b8192f9528e8bf32b1fac83e",
+              "number": 0
+            },
+            "l2_time": 1721211095,
+            "system_config": {
+              "batcherAddr": "0x73c98Cf34AF1f7D798e8e6f34b16037530Bffc41",
+              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "scalar": "0x0100000000000000000000000000000000000000000000000000000000003138",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x5a4ebF927338EA6af377caEee99C85088908f57D",
+            "AnchorStateRegistryProxy": "0x48eB5A81CC3a8955d0DabD6eEd45ac09C7c1889f",
+            "BatchSubmitter": "0x73c98Cf34AF1f7D798e8e6f34b16037530Bffc41",
+            "Challenger": "0x9f8b2470ffECbca2FFda20B9e10f6a12F33BC2Ce",
+            "DAChallengeAddress": "0xF40b807c2407e1d7dabb85f3ceefd5EACc7bF3CD",
+            "DelayedWETHProxy": "0x7992352f723d1209CDd9B786dEF1fBd8DC6511DB",
+            "DisputeGameFactoryProxy": "0x2Dc9d2Cb1Ba0b8A46AE252ab4FBE1ad5C5c3B795",
+            "Guardian": "0x052a8cd5967bc3Bdb5660c989a3A68bCA683A077",
+            "L1CrossDomainMessengerProxy": "0x8F56a665c376A08b604DD32ee6E88667A6093172",
+            "L1ERC721BridgeProxy": "0x94519dD4BA8ba20Aaad14f7C6cD00fa1bB0192E9",
+            "L1StandardBridgeProxy": "0xA2C1C1A473250094a6244F2bcf6Cb51F670Ad3aC",
+            "L2OutputOracleProxy": "0x1A9aE6486caEc0504657351ac473B3dF8A1367cb",
+            "MIPS": "0x29564D1B96A1308E6930F88665576763Ed4837E2",
+            "OptimismMintableERC20FactoryProxy": "0x87e75DcC1BB4e5B42cB5c52eB5832d6eCC3bFeF4",
+            "OptimismPortalProxy": "0x5C9C7f98eD153a2deAA981eB5C97B31744AccF22",
+            "PreimageOracle": "0xd8f66eFeC53CeA76C597827ba5Bf3F68D29f2fA8",
+            "Proposer": "0x7a7690bBAb496537Ac59B45B4c59d789233BcA16",
+            "ProxyAdmin": "0xD069C4724f9bC15FA53b3b2516594512AEf8c957",
+            "ProxyAdminOwner": "0x89CB6669f87c165E7128F4a57476EE4Daa7ffbCD",
+            "SuperchainConfig": "0xD3B2Ee457Cf8F05f00c17BFe509b43BA04c9e5a2",
+            "SystemConfigOwner": "0xc0CE2761d5cC92d25dB6ccD95e4b9483eD22D11B",
+            "SystemConfigProxy": "0xD39a6CcCFa23cb741bB530497e42EC337f1215a8",
+            "UnsafeBlockSigner": "0x843458b6De651E02dFD5bFFea0e9cfb3eca293EF"
+          }
+        },
+        {
+          "Name": "Mode",
+          "l2_chain_id": 34443,
+          "PublicRPC": "https://mainnet.mode.network",
+          "SequencerRPC": "https://mainnet-sequencer.mode.network",
+          "Explorer": "https://explorer.mode.network",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": true,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0x24E59d9d3Bd73ccC28Dc54062AF7EF7bFF58Bd67",
+          "Superchain": "mainnet",
+          "Chain": "mode",
+          "canyon_time": 1704992401,
+          "delta_time": 1708560000,
+          "ecotone_time": 1710374401,
+          "fjord_time": 1720627201,
+          "granite_time": 1726070401,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0xf9b1b22a7ef9d13f063ea467bcb70fb6e9f29698ecb7366a2cdf5af2165cacee",
+              "number": 18586927
+            },
+            "l2": {
+              "hash": "0xb0f682e12fc555fd5ce8fce51a59a67d66a5b46be28611a168260a549dac8a9b",
+              "number": 0
+            },
+            "l2_time": 1700167583,
+            "system_config": {
+              "batcherAddr": "0x99199a22125034c808ff20f377d91187E8050F2E",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x50eF494573f28Cad6B64C31b7a00Cdaa48306e15",
+            "BatchSubmitter": "0x99199a22125034c808ff20f377d91187E8050F2E",
+            "Challenger": "0x309Fe2536d01867018D120b40e4676723C53A14C",
+            "Guardian": "0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2",
+            "L1CrossDomainMessengerProxy": "0x95bDCA6c8EdEB69C98Bd5bd17660BaCef1298A6f",
+            "L1ERC721BridgeProxy": "0x2901dA832a4D0297FF0691100A8E496626cc626D",
+            "L1StandardBridgeProxy": "0x735aDBbE72226BD52e818E7181953f42E3b0FF21",
+            "L2OutputOracleProxy": "0x4317ba146D4933D889518a3e5E11Fe7a53199b04",
+            "OptimismMintableERC20FactoryProxy": "0x69216395A62dFb243C05EF4F1C27AF8655096a95",
+            "OptimismPortalProxy": "0x8B34b14c7c7123459Cf3076b8Cb929BE097d0C07",
+            "Proposer": "0x674F64D64Ddc198db83cd9047dF54BF89cCD0ddB",
+            "ProxyAdmin": "0x470d87b1dae09a454A43D1fD772A561a03276aB7",
+            "ProxyAdminOwner": "0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A",
+            "SystemConfigOwner": "0x4a4962275DF8C60a80d3a25faEc5AA7De116A746",
+            "SystemConfigProxy": "0x5e6432F18Bc5d497B1Ab2288a025Fbf9D69E2221",
+            "UnsafeBlockSigner": "0xa7fA9CA4ac88686A542C0f830d7378eAB4A0278F"
+          }
+        },
+        {
+          "Name": "Automata Mainnet",
+          "l2_chain_id": 65536,
+          "PublicRPC": "https://rpc.ata.network",
+          "SequencerRPC": "https://automata-mainnet.alt.technology/",
+          "Explorer": "https://explorer.ata.network",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000001111111",
+          "Superchain": "mainnet",
+          "Chain": "automata",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "fjord_time": 0,
+          "block_time": 2,
+          "seq_window_size": 7200,
+          "max_sequencer_drift": 1800,
+          "DataAvailabilityType": "alt-da",
+          "optimism": {
+            "eip1559Elasticity": 10,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "alt_da": {
+            "da_challenge_contract_address": "0x08c5DCDD5e46d31CC1591ee15b084663507597f3",
+            "da_challenge_window": 3600,
+            "da_resolve_window": 3600,
+            "da_commitment_type": "KeccakCommitment"
+          },
+          "GasPayingToken": "0xA2120b9e674d3fC3875f415A7DF52e382F141225",
+          "genesis": {
+            "l1": {
+              "hash": "0x2f2ea5358078fdc01d978ff85a3a8fb2efff470b624ba95c5eef0ecd75a6e81d",
+              "number": 20323239
+            },
+            "l2": {
+              "hash": "0x11bb44203634fd85571a9971e6f09d633cbf22826681f809283081ff4e1b5192",
+              "number": 0
+            },
+            "l2_time": 1721183063,
+            "system_config": {
+              "batcherAddr": "0x5BEF09f138921eF7985d83AAB97da1dB6E4dd190",
+              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "scalar": "0x0100000000000000000000000000000000000000000000000000000000013880",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xF1C911e0c1E6dd08c8a7C80c9890e2037e0504c6",
+            "AnchorStateRegistryProxy": "0x4dAA22Ec75406E8ea2c70610115850912A770A3a",
+            "BatchSubmitter": "0x5BEF09f138921eF7985d83AAB97da1dB6E4dd190",
+            "Challenger": "0x34Faa77b4D1686E399c96deF0de31D30572eaa9F",
+            "DAChallengeAddress": "0x08c5DCDD5e46d31CC1591ee15b084663507597f3",
+            "DelayedWETHProxy": "0xd015f61F3CB26560507D758a726c77d18Bf849bB",
+            "DisputeGameFactoryProxy": "0xB52337F38747D6931f2976eEa24A3f3F6B7CDEA2",
+            "Guardian": "0xa5822fb7E3Fb516E518e2629E6786e93858e41F4",
+            "L1CrossDomainMessengerProxy": "0x825C858149F1E775a0f4Aeb172037B970bE7B736",
+            "L1ERC721BridgeProxy": "0x00bd00c5C7F60e222D9CB8040270Ba929241A280",
+            "L1StandardBridgeProxy": "0xE639919b92AB6DD238aEACc6F2A8d6e355D17bd5",
+            "L2OutputOracleProxy": "0xdbf381984c4515Fe3285D3C55fDfb3054C52c261",
+            "MIPS": "0x2B0293A059a2715935fA9459C9F3a4dcE2BC6331",
+            "OptimismMintableERC20FactoryProxy": "0xa74b7baF04867E62B7824268e96144E503A23666",
+            "OptimismPortalProxy": "0xD52ba64CBE1e3B44167f810622fBef36bE24d95c",
+            "PreimageOracle": "0x4a7bd533Be022E7a2911c3C61e7E11e7a32Ee77d",
+            "Proposer": "0x8c6F6580C846634C5DA08c40AE308DE23006a679",
+            "ProxyAdmin": "0x7617f4a55d62b9EE49578D9C90593e58E607415F",
+            "ProxyAdminOwner": "0x03eC1C43434E2f910A2fb984906cd2470fdb39c8",
+            "SuperchainConfig": "0xDf87154Ed6cF332931b70014bA3d9dF423074FfF",
+            "SystemConfigOwner": "0x49eC5Bd8C9cC35Ce26b87E534d2E36980621dDD2",
+            "SystemConfigProxy": "0x72934D7AEDC1A2d889ca89Aaf064CD9455E64d00",
+            "UnsafeBlockSigner": "0xA940a669DAe672111FD02Df597Cf7De7Cf758fAD"
+          }
+        },
+        {
+          "Name": "Zora",
+          "l2_chain_id": 7777777,
+          "PublicRPC": "https://rpc.zora.energy",
+          "SequencerRPC": "https://rpc.zora.energy",
+          "Explorer": "https://explorer.zora.energy",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": true,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0x6F54Ca6F6EdE96662024Ffd61BFd18f3f4e34DFf",
+          "Superchain": "mainnet",
+          "Chain": "zora",
+          "canyon_time": 1704992401,
+          "delta_time": 1708560000,
+          "ecotone_time": 1710374401,
+          "fjord_time": 1720627201,
+          "granite_time": 1726070401,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0xbdbd2847f7aa5f7cd1bd4c9f904057f4ba0b498c7e380199c01d240e3a41a84f",
+              "number": 17473923
+            },
+            "l2": {
+              "hash": "0x47555a45a1af8d4728ca337a1e48375a83919b1ea16591e070a07388b7364e29",
+              "number": 0
+            },
+            "l2_time": 1686693839,
+            "system_config": {
+              "batcherAddr": "0x625726c858dBF78c0125436C943Bf4b4bE9d9033",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xEF8115F2733fb2033a7c756402Fc1deaa56550Ef",
+            "BatchSubmitter": "0x625726c858dBF78c0125436C943Bf4b4bE9d9033",
+            "Challenger": "0xcA4571b1ecBeC86Ea2E660d242c1c29FcB55Dc72",
+            "Guardian": "0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2",
+            "L1CrossDomainMessengerProxy": "0xdC40a14d9abd6F410226f1E6de71aE03441ca506",
+            "L1ERC721BridgeProxy": "0x83A4521A3573Ca87f3a971B169C5A0E1d34481c3",
+            "L1StandardBridgeProxy": "0x3e2Ea9B92B7E48A52296fD261dc26fd995284631",
+            "L2OutputOracleProxy": "0x9E6204F750cD866b299594e2aC9eA824E2e5f95c",
+            "OptimismMintableERC20FactoryProxy": "0xc52BC7344e24e39dF1bf026fe05C4e6E23CfBcFf",
+            "OptimismPortalProxy": "0x1a0ad011913A150f69f6A19DF447A0CfD9551054",
+            "Proposer": "0x48247032092e7b0ecf5dEF611ad89eaf3fC888Dd",
+            "ProxyAdmin": "0xD4ef175B9e72cAEe9f1fe7660a6Ec19009903b49",
+            "ProxyAdminOwner": "0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A",
+            "SystemConfigOwner": "0xC72aE5c7cc9a332699305E29F68Be66c73b60542",
+            "SystemConfigProxy": "0xA3cAB0126d5F504B071b81a3e8A2BBBF17930d86",
+            "UnsafeBlockSigner": "0x3Dc8Dfd0709C835cAd15a6A27e089FF4cF4C9228"
+          }
+        }
+      ]
+    },
+    {
+      "name": "sepolia",
+      "config": {
+        "Name": "Sepolia",
+        "L1": {
+          "ChainID": 11155111,
+          "PublicRPC": "https://ethereum-sepolia-rpc.publicnode.com",
+          "Explorer": "https://sepolia.etherscan.io"
+        },
+        "ProtocolVersionsAddr": "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090",
+        "SuperchainConfigAddr": "0xC2Be75506d5724086DEB7245bd260Cc9753911Be",
+        "OPContractsManagerProxyAddr": "0xF564eEA7960EA244bfEbCBbB17858748606147bf"
+      },
+      "chains": [
+        {
+          "Name": "Ethernity Testnet",
+          "l2_chain_id": 233,
+          "PublicRPC": "https://testnet.ethernitychain.io",
+          "SequencerRPC": "https://testnet.ethernitychain.io",
+          "Explorer": "https://testnet.ernscan.io",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": true,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xFf00000000000000000000000000000000000233",
+          "Superchain": "sepolia",
+          "Chain": "ethernity",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "fjord_time": 0,
+          "granite_time": 1723478400,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x2d9c0b883cfc901f509bd94953c283c477adc57c8a20e234029244e68f00142a",
+              "number": 6037466
+            },
+            "l2": {
+              "hash": "0x4715665848c513c54d71a3e60700743f2b37ec21df9b9d0b8eefee4c30cd557a",
+              "number": 0
+            },
+            "l2_time": 1717499232,
+            "system_config": {
+              "batcherAddr": "0x973A9E30D6D11355A459A69E7CbFBa61C7627736",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000f4240",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x2d34a143D7BeAD8F75479C841e3AAbF6c4AFdeC8",
+            "AnchorStateRegistryProxy": "0xB065B32927C3114c0e0Df16d3887F4Fd12eF7117",
+            "BatchSubmitter": "0x973A9E30D6D11355A459A69E7CbFBa61C7627736",
+            "Challenger": "0x097955A7aa7966d55D781688Aa1493493AB513Af",
+            "DelayedWETHProxy": "0x21676D682F11f3e46cCe1797B19205Dda78f0f6C",
+            "DisputeGameFactoryProxy": "0x64d0Bce6eD7c16CAC7817F3597758E31AFacD01B",
+            "Guardian": "0x097955A7aa7966d55D781688Aa1493493AB513Af",
+            "L1CrossDomainMessengerProxy": "0x1c8b6a6F3E3612c79E62460a6e44C24D1EfF2FDa",
+            "L1ERC721BridgeProxy": "0xBf0D43e12eF74dC21917e1D6175702AD673e1283",
+            "L1StandardBridgeProxy": "0xFd1a12b7a04B13c031d8b075BA5b9080a2CF246f",
+            "L2OutputOracleProxy": "0x11118536F94Bc7C98bBaf9194bE13FC1987293cd",
+            "MIPS": "0xfed5EDD40bfbEFC99432BBb4F2cEcd450c4c8675",
+            "OptimismMintableERC20FactoryProxy": "0x0D085b528E1F9F48018b46f9aC3696f16B7007F9",
+            "OptimismPortalProxy": "0x1F24d471Ef7291c7F97DBD2f76299b30D3e3B6E3",
+            "PreimageOracle": "0x4abd4d6D11c5D7cE392b2b0544E37314710F53c2",
+            "Proposer": "0xBf1374D8c2E98074368326786343f1aDE19d5ccD",
+            "ProxyAdmin": "0x7eA23A9Df2E3E491757a9FF6c32083a44BE560e6",
+            "ProxyAdminOwner": "0x5a19d3Afd327Bd01D390eb52c11C2A9a79BcFB32",
+            "SuperchainConfig": "0x62e4d37aB459A65298DBedF17d35Bf0f958A97Bd",
+            "SystemConfigOwner": "0x097955A7aa7966d55D781688Aa1493493AB513Af",
+            "SystemConfigProxy": "0x7C957fec1F6B3d1024442E989cB08b8f2285686C",
+            "UnsafeBlockSigner": "0xdb0C6821a033eb9Dc152bB008f42ebad0EAdDcA3"
+          }
+        },
+        {
+          "Name": "Binary Sepolia",
+          "l2_chain_id": 625,
+          "PublicRPC": "https://rpc.testnet.thebinaryholdings.com",
+          "SequencerRPC": "https://sequencer.rpc.bnry.testnet.zeeve.net",
+          "Explorer": "https://explorer.sepolia.thebinaryholdings.com",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xFf00000000000000000000000000000000042069",
+          "Superchain": "sepolia",
+          "Chain": "tbn",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "fjord_time": 1723204838,
+          "granite_time": 1723545055,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": "0x46d878bf7BF62Ec542953CB89Ac0bF58d991181e",
+          "genesis": {
+            "l1": {
+              "hash": "0x8d457519705ad17cf812d7cd4cfe5726eca8249f9e5f40a1d19992b07c2521ce",
+              "number": 6092340
+            },
+            "l2": {
+              "hash": "0xf1c38d92222758e1ea0c9c7ae1f7f2dfd0e3e747609f1c2d5a41ecfc5e84aba9",
+              "number": 0
+            },
+            "l2_time": 1718195040,
+            "system_config": {
+              "batcherAddr": "0x9CF89F8cB7cC94C579426f967d9517cd2e9adf29",
+              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "scalar": "0x010000000000000000000000000000000000000000000000000c5fc500000558",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xd1d82d6FC94962fe25912C181375352D4A10c6f0",
+            "AnchorStateRegistryProxy": "0xb86eC23019C6c3f2FbC38502D26b7009d2A300Be",
+            "BatchSubmitter": "0x9CF89F8cB7cC94C579426f967d9517cd2e9adf29",
+            "Challenger": "0xD7E60cd8fBeA5142a207042c477e1359Df5FA688",
+            "DelayedWETHProxy": "0x017e8A21e37AE4bFC482170656B1eBF8390BF880",
+            "DisputeGameFactoryProxy": "0x096b38bDC80B5BF5B5Fb4e1A75Ae38BDa520474A",
+            "Guardian": "0xD7E60cd8fBeA5142a207042c477e1359Df5FA688",
+            "L1CrossDomainMessengerProxy": "0x33Dc556A5df0B8998dC2640c78E531Ae1dB7925d",
+            "L1ERC721BridgeProxy": "0x7c95EebEA6f68875b4093D9c2211Fd26067a808F",
+            "L1StandardBridgeProxy": "0x3B78C3B41b3e3fC6bdf0bD3060C9E2471401C098",
+            "L2OutputOracleProxy": "0xF3699f96cBdD3868B64352669805D96d1Fb6431d",
+            "MIPS": "0xb51FFE0a519291Cbc0080A4F497A2bb4ac0A1C04",
+            "OptimismMintableERC20FactoryProxy": "0xD47e937d602FFba8597b4F042c7A49E1149392fC",
+            "OptimismPortalProxy": "0xFBEd910ca54F013bfeA67Bd4DC836263bdd0b46C",
+            "PreimageOracle": "0x029E58272e3B5f7B69AA4455473FcC8C8B8DEAC3",
+            "Proposer": "0x6087Ec0371C2950d018ec97D8A1573d412DFbDBE",
+            "ProxyAdmin": "0xF42CfF60b92a151911D99F3Ed36ba1266511fd43",
+            "ProxyAdminOwner": "0x5A11a7a6ca68819C601A4136BFbDFBa26D5f043e",
+            "SuperchainConfig": "0x981A2D45d870BD5E6B011907650fE86b89DCaBc3",
+            "SystemConfigOwner": "0xD7E60cd8fBeA5142a207042c477e1359Df5FA688",
+            "SystemConfigProxy": "0x1a6D0312FaaaCa2BF818660F164450176C6205C9",
+            "UnsafeBlockSigner": "0x0F68fC933D50f719aBfBD680f56C22277e2f307c"
+          }
+        },
+        {
+          "Name": "Mode Testnet",
+          "l2_chain_id": 919,
+          "PublicRPC": "https://sepolia.mode.network",
+          "SequencerRPC": "https://sepolia.mode.network",
+          "Explorer": "https://sepolia.explorer.mode.network",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": true,
+          "SuperchainTime": 1703203200,
+          "batch_inbox_address": "0xcDDaE6148dA1E003C230E4527f9baEdc8a204e7E",
+          "Superchain": "sepolia",
+          "Chain": "mode",
+          "canyon_time": 1703203200,
+          "delta_time": 1703203200,
+          "ecotone_time": 1708534800,
+          "fjord_time": 1716998400,
+          "granite_time": 1723478400,
+          "holocene_time": 1732633200,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x4370cafe528a1b8f2aaffc578094731daf69ff82fd9edc30d2d842d3763f3410",
+              "number": 3778382
+            },
+            "l2": {
+              "hash": "0x13c352562289a88ed33087a51b6b6c859a27709c8555c9def7cb9757c043acad",
+              "number": 0
+            },
+            "l2_time": 1687867932,
+            "system_config": {
+              "batcherAddr": "0x4e6BD53883107B063c502dDd49F9600Dc51b3DDc",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x83D45725d6562d8CD717673D6bb4c67C07dC1905",
+            "BatchSubmitter": "0x4e6BD53883107B063c502dDd49F9600Dc51b3DDc",
+            "Challenger": "0x45eFFbD799Ab49122eeEAB75B78D9C56A187F9A7",
+            "Guardian": "0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E",
+            "L1CrossDomainMessengerProxy": "0xc19a60d9E8C27B9A43527c3283B4dd8eDC8bE15C",
+            "L1ERC721BridgeProxy": "0x015a8c2e0a5fEd579dbb05fd290e413Adc6FC24A",
+            "L1StandardBridgeProxy": "0xbC5C679879B2965296756CD959C3C739769995E2",
+            "L2OutputOracleProxy": "0x2634BD65ba27AB63811c74A63118ACb312701Bfa",
+            "OptimismMintableERC20FactoryProxy": "0x00F7ab8c72D32f55cFf15e8901C2F9f2BF29A3C0",
+            "OptimismPortalProxy": "0x320e1580effF37E008F1C92700d1eBa47c1B23fD",
+            "Proposer": "0xe9e08A478e3a773c1B5D59014A0FDb901e6d1d69",
+            "ProxyAdmin": "0xE7413127F29E050Df65ac3FC9335F85bB10091AE",
+            "ProxyAdminOwner": "0x1Eb2fFc903729a0F03966B917003800b145F56E2",
+            "SystemConfigOwner": "0x23BA22Dd7923F3a3f2495bB32a6f3c9b9CD1EC6C",
+            "SystemConfigProxy": "0x15cd4f6e0CE3B4832B33cB9c6f6Fe6fc246754c2",
+            "UnsafeBlockSigner": "0x93A14E6894eEB4FF6a373E1Ad4f498c3a207afe4"
+          }
+        },
+        {
+          "Name": "Unichain Sepolia Testnet",
+          "l2_chain_id": 1301,
+          "PublicRPC": "https://sepolia.unichain.org",
+          "SequencerRPC": "https://sepolia-sequencer.unichain.org",
+          "Explorer": "https://sepolia.uniscan.xyz",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": true,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xFf00000000000000000000000000000000001301",
+          "Superchain": "sepolia",
+          "Chain": "unichain",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "fjord_time": 0,
+          "granite_time": 0,
+          "block_time": 1,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x81719966c43c08d616a832331500633db68006f5e8c0b575a6faf1704ad350c0",
+              "number": 6728364
+            },
+            "l2": {
+              "hash": "0xb7fe0bc9f98ca03294ca0094ff9374cc3e64130b6ec85850d6e260191f48bfe7",
+              "number": 0
+            },
+            "l2_time": 1726852428,
+            "system_config": {
+              "batcherAddr": "0x4AB3387810eF500bfe05a49dc53A44C222cbab3e",
+              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "scalar": "0x010000000000000000000000000000000000000000000000000dbba0000007d0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xEf1295ED471DFEC101691b946fb6B4654E88f98A",
+            "AnchorStateRegistryProxy": "0xf971F1b0D80eb769577135b490b913825BfcF00B",
+            "BatchSubmitter": "0x4AB3387810eF500bfe05a49dc53A44C222cbab3e",
+            "Challenger": "0x921D59f383E9B86b3161a356013b6F8b40CF43C4",
+            "DisputeGameFactoryProxy": "0xeff73e5aa3B9AEC32c659Aa3E00444d20a84394b",
+            "Guardian": "0xD032D9E1F3b3ca6362EC56FbC9d689565F759825",
+            "L1CrossDomainMessengerProxy": "0x448A37330A60494E666F6DD60aD48d930AEbA381",
+            "L1ERC721BridgeProxy": "0x4696b5e042755103fe558738Bcd1ecEe7A45eBfe",
+            "L1StandardBridgeProxy": "0xea58fcA6849d79EAd1f26608855c2D6407d54Ce2",
+            "MIPS": "0x1cEc5b1954302F6FAf45515145C72d7f7266546c",
+            "OptimismMintableERC20FactoryProxy": "0xDf7977C3005730329A160637E8CB9f1675A4d9Be",
+            "OptimismPortalProxy": "0x0d83dab629f0e0F9d36c0Cbc89B69a489f0751bD",
+            "PermissionedDisputeGame": "0x2A82958845ddc647cE1D45F44a7038d6A2D363Ac",
+            "PreimageOracle": "0xAd0a6f4F1503048C34D90dF845c37c876407355a",
+            "Proposer": "0xA25B0eF1CC3ee12a0a167B5BF44dB1a9c166474e",
+            "ProxyAdmin": "0x2BF403E5353A7a082ef6bb3Ae2Be3B866D8D3ea4",
+            "ProxyAdminOwner": "0xd363339eE47775888Df411A163c586a8BdEA9dbf",
+            "SuperchainConfig": "0xe7e23eBa32A6FD2aC79dd5EC72FE7f6217b41BDC",
+            "SystemConfigOwner": "0xB6185370E3db2472EC7Ec4A2826954D2d4923B9f",
+            "SystemConfigProxy": "0xaeE94b9aB7752D3F7704bDE212c0C6A0b701571D",
+            "UnsafeBlockSigner": "0x565B71025Ab4de80AcA33c62E51439af56301493"
+          }
+        },
+        {
+          "Name": "Metal L2 Testnet",
+          "l2_chain_id": 1740,
+          "PublicRPC": "https://testnet.rpc.metall2.com",
+          "SequencerRPC": "https://testnet.rpc.metall2.com",
+          "Explorer": "https://testnet.explorer.metall2.com",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": true,
+          "SuperchainTime": 1708534800,
+          "batch_inbox_address": "0x24567B64a86A4c966655fba6502a93dFb701E316",
+          "Superchain": "sepolia",
+          "Chain": "metal",
+          "canyon_time": 1708129622,
+          "delta_time": 1708385400,
+          "ecotone_time": 1708534800,
+          "fjord_time": 1716998400,
+          "granite_time": 1723478400,
+          "holocene_time": 1732633200,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x6a10927c70985f75898c48235b620acb2a48e9c777a40022f9dbad1b0c96a9c1",
+              "number": 5304030
+            },
+            "l2": {
+              "hash": "0xd24cf8e46b189b0c128dab4e46168520e3a4cdd390b239e8cc1e5abd22a629ae",
+              "number": 0
+            },
+            "l2_time": 1708129620,
+            "system_config": {
+              "batcherAddr": "0xdb80Eca386AC72a55510e33CF9CF7533e75916eE",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x394f844B9A0FC876935d1b0b791D9e94Ad905e8b",
+            "BatchSubmitter": "0xdb80Eca386AC72a55510e33CF9CF7533e75916eE",
+            "Challenger": "0x45eFFbD799Ab49122eeEAB75B78D9C56A187F9A7",
+            "Guardian": "0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E",
+            "L1CrossDomainMessengerProxy": "0x5D335Aa7d93102110879e3B54985c5F08146091E",
+            "L1ERC721BridgeProxy": "0x5d6cE6917dBeeacF010c96BfFdaBE89e33a30309",
+            "L1StandardBridgeProxy": "0x21530aAdF4DCFb9c477171400E40d4ef615868BE",
+            "L2OutputOracleProxy": "0x75a6B961c8da942Ee03CA641B09C322549f6FA98",
+            "OptimismMintableERC20FactoryProxy": "0x49Ff2C4be882298e8CA7DeCD195c207c42B45F66",
+            "OptimismPortalProxy": "0x01D4dfC994878682811b2980653D03E589f093cB",
+            "ProxyAdmin": "0xF7Bc4b3a78C7Dd8bE9B69B3128EEB0D6776Ce18A",
+            "ProxyAdminOwner": "0x1Eb2fFc903729a0F03966B917003800b145F56E2",
+            "SystemConfigOwner": "0x23BA22Dd7923F3a3f2495bB32a6f3c9b9CD1EC6C",
+            "SystemConfigProxy": "0x5D63A8Dc2737cE771aa4a6510D063b6Ba2c4f6F2"
+          }
+        },
+        {
+          "Name": "Minato",
+          "l2_chain_id": 1946,
+          "PublicRPC": "https://rpc.minato.soneium.org",
+          "SequencerRPC": "https://rpc.minato.soneium.org",
+          "Explorer": "https://soneium-minato.blockscout.com/",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": true,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0x00Ca81E019a5312d404aE7fe8367D30DE4c11365",
+          "Superchain": "sepolia",
+          "Chain": "minato",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "fjord_time": 1730106000,
+          "granite_time": 1730106000,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 1800,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x87e648e8d219737526cbcbc03dc914256d4f8e13ae13dc0a2ad377d831cd6473",
+              "number": 6465975
+            },
+            "l2": {
+              "hash": "0x7ec49d93fa8f47c00e98cc5965cd3903a8faa9238743d2eba0e0550ab4c45c43",
+              "number": 0
+            },
+            "l2_time": 1723194336,
+            "system_config": {
+              "batcherAddr": "0xF0AB0441c8f4B89b561aE685B98c6aD5175e0CAB",
+              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x6e8A77673109783001150DFA770E6c662f473DA9",
+            "AnchorStateRegistryProxy": "0xa4AbebA1612Cf731843460791e1A925c84d0991C",
+            "BatchSubmitter": "0xF0AB0441c8f4B89b561aE685B98c6aD5175e0CAB",
+            "Challenger": "0xB278818732E5BEbb742dc4Aa0617ccd1Dec76b65",
+            "DisputeGameFactoryProxy": "0xB3Ad2c38E6e0640d7ce6aA952AB3A60E81bf7a01",
+            "Guardian": "0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E",
+            "L1CrossDomainMessengerProxy": "0x0184245D202724dc28a2b688952Cb56C882c226F",
+            "L1ERC721BridgeProxy": "0x2bfb22cd534a462028771a1cA9D6240166e450c4",
+            "L1StandardBridgeProxy": "0x5f5a404A5edabcDD80DB05E8e54A78c9EBF000C2",
+            "L2OutputOracleProxy": "0x710e5286C746eC38beeB7538d0146f60D27be343",
+            "MIPS": "0x4e3Db3fa21566FF2AD6E11D1ADC129ECf649e47F",
+            "OptimismMintableERC20FactoryProxy": "0x6069BC38c6185f2db0d161f08eC8d1657F6078Df",
+            "OptimismPortalProxy": "0x65ea1489741A5D72fFdD8e6485B216bBdcC15Af3",
+            "PermissionedDisputeGame": "0x55bC868c07c8Cd48446A76966894F4d87844839C",
+            "PreimageOracle": "0xBFEbcF9b8855C3E1d01b2AD28DB9F59BC6CB6965",
+            "Proposer": "0xa759A2C80Ec4C6421829862da30dD34436114502",
+            "ProxyAdmin": "0xff9d236641962Cebf9DBFb54E7b8e91F99f10Db0",
+            "ProxyAdminOwner": "0x4d59CccA765E1211Bd32Aa6F2A037fD37E519a25",
+            "SuperchainConfig": "0xC2Be75506d5724086DEB7245bd260Cc9753911Be",
+            "SystemConfigOwner": "0xB278818732E5BEbb742dc4Aa0617ccd1Dec76b65",
+            "SystemConfigProxy": "0x4Ca9608Fef202216bc21D543798ec854539bAAd3",
+            "UnsafeBlockSigner": "0x55930859CD7003F32A2ba171297408476532E535"
+          }
+        },
+        {
+          "Name": "Lisk Sepolia Testnet",
+          "l2_chain_id": 4202,
+          "PublicRPC": "https://rpc.sepolia-api.lisk.com",
+          "SequencerRPC": "https://rpc.sepolia-api.lisk.com",
+          "Explorer": "https://sepolia-blockscout.lisk.com",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": true,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000000004202",
+          "Superchain": "sepolia",
+          "Chain": "lisk",
+          "canyon_time": 1705312994,
+          "delta_time": 1705312994,
+          "ecotone_time": 1708534800,
+          "fjord_time": 1716998400,
+          "granite_time": 1723478400,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 10,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x7d9d6dcec39efe182119f41b1bd2aa7b35b82e43927522afea86d210a4eace4b",
+              "number": 5089851
+            },
+            "l2": {
+              "hash": "0xead3e6ddd08ae7e27fd952b74ceb468ba889047ac96b351dd13bd55e5faf3372",
+              "number": 0
+            },
+            "l2_time": 1705312992,
+            "system_config": {
+              "batcherAddr": "0x246E119a5BcC2875161b23E4e602e25cEcE96E37",
+              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000834",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000f4240",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x27Bb4A7cd8FB20cb816BF4Aac668BF841bb3D5d3",
+            "BatchSubmitter": "0x246E119a5BcC2875161b23E4e602e25cEcE96E37",
+            "Challenger": "0x19De6D30Bf43654B7244B8adA135E1AA639bF091",
+            "DisputeGameFactoryProxy": "0x9AA3890a87E6BD2CB85Dad1A5D8B0A9D669e658a",
+            "Guardian": "0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E",
+            "L1CrossDomainMessengerProxy": "0x857824E6234f7733ecA4e9A76804fd1afa1A3A2C",
+            "L1ERC721BridgeProxy": "0xb4E988CF1aD8C361D56118437502A8f11C7FaA01",
+            "L1StandardBridgeProxy": "0x1Fb30e446eA791cd1f011675E5F3f5311b70faF5",
+            "L2OutputOracleProxy": "0xA0E35F56C318DE1bD5D9ca6A94Fe7e37C5663348",
+            "OptimismMintableERC20FactoryProxy": "0x269d632C1E518a922C30C749cFD3f82Eb5C779B0",
+            "OptimismPortalProxy": "0xe3d90F21490686Ec7eF37BE788E02dfC12787264",
+            "Proposer": "0xBbD3a1D90B0Ef416581ACdC6a72046b38D3af9AD",
+            "ProxyAdmin": "0x5Db9F05921d8d5a6a157F6f49c411cc0e46c6330",
+            "ProxyAdminOwner": "0x465874903125F26316c730aE84862606a3326cA5",
+            "SuperchainConfig": "0xC2Be75506d5724086DEB7245bd260Cc9753911Be",
+            "SystemConfigOwner": "0x19De6D30Bf43654B7244B8adA135E1AA639bF091",
+            "SystemConfigProxy": "0xF54791059df4a12BA461b881B4080Ae81a1d0AC0",
+            "UnsafeBlockSigner": "0x99804980804e9EbE78db89C049fFe36ceaaEF654"
+          }
+        },
+        {
+          "Name": "World Chain Sepolia Testnet",
+          "l2_chain_id": 4801,
+          "PublicRPC": "https://worldchain-sepolia.g.alchemy.com/public",
+          "SequencerRPC": "https://worldchain-sepolia-sequencer.g.alchemy.com",
+          "Explorer": "https://worldchain-sepolia.explorer.alchemy.com/",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xFf00000000000000000000000000000000484752",
+          "Superchain": "sepolia",
+          "Chain": "worldchain",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "fjord_time": 1721739600,
+          "granite_time": 1726570800,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 1800,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 10,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0xd220bbdf24df6d1611f4ece1d08c64feae914ce6299ab2806c864e30a5289201",
+              "number": 6278018
+            },
+            "l2": {
+              "hash": "0xf1deb67ee953f94d8545d2647918687fa8ba1f30fa6103771f11b7c483984070",
+              "number": 0
+            },
+            "l2_time": 1720547424,
+            "system_config": {
+              "batcherAddr": "0x0f3ff4731D7a10B89ED79AD1Fd97844d7F66B96d",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 100000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xc50Ba0767A1c0Ef69Cf1D9cd44De52b08589F691",
+            "AnchorStateRegistryProxy": "0x1517FDD5A31B35f790eA8a3c6cC2F595B1BD4742",
+            "BatchSubmitter": "0x0f3ff4731D7a10B89ED79AD1Fd97844d7F66B96d",
+            "Challenger": "0xe78a0A96C5D6aE6C606418ED4A9Ced378cb030A0",
+            "DelayedWETHProxy": "0x4F4B8Adf1af4b61bb62F68b7aF1c37f8A6311663",
+            "DisputeGameFactoryProxy": "0x8cF97Ee616C986a070F5020d973b456D0120C253",
+            "Guardian": "0xe78a0A96C5D6aE6C606418ED4A9Ced378cb030A0",
+            "L1CrossDomainMessengerProxy": "0x7768c821200554d8F359A8902905Ba9eDe5659a9",
+            "L1ERC721BridgeProxy": "0x3580505c56f8560E3777E92Fb27f70fD20c5B493",
+            "L1StandardBridgeProxy": "0xd7DF54b3989855eb66497301a4aAEc33Dbb3F8DE",
+            "L2OutputOracleProxy": "0xc8886f8BAb6Eaeb215aDB5f1c686BF699248300e",
+            "MIPS": "0xCEd5c6ca2f32dE7bf43DB981E1cac398D7A978F2",
+            "OptimismMintableERC20FactoryProxy": "0x2D272eF54Ee8EF5c2Ff3523559186580b158cd57",
+            "OptimismPortalProxy": "0xFf6EBa109271fe6d4237EeeD4bAb1dD9A77dD1A4",
+            "PreimageOracle": "0x954C0Fb8083047f37c8Fe954c114f8138614131C",
+            "Proposer": "0x77a95104e4025fC8B88A6a0F5FB7Fae20851E414",
+            "ProxyAdmin": "0x3a987FE1cb587B0A1808cf9bB7Cbe0E341838319",
+            "ProxyAdminOwner": "0x945185C01fb641bA3E63a9bdF66575e35a407837",
+            "SuperchainConfig": "0x4642C5eD3B1568e0F05d73B10d02e6Fb2595aF9a",
+            "SystemConfigOwner": "0xe78a0A96C5D6aE6C606418ED4A9Ced378cb030A0",
+            "SystemConfigProxy": "0x166F9406e79A656f12F05247fb8F5DfA6155bCBF",
+            "UnsafeBlockSigner": "0x3241A7D28eA74E807A5087BA637fB58D8dDcd078"
+          }
+        },
+        {
+          "Name": "RACE Testnet",
+          "l2_chain_id": 6806,
+          "PublicRPC": "https://racetestnet.io",
+          "SequencerRPC": "https://racetestnet.io",
+          "Explorer": "https://testnet.racescan.io/",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000000006806",
+          "Superchain": "sepolia",
+          "Chain": "race",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x28dd1dd74080560ef0b02f8f1ae31d1be75b01a70a5be6ef22e673cec538770f",
+              "number": 6210400
+            },
+            "l2": {
+              "hash": "0x994d67464c3368b8eb6f9770087399486b25d721a1868b95bb37de327b49ab89",
+              "number": 0
+            },
+            "l2_time": 1719646560,
+            "system_config": {
+              "batcherAddr": "0x584D61A30C7Ef1E8D547eE02099dADC487f49889",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x1B573Db1000eA419B6dE8eB482C6d394179Bd1A3",
+            "BatchSubmitter": "0x584D61A30C7Ef1E8D547eE02099dADC487f49889",
+            "Challenger": "0xE6869aF6c871614df04902870Bb13d4505E1586c",
+            "Guardian": "0xE6869aF6c871614df04902870Bb13d4505E1586c",
+            "L1CrossDomainMessengerProxy": "0xdaeab17598938A4f27E50AC771249Ad7df12Ea7D",
+            "L1ERC721BridgeProxy": "0xBafb1a6e54e7750aF29489D65888d1c96Dfd66Df",
+            "L1StandardBridgeProxy": "0x289179e9d43A35D47239456251F9c2fdbf9fbeA2",
+            "L2OutputOracleProxy": "0xccac2B8FFc4f778242105F3a9E6B3Ae3F827fC6a",
+            "OptimismMintableERC20FactoryProxy": "0xbd023e7F08AE0274dCEd397D4B6630D697aC738A",
+            "OptimismPortalProxy": "0xF2891fc6819CDd6BD9221874619BB03A6277d72A",
+            "Proposer": "0x5a145E3F466FD6cC095214C700359df7894BaD21",
+            "ProxyAdmin": "0x4a0E8415e3eB85E7393445FD8E588283b62216C8",
+            "ProxyAdminOwner": "0xAc78E9B3Aa9373AE4bE2Ba5Bc9F716d7A746A65E",
+            "SuperchainConfig": "0x1696a64C7F170E46D32088E8eC29193300C35817",
+            "SystemConfigOwner": "0xE6869aF6c871614df04902870Bb13d4505E1586c",
+            "SystemConfigProxy": "0x07e7A3F25aA73dA15bc19B71FEF8f5511342a409",
+            "UnsafeBlockSigner": "0x89eA88ef4AC23f4C7Fdc611Fc9cD1c50DF702C2C"
+          }
+        },
+        {
+          "Name": "Shape Sepolia Testnet",
+          "l2_chain_id": 11011,
+          "PublicRPC": "https://sepolia.shape.network/",
+          "SequencerRPC": "https://shape-sepolia-sequencer.g.alchemy.com",
+          "Explorer": "https://shape-sepolia.explorer.alchemy.com/",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": true,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xFF00000000000000000000000000000000011011",
+          "Superchain": "sepolia",
+          "Chain": "shape",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "fjord_time": 1721732400,
+          "granite_time": 1727197200,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 1800,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x0e1156bae935f43af44f8d3e011275b8aeab57acd83cbd71d92903d3c9b29cf3",
+              "number": 6151675
+            },
+            "l2": {
+              "hash": "0xcb3558db049390808cbde6b82a48d06ed98d3fe959e088ac20ae56174595cfce",
+              "number": 0
+            },
+            "l2_time": 1718936160,
+            "system_config": {
+              "batcherAddr": "0x6fF556Fa7CaFEc55aE77C5C1d58A010be75f9991",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x42721d8512d62aA26B2Cfa1AE18bEEd5a9Ab1337",
+            "AnchorStateRegistryProxy": "0x41ea3c370896632121Cdde1b94a4eCcf23DA4532",
+            "BatchSubmitter": "0x6fF556Fa7CaFEc55aE77C5C1d58A010be75f9991",
+            "Challenger": "0xa9ABe4af69BEA2f381ca600f625Eb3E6b7559266",
+            "DelayedWETHProxy": "0x7cc9cA91BA4f92F4C967E93a1AAd97beB18d3877",
+            "DisputeGameFactoryProxy": "0x93eaa7A1E7d7af7eD9D612F9957988C8631c33e8",
+            "Guardian": "0xa9ABe4af69BEA2f381ca600f625Eb3E6b7559266",
+            "L1CrossDomainMessengerProxy": "0xF9F730650e1AB4D23E2ac983934271ca7c5EF293",
+            "L1ERC721BridgeProxy": "0x19f02c55254d2644eF94f30C74A932D64e1D4F86",
+            "L1StandardBridgeProxy": "0x341ab1DAFdfB73b3D6D075ef10b29e3cACB2A653",
+            "L2OutputOracleProxy": "0x532dDCed3440Eab81c529Ac8b0d7e429B5C05c52",
+            "MIPS": "0xaCf1Ed7357E41f652407ae6cFE1024705c758C38",
+            "OptimismMintableERC20FactoryProxy": "0x46085E2e648488e49FBeaF6544b8e9Dc96df8BDd",
+            "OptimismPortalProxy": "0xfF8Ca2B4d8122E41441F7ccDCf61b8692198Bd1E",
+            "PreimageOracle": "0x8F3B1c59eD4439ebF564604aA4B93130DA4CD1D5",
+            "Proposer": "0xf8Ed03b83c15aa3d0b52095F3c9971225948B777",
+            "ProxyAdmin": "0xd60a706Bf6108F090d055787B9B353FA7EEE1355",
+            "ProxyAdminOwner": "0x4c4526C8C55c4e1a6F2aaf91e37f07c97786e0f5",
+            "SuperchainConfig": "0xe5b3692266FF4Ab8A96A9C7Da6EeEe532CCc7916",
+            "SystemConfigOwner": "0xa9ABe4af69BEA2f381ca600f625Eb3E6b7559266",
+            "SystemConfigProxy": "0xa1aC91ED91EbE40E00d61E233c8026318b4da5fb",
+            "UnsafeBlockSigner": "0xbB4f4B3a46361653BE9DB255D8ff2D004F0FB248"
+          }
+        },
+        {
+          "Name": "Base Sepolia Testnet",
+          "l2_chain_id": 84532,
+          "PublicRPC": "https://sepolia.base.org",
+          "SequencerRPC": "https://sepolia-sequencer.base.org",
+          "Explorer": "https://sepolia-explorer.base.org",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": true,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0xfF00000000000000000000000000000000084532",
+          "Superchain": "sepolia",
+          "Chain": "base",
+          "canyon_time": 1699981200,
+          "delta_time": 1703203200,
+          "ecotone_time": 1708534800,
+          "fjord_time": 1716998400,
+          "granite_time": 1723478400,
+          "holocene_time": 1732633200,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 10,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0xcac9a83291d4dec146d6f7f69ab2304f23f5be87b1789119a0c5b1e4482444ed",
+              "number": 4370868
+            },
+            "l2": {
+              "hash": "0x0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4",
+              "number": 0
+            },
+            "l2_time": 1695768288,
+            "system_config": {
+              "batcherAddr": "0x6CDEbe940BC0F26850285cacA097C11c33103E47",
+              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000834",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000f4240",
+              "gasLimit": 25000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x709c2B8ef4A9feFc629A8a2C1AF424Dc5BD6ad1B",
+            "AnchorStateRegistryProxy": "0x4C8BA32A5DAC2A720bb35CeDB51D6B067D104205",
+            "BatchSubmitter": "0xfc56E7272EEBBBA5bC6c544e159483C4a38f8bA3",
+            "Challenger": "0xDa3037Ff70Ac92CD867c683BD807e5A484857405",
+            "DelayedWETHProxy": "0x7698b262B7a534912c8366dD8a531672deEC634e",
+            "DisputeGameFactoryProxy": "0xd6E6dBf4F7EA0ac412fD8b65ED297e64BB7a06E1",
+            "FaultDisputeGame": "0x8A9bA50a785c3868bEf1FD4924b640A5e0ed54CF",
+            "Guardian": "0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E",
+            "L1CrossDomainMessengerProxy": "0xC34855F4De64F1840e5686e64278da901e261f20",
+            "L1ERC721BridgeProxy": "0x21eFD066e581FA55Ef105170Cc04d74386a09190",
+            "L1StandardBridgeProxy": "0xfd0Bf71F60660E2f608ed56e1659C450eB113120",
+            "MIPS": "0xFF760A87E41144b336E29b6D4582427dEBdB6dee",
+            "OptimismMintableERC20FactoryProxy": "0xb1efB9650aD6d0CC1ed3Ac4a0B7f1D5732696D37",
+            "OptimismPortalProxy": "0x49f53e41452C74589E85cA1677426Ba426459e85",
+            "PermissionedDisputeGame": "0x593D20C4c69485B95D11507239BE2C725ea2A6fD",
+            "PreimageOracle": "0x627F825CBd48c4102d36f287be71f4234426b9e4",
+            "Proposer": "0x037637067c1DbE6d2430616d8f54Cb774Daa5999",
+            "ProxyAdmin": "0x0389E59Aa0a41E4A413Ae70f0008e76CAA34b1F3",
+            "ProxyAdminOwner": "0x0fe884546476dDd290eC46318785046ef68a0BA9",
+            "SystemConfigOwner": "0x0fe884546476dDd290eC46318785046ef68a0BA9",
+            "SystemConfigProxy": "0xf272670eb55e895584501d564AfEB048bEd26194",
+            "UnsafeBlockSigner": "0xb830b99c95Ea32300039624Cb567d324D4b1D83C"
+          }
+        },
+        {
+          "Name": "Funki Sepolia Testnet",
+          "l2_chain_id": 3397901,
+          "PublicRPC": "https://funki-testnet.alt.technology",
+          "SequencerRPC": "https://funki-testnet.alt.technology",
+          "Explorer": "https://sepolia-sandbox.funkichain.com/",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff000000000000000000000000000000000084bB",
+          "Superchain": "sepolia",
+          "Chain": "funki",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "block_time": 2,
+          "seq_window_size": 28800,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "alt-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "alt_da": {
+            "da_challenge_contract_address": "0x12C6A7dB25b20347CA6F5d47E56D5E8219871C6d",
+            "da_challenge_window": 1,
+            "da_resolve_window": 1,
+            "da_commitment_type": "KeccakCommitment"
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x6bc7182e10df2bf35d76362989e10e2c6799c4ceff2eb32741cb804dfab9dd06",
+              "number": 5853286
+            },
+            "l2": {
+              "hash": "0xcebbf8fc7d0fab412866fe1e7df73c721104550ec35e55d173064acb2c0aeac9",
+              "number": 0
+            },
+            "l2_time": 1715060436,
+            "system_config": {
+              "batcherAddr": "0xDa19a4E4d1DbC69bACf13435f08F76cED9B3C245",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000b4",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x6ECc4a306cD20f8041d63B3Db8ecA46b713cDEcC",
+            "BatchSubmitter": "0xDa19a4E4d1DbC69bACf13435f08F76cED9B3C245",
+            "Challenger": "0x542A7142093d536Bf277FA3B0410883ac4e121dc",
+            "DAChallengeAddress": "0x12C6A7dB25b20347CA6F5d47E56D5E8219871C6d",
+            "DelayedWETHProxy": "0x31D0D1D3Fc27B3f174E544364e7Bb836980162d1",
+            "DisputeGameFactoryProxy": "0xEc7C6E35f4e5361D279d5Fe7222F3F45A8A83352",
+            "Guardian": "0xdf3d6FA42Fe4225E6A042C4eD191d7E5D8252E6f",
+            "L1CrossDomainMessengerProxy": "0x6F82D895E223Dde65DA28a8bbD14f3eF79cBF3b8",
+            "L1ERC721BridgeProxy": "0x598D245Ea85FBfBceCe6c62232bbCAB688D3F68b",
+            "L1StandardBridgeProxy": "0x1ba82f688eF3C5B4363Ff667254ed4DC59E97477",
+            "L2OutputOracleProxy": "0xB25812386D1Cb976b50de7387F5CBc10Fec3F27c",
+            "MIPS": "0x71483031c5D2927Ea83807d5C88bd8EccFaF292d",
+            "OptimismMintableERC20FactoryProxy": "0x8eE8eB6B829C382cA395D35C40Dcd2ef8AE57c68",
+            "OptimismPortalProxy": "0xCeE7ef4dDF482447FE14c605Ea94B37cBE87Ca9D",
+            "PreimageOracle": "0x2DE051316aaD761A3eBd6fF008D714805bD02c56",
+            "Proposer": "0x0b8AA7c355917016496e999a80F1737ef9c0C962",
+            "ProxyAdmin": "0xB3E1F3ab2A22049Cc155ebA7089Ea20A5EAB99ca",
+            "ProxyAdminOwner": "0x814973b1ec9Eb9172996931dE7BF1380bd64a824",
+            "SuperchainConfig": "0x00df2E8EfbE6ad2538D940a2cCAAE65112bd0437",
+            "SystemConfigOwner": "0xCDAf106c5531fd27Bf27536E4696E325de9F52b8",
+            "SystemConfigProxy": "0xd6A01f1Ef51D65F023433992a8F62fEeAD35b172",
+            "UnsafeBlockSigner": "0x5359050ACb96c515562896BA71089487138e4bDe"
+          }
+        },
+        {
+          "Name": "OP Sepolia Testnet",
+          "l2_chain_id": 11155420,
+          "PublicRPC": "https://sepolia.optimism.io",
+          "SequencerRPC": "https://sepolia-sequencer.optimism.io",
+          "Explorer": "https://sepolia-optimistic.etherscan.io",
+          "SuperchainLevel": 1,
+          "StandardChainCandidate": false,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0xff00000000000000000000000000000011155420",
+          "Superchain": "sepolia",
+          "Chain": "op",
+          "canyon_time": 1699981200,
+          "delta_time": 1703203200,
+          "ecotone_time": 1708534800,
+          "fjord_time": 1716998400,
+          "granite_time": 1723478400,
+          "holocene_time": 1732633200,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x48f520cf4ddaf34c8336e6e490632ea3cf1e5e93b0b2bc6e917557e31845371b",
+              "number": 4071408
+            },
+            "l2": {
+              "hash": "0x102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d",
+              "number": 0
+            },
+            "l2_time": 1691802540,
+            "system_config": {
+              "batcherAddr": "0x8F23BB38F531600e5d8FDDaAEC41F13FaB46E98c",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x9bFE9c5609311DF1c011c47642253B78a4f33F4B",
+            "AnchorStateRegistryProxy": "0x218CD9489199F321E1177b56385d333c5B598629",
+            "BatchSubmitter": "0x8F23BB38F531600e5d8FDDaAEC41F13FaB46E98c",
+            "Challenger": "0xfd1D2e729aE8eEe2E146c033bf4400fE75284301",
+            "DelayedWETHProxy": "0xcdFdC692a53B4aE9F81E0aEBd26107Da4a71dB84",
+            "DisputeGameFactoryProxy": "0x05F9613aDB30026FFd634f38e5C4dFd30a197Fa1",
+            "FaultDisputeGame": "0xD9d616E4a03a8e7cC962396C9f8D4e3d306097D3",
+            "Guardian": "0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E",
+            "L1CrossDomainMessengerProxy": "0x58Cc85b8D04EA49cC6DBd3CbFFd00B4B8D6cb3ef",
+            "L1ERC721BridgeProxy": "0xd83e03D576d23C9AEab8cC44Fa98d058D2176D1f",
+            "L1StandardBridgeProxy": "0xFBb0621E0B23b5478B630BD55a5f21f67730B0F1",
+            "MIPS": "0x47B0E34C1054009e696BaBAAd56165e1e994144d",
+            "OptimismMintableERC20FactoryProxy": "0x868D59fF9710159C2B330Cc0fBDF57144dD7A13b",
+            "OptimismPortalProxy": "0x16Fc5058F25648194471939df75CF27A2fdC48BC",
+            "PermissionedDisputeGame": "0x98E3F752c7224F8322Afa935a4CaEC3832bB25c9",
+            "PreimageOracle": "0x92240135b46fc1142dA181f550aE8f595B858854",
+            "Proposer": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
+            "ProxyAdmin": "0x189aBAAaa82DfC015A588A7dbaD6F13b1D3485Bc",
+            "ProxyAdminOwner": "0x1Eb2fFc903729a0F03966B917003800b145F56E2",
+            "SystemConfigOwner": "0xfd1D2e729aE8eEe2E146c033bf4400fE75284301",
+            "SystemConfigProxy": "0x034edD2A225f7f429A63E0f1D2084B9E0A93b538",
+            "UnsafeBlockSigner": "0x57CACBB0d30b01eb2462e5dC940c161aff3230D3"
+          }
+        },
+        {
+          "Name": "Cyber Testnet",
+          "l2_chain_id": 111557560,
+          "PublicRPC": "https://rpc.testnet.cyber.co",
+          "SequencerRPC": "https://cyber.alt.technology/",
+          "Explorer": "https://testnet.cyberscan.co/",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xFf00000000000000000000000000000000042069",
+          "Superchain": "sepolia",
+          "Chain": "cyber",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "block_time": 10,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 10,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x0ad7012996ee943369fe592424821845ab115e43a9bc5d4e17bf9493869f98e3",
+              "number": 5488109
+            },
+            "l2": {
+              "hash": "0xd61aa9a43cba806375bec108aba488f00cf784a53a6e5164bc3ef9eb8b169eaf",
+              "number": 0
+            },
+            "l2_time": 1710470112,
+            "system_config": {
+              "batcherAddr": "0x90BB84339856530192CD002533cd7f1290Fc5142",
+              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000834",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000f4240",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x4E9874640d6a670B7F4c7A1370bC303Bb46F360f",
+            "BatchSubmitter": "0x90BB84339856530192CD002533cd7f1290Fc5142",
+            "Challenger": "0x66530799037b46913e52e9e0144D15ab6ed954f5",
+            "DisputeGameFactoryProxy": "0x99f0f9B0E7B16B10042E0935CE34F2fCebBE13C1",
+            "Guardian": "0x66530799037b46913e52e9e0144D15ab6ed954f5",
+            "L1CrossDomainMessengerProxy": "0xB88ee11d822bEc8055f19711458dE8593E7117A3",
+            "L1ERC721BridgeProxy": "0x524e85D2B49497561c53EFEB4B126Aa63883B480",
+            "L1StandardBridgeProxy": "0xAA1bD6D4d8cFD37330a917bc678CB38BEFAf44E6",
+            "L2OutputOracleProxy": "0xD94Ce9E4886A6dcEbC7cF993f4b38F5276516643",
+            "MIPS": "0xD0E6c40D8462466633BAa2d24796d788A08b2e9F",
+            "OptimismMintableERC20FactoryProxy": "0xCfc893490072F14F19ed6dF2b0d985f908ACEE50",
+            "OptimismPortalProxy": "0x06C9Cadb0346c8E142fb8299cEF3EB5120d4c9b6",
+            "PreimageOracle": "0xceF1e04Fd7413C4a7287DF9099Ac57EEd48fB8f2",
+            "Proposer": "0x69ffD6a97141B632631Ef7f56cCeA6a36f02bD7F",
+            "ProxyAdmin": "0x6FcE62e16720BE713e77C954d6f1e6bC8B8d9F48",
+            "ProxyAdminOwner": "0x642A102cD63f039930f99b4657f41Fd4AD7699d6",
+            "SuperchainConfig": "0x3BB614Da92A136Aa14912713F713b3Fa6d6176fE",
+            "SystemConfigOwner": "0x66530799037b46913e52e9e0144D15ab6ed954f5",
+            "SystemConfigProxy": "0x43b838Aa237B27c4fC953E591594CEBb1CA2817F",
+            "UnsafeBlockSigner": "0xf6C6d69ad0eC617593BDDae9702b3F912621C6fe"
+          }
+        },
+        {
+          "Name": "Zora Sepolia Testnet",
+          "l2_chain_id": 999999999,
+          "PublicRPC": "https://sepolia.rpc.zora.energy",
+          "SequencerRPC": "https://sepolia.rpc.zora.energy",
+          "Explorer": "https://sepolia.explorer.zora.energy",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": true,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0xCd734290E4bd0200dAC631c7D4b9E8a33234e91f",
+          "Superchain": "sepolia",
+          "Chain": "zora",
+          "canyon_time": 1699981200,
+          "delta_time": 1703203200,
+          "ecotone_time": 1708534800,
+          "fjord_time": 1716998400,
+          "granite_time": 1723478400,
+          "holocene_time": 1732633200,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0xf782446a2487d900addb5d466a8597c7c543b59fa9aaa154d413830238f8798a",
+              "number": 4548041
+            },
+            "l2": {
+              "hash": "0x8b17d2d52564a5a90079d9c860e1386272579e87b17ea27a3868513f53facd74",
+              "number": 0
+            },
+            "l2_time": 1698080004,
+            "system_config": {
+              "batcherAddr": "0x3Cd868E221A3be64B161D596A7482257a99D857f",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x27c9392144DFcB6dab113F737356C32435cD1D55",
+            "BatchSubmitter": "0x3Cd868E221A3be64B161D596A7482257a99D857f",
+            "Challenger": "0x45eFFbD799Ab49122eeEAB75B78D9C56A187F9A7",
+            "Guardian": "0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E",
+            "L1CrossDomainMessengerProxy": "0x1bDBC0ae22bEc0c2f08B4dd836944b3E28fe9b7A",
+            "L1ERC721BridgeProxy": "0x16B0a4f451c4CB567703367e587E15Ac108e4311",
+            "L1StandardBridgeProxy": "0x5376f1D543dcbB5BD416c56C189e4cB7399fCcCB",
+            "L2OutputOracleProxy": "0x2615B481Bd3E5A1C0C7Ca3Da1bdc663E8615Ade9",
+            "OptimismMintableERC20FactoryProxy": "0x5F3bdd57f01e88cE2F88f00685D30D6eb51A187c",
+            "OptimismPortalProxy": "0xeffE2C6cA9Ab797D418f0D91eA60807713f3536f",
+            "Proposer": "0xe8326a5839175dE7f467e66D8bB443aa70DA1c3e",
+            "ProxyAdmin": "0xE17071F4C216Eb189437fbDBCc16Bb79c4efD9c2",
+            "ProxyAdminOwner": "0x1Eb2fFc903729a0F03966B917003800b145F56E2",
+            "SystemConfigOwner": "0x23BA22Dd7923F3a3f2495bB32a6f3c9b9CD1EC6C",
+            "SystemConfigProxy": "0xB54c7BFC223058773CF9b739cC5bd4095184Fb08",
+            "UnsafeBlockSigner": "0x3609513933100689bd1f84782529A99239842344"
+          }
+        }
+      ]
+    },
+    {
+      "name": "sepolia-dev-0",
+      "config": {
+        "Name": "Sepolia Dev 0",
+        "L1": {
+          "ChainID": 11155111,
+          "PublicRPC": "https://ethereum-sepolia-rpc.publicnode.com",
+          "Explorer": "https://sepolia.etherscan.io"
+        },
+        "ProtocolVersionsAddr": "0x252CbE9517F731C618961D890D534183822dcC8d",
+        "SuperchainConfigAddr": "0x02d91Cf852423640d93920BE0CAdceC0E7A00FA7",
+        "OPContractsManagerProxyAddr": null
+      },
+      "chains": [
+        {
+          "Name": "OP Labs Sepolia devnet 0",
+          "l2_chain_id": 11155421,
+          "PublicRPC": "",
+          "SequencerRPC": "",
+          "Explorer": "",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": false,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0xFf00000000000000000000000000000011155421",
+          "Superchain": "sepolia-dev-0",
+          "Chain": "oplabs-devnet-0",
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 1706634000,
+          "fjord_time": 1715961600,
+          "granite_time": 1723046400,
+          "holocene_time": 1731682800,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x5639be97000fec7131a880b19b664cae43f975c773f628a08a9bb658c2a68df0",
+              "number": 5173577
+            },
+            "l2": {
+              "hash": "0x027ae1f4f9a441f9c8a01828f3b6d05803a0f524c07e09263264a38b755f804b",
+              "number": 0
+            },
+            "l2_time": 1706484048,
+            "system_config": {
+              "batcherAddr": "0x19CC7073150D9f5888f09E0e9016d2a39667df14",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x3eb579b25F6b9547e0073c848389a768FD382296",
+            "AnchorStateRegistryProxy": "0x03b82AE60989863BCEb0BbD442A70568e5AefB85",
+            "BatchSubmitter": "0x19CC7073150D9f5888f09E0e9016d2a39667df14",
+            "Challenger": "0x8c20c40180751d93E939DDDee3517AE0d1EBeAd2",
+            "DelayedWETHProxy": "0xE99696a028171e31a72828A196C27c2Dd670E1aa",
+            "DisputeGameFactoryProxy": "0x2419423C72998eb1c6c15A235de2f112f8E38efF",
+            "FaultDisputeGame": "0x54416A2E28E8cbC761fbce0C7f107307991282e5",
+            "Guardian": "0x8c20c40180751d93E939DDDee3517AE0d1EBeAd2",
+            "L1CrossDomainMessengerProxy": "0x18e72C15FEE4e995454b919EfaA61D8f116F82dd",
+            "L1ERC721BridgeProxy": "0x1bb726658E039E8a9A4ac21A41fE5a0704760461",
+            "L1StandardBridgeProxy": "0x6D8bC564EF04AaF355a10c3eb9b00e349dd077ea",
+            "MIPS": "0xceDE5949A189aC60F41F1385a86DBce7Bd3B1943",
+            "OptimismMintableERC20FactoryProxy": "0xA16b8db3b5Cdbaf75158F34034B0537e528E17e2",
+            "OptimismPortalProxy": "0x76114bd29dFcC7a9892240D317E6c7C2A281Ffc6",
+            "PermissionedDisputeGame": "0x50573970b291726B881b204eD9F3c1D507e504cD",
+            "PreimageOracle": "0xB73342DdD69620e5Ab2Cc604Dad46434C2338025",
+            "Proposer": "0x95014c45078354Ff839f14192228108Eac82E00A",
+            "ProxyAdmin": "0x18d890A46A3556e7F36f28C79F6157BC7a59f867",
+            "ProxyAdminOwner": "0x4377BB0F0103992b31eC12b4d796a8687B8dC8E9",
+            "SystemConfigOwner": "0x8c20c40180751d93E939DDDee3517AE0d1EBeAd2",
+            "SystemConfigProxy": "0xa6b72407e2dc9EBF84b839B69A24C88929cf20F7",
+            "UnsafeBlockSigner": "0xa95B83e39AA78B00F12fe431865B563793D97AF5"
+          }
+        },
+        {
+          "Name": "Base devnet 0",
+          "l2_chain_id": 11763072,
+          "PublicRPC": "",
+          "SequencerRPC": "",
+          "Explorer": "",
+          "SuperchainLevel": 0,
+          "StandardChainCandidate": false,
+          "SuperchainTime": 1706634000,
+          "batch_inbox_address": "0xfF00000000000000000000000000000011763072",
+          "Superchain": "sepolia-dev-0",
+          "Chain": "base-devnet-0",
+          "canyon_time": 1698436800,
+          "delta_time": 1706555000,
+          "ecotone_time": 1706634000,
+          "fjord_time": 1715961600,
+          "granite_time": 1723046400,
+          "holocene_time": 1731682800,
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "GasPayingToken": null,
+          "genesis": {
+            "l1": {
+              "hash": "0x86252c512dc5bd7201d0532b31d50696ba84344a7cda545e04a98073a8e13d87",
+              "number": 4344216
+            },
+            "l2": {
+              "hash": "0x1ab91449a7c65b8cd6c06f13e2e7ea2d10b6f9cbf5def79f362f2e7e501d2928",
+              "number": 0
+            },
+            "l2_time": 1695433056,
+            "system_config": {
+              "batcherAddr": "0x212dD524932bC43478688F91045F2682913ad8EE",
+              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000834",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000f4240",
+              "gasLimit": 25000000
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x882a60911d00867Fe4ea632C479cc48e583A8D69",
+            "BatchSubmitter": "0x7A43fD33e42054C965eE7175dd4590D2BDba79cB",
+            "Challenger": "0x5a533AaAC6cd81605b301a1077BC393A94658B6D",
+            "Guardian": "0x4F43c7422a9b2AC4BC6145Bd4eE206EA73cF8266",
+            "L1CrossDomainMessengerProxy": "0x2cbD403d5BA3949D24ee4dF57805eaC612C2662f",
+            "L1ERC721BridgeProxy": "0xc3016ED03E087d092d576B585F5222fFD9cadc10",
+            "L1StandardBridgeProxy": "0x5638e55db5Fcf7A58df525F1098E8569C8DbA80c",
+            "L2OutputOracleProxy": "0xB5901509329307E3f910f333Fa9C4B4A8EE7CE1A",
+            "OptimismMintableERC20FactoryProxy": "0xEAa11178375e6B1078d815d6F9F85cBbb69b09Cd",
+            "OptimismPortalProxy": "0x579c82A835B884336B632eeBeCC78FA08D3291Ec",
+            "Proposer": "0xf99C2Da4822Af652fe1BF55F99713980efe5D261",
+            "ProxyAdmin": "0xC5aE9023bFA79124ffA50169E1423E733D0166f1",
+            "ProxyAdminOwner": "0xAf6E0E871f38c7B653700F7CbAEDafaa2784D430",
+            "SystemConfigOwner": "0xAf6E0E871f38c7B653700F7CbAEDafaa2784D430",
+            "SystemConfigProxy": "0x7F67DC4959cb3E532B10A99F41bDD906C46FdFdE",
+            "UnsafeBlockSigner": "0xfd7bc3C58Fe4D4296F11F7843ebbA84D729A24B9"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/crates/registry/src/chain_list.rs
+++ b/crates/registry/src/chain_list.rs
@@ -1,0 +1,67 @@
+//! List of OP Stack chains.
+
+use alloc::{string::String, vec::Vec};
+
+/// List of Chains.
+#[derive(Debug, Clone, Default, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ChainList {
+    /// List of Chains.
+    pub chains: Vec<Chain>,
+}
+
+/// A Chain Definition.
+#[derive(Debug, Clone, Default, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Chain {
+    /// The name of the chain.
+    pub name: String,
+    /// Chain identifier.
+    pub identifier: String,
+    /// Chain ID.
+    pub chain_id: u64,
+    /// List of RPC Endpoints.
+    pub rpc: Vec<String>,
+    /// List of Explorer Endpoints.
+    pub explorers: Vec<String>,
+    /// The Superchain Level.
+    pub superchain_level: u64,
+    /// The data avilability type.
+    pub data_availability_type: String,
+    /// The Superchain Parent.
+    pub parent: SuperchainParent,
+}
+
+/// A Chain Parent
+#[derive(Debug, Clone, Default, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SuperchainParent {
+    /// The parent type.
+    pub r#type: String,
+    /// The chain identifier.
+    pub chain: String,
+}
+
+impl SuperchainParent {
+    /// Returns the chain id for the parent.
+    pub fn chain_id(&self) -> u64 {
+        match self.chain.as_ref() {
+            "mainnet" => 1,
+            "sepolia" => 11155111,
+            "sepolia-dev-0" => 11155421,
+            _ => 10,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_chain_list_file() {
+        let chain_list = include_str!("../etc/chainList.json");
+        let chains: Vec<Chain> = serde_json::from_str(chain_list).unwrap();
+        let base_chain = chains.iter().find(|c| c.name == "Base").unwrap();
+        assert_eq!(base_chain.chain_id, 8453);
+    }
+}

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -1,0 +1,51 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/alloy.jpg",
+    html_favicon_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/favicon.ico"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
+
+extern crate alloc;
+
+pub use alloy_primitives::map::{DefaultHashBuilder, HashMap};
+pub use op_alloy_genesis::{ChainConfig, RollupConfig};
+
+pub mod chain_list;
+pub use chain_list::{Chain, ChainList};
+
+pub mod superchain;
+pub use superchain::Registry;
+
+lazy_static::lazy_static! {
+    /// Private initializer that loads the superchain configurations.
+    static ref _INIT: Registry = Registry::from_chain_list();
+
+    /// Chain configurations exported from the registry
+    pub static ref CHAINS: alloc::vec::Vec<Chain> = _INIT.chains.clone();
+
+    /// OP Chain configurations exported from the registry
+    pub static ref OPCHAINS: HashMap<u64, ChainConfig, DefaultHashBuilder> = _INIT.op_chains.clone();
+
+    /// Rollup configurations exported from the registry
+    pub static ref ROLLUP_CONFIGS: HashMap<u64, RollupConfig, DefaultHashBuilder> = _INIT.rollup_configs.clone();
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_hardcoded_rollup_configs() {
+        let test_cases = vec![
+            (10, op_alloy_genesis::OP_MAINNET_CONFIG),
+            (8453, op_alloy_genesis::BASE_MAINNET_CONFIG),
+            (11155420, op_alloy_genesis::OP_SEPOLIA_CONFIG),
+            (84532, op_alloy_genesis::BASE_SEPOLIA_CONFIG),
+        ];
+
+        for (chain_id, expected) in test_cases {
+            let derived = super::ROLLUP_CONFIGS.get(&chain_id).unwrap();
+            assert_eq!(expected, *derived);
+        }
+    }
+}

--- a/crates/registry/src/superchain.rs
+++ b/crates/registry/src/superchain.rs
@@ -1,0 +1,216 @@
+//! Contains the full superchain data.
+
+use super::Chain;
+use alloc::{string::String, vec::Vec};
+use alloy_primitives::{
+    map::{DefaultHashBuilder, HashMap},
+    Address,
+};
+use op_alloy_genesis::{ChainConfig, HardForkConfiguration, RollupConfig};
+
+/// A superchain configuration.
+#[derive(Debug, Clone, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Superchain {
+    /// Superchain identifier, without capitalization or display changes.
+    pub name: String,
+    /// Superchain configuration file contents.
+    pub config: SuperchainConfig,
+    /// Chain IDs of chains that are part of this superchain.
+    pub chains: Vec<ChainConfig>,
+}
+
+/// A superchain configuration file format
+#[derive(Debug, Clone, Default, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct SuperchainConfig {
+    /// Superchain name (e.g. "Mainnet")
+    pub name: String,
+    /// Superchain L1 anchor information
+    pub l1: SuperchainL1Info,
+    /// Optional addresses for the superchain-wide default protocol versions contract.
+    pub protocol_versions_addr: Option<Address>,
+    /// Optional address for the superchain-wide default superchain config contract.
+    pub superchain_config_addr: Option<Address>,
+    /// Hardfork Configuration. These values may be overridden by individual chains.
+    #[serde(flatten)]
+    pub hardfork_defaults: HardForkConfiguration,
+}
+
+/// Superchain L1 anchor information
+#[derive(Debug, Clone, Default, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct SuperchainL1Info {
+    /// L1 chain ID
+    #[serde(rename = "ChainID")]
+    pub chain_id: u64,
+    /// L1 chain public RPC endpoint
+    #[serde(rename = "PublicRPC")]
+    pub public_rpc: String,
+    /// L1 chain explorer RPC endpoint
+    pub explorer: String,
+}
+
+/// A list of Hydrated Superchain Configs.
+#[derive(Debug, Clone, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Superchains {
+    /// A list of superchain configs.
+    pub superchains: Vec<Superchain>,
+}
+
+/// The registry containing all the superchain configurations.
+#[derive(Debug, Clone, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Registry {
+    /// The list of chains.
+    pub chains: Vec<Chain>,
+    /// Map of chain IDs to their chain configuration.
+    pub op_chains: HashMap<u64, ChainConfig, DefaultHashBuilder>,
+    /// Map of chain IDs to their rollup configurations.
+    pub rollup_configs: HashMap<u64, RollupConfig, DefaultHashBuilder>,
+}
+
+impl Registry {
+    /// Read the chain list.
+    pub fn read_chain_list() -> Vec<Chain> {
+        let chain_list = include_str!("../etc/chainList.json");
+        serde_json::from_str(chain_list).expect("Failed to read chain list")
+    }
+
+    /// Read superchain configs.
+    pub fn read_superchain_configs() -> Superchains {
+        let superchain_configs = include_str!("../etc/configs.json");
+        serde_json::from_str(superchain_configs).expect("Failed to read superchain configs")
+    }
+
+    /// Initialize the superchain configurations from the chain list.
+    pub fn from_chain_list() -> Self {
+        let chains = Self::read_chain_list();
+        let superchains = Self::read_superchain_configs();
+        let mut op_chains = HashMap::default();
+        let mut rollup_configs = HashMap::default();
+
+        for superchain in superchains.superchains {
+            for mut chain_config in superchain.chains {
+                chain_config.l1_chain_id = superchain.config.l1.chain_id;
+                if let Some(a) = &mut chain_config.addresses {
+                    a.zero_proof_addresses();
+                }
+                let mut rollup = chain_config.load_op_stack_rollup_config();
+                rollup.protocol_versions_address = superchain
+                    .config
+                    .protocol_versions_addr
+                    .expect("Missing protocol versions address");
+                rollup.superchain_config_address = superchain.config.superchain_config_addr;
+                rollup_configs.insert(chain_config.chain_id, rollup);
+                op_chains.insert(chain_config.chain_id, chain_config);
+            }
+        }
+
+        Self { chains, op_chains, rollup_configs }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_eips::BlockNumHash;
+    use alloy_primitives::{address, b256, uint};
+    use op_alloy_genesis::{
+        AddressList, ChainGenesis, HardForkConfiguration, SuperchainLevel, SystemConfig,
+        OP_MAINNET_BASE_FEE_PARAMS,
+    };
+
+    #[test]
+    fn test_read_chain_configs() {
+        let superchains = Registry::from_chain_list();
+        assert!(superchains.chains.len() > 1);
+        let base_config = ChainConfig {
+            name: String::from("Base"),
+            chain_id: 8453,
+            l1_chain_id: 1,
+            public_rpc: String::from("https://mainnet.base.org"),
+            sequencer_rpc: String::from("https://mainnet-sequencer.base.org"),
+            explorer: String::from("https://explorer.base.org"),
+            superchain_level: SuperchainLevel::Frontier,
+            standard_chain_candidate: true,
+            superchain_time: Some(0),
+            batch_inbox_addr: address!("ff00000000000000000000000000000000008453"),
+            superchain: String::from("mainnet"),
+            chain: String::new(),
+            hardfork_configuration: HardForkConfiguration {
+                canyon_time: Some(1704992401),
+                delta_time: Some(1708560000),
+                ecotone_time: Some(1710374401),
+                fjord_time: Some(1720627201),
+                granite_time: Some(1726070401),
+                holocene_time: None,
+            },
+            block_time: 2,
+            seq_window_size: 3600,
+            max_sequencer_drift: 600,
+            data_availability_type: "eth-da".to_string(),
+            optimism: Some(OP_MAINNET_BASE_FEE_PARAMS),
+            alt_da: None,
+            genesis: ChainGenesis {
+                l1: BlockNumHash {
+                    number: 17481768,
+                    hash: b256!("5c13d307623a926cd31415036c8b7fa14572f9dac64528e857a470511fc30771"),
+                },
+                l2: BlockNumHash {
+                    number: 0,
+                    hash: b256!("f712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd"),
+                },
+                l2_time: 1686789347,
+                system_config: Some(SystemConfig {
+                    batcher_address: address!("5050F69a9786F081509234F1a7F4684b5E5b76C9"),
+                    overhead: uint!(0xbc_U256),
+                    scalar: uint!(0xa6fe0_U256),
+                    gas_limit: 30000000_u64,
+                    ..Default::default()
+                }),
+            },
+            addresses: Some(AddressList {
+                address_manager: address!("8EfB6B5c4767B09Dc9AA6Af4eAA89F749522BaE2"),
+                l1_cross_domain_messenger_proxy: address!(
+                    "866E82a600A1414e583f7F13623F1aC5d58b0Afa"
+                ),
+                l1_erc721_bridge_proxy: address!("608d94945A64503E642E6370Ec598e519a2C1E53"),
+                l1_standard_bridge_proxy: address!("3154Cf16ccdb4C6d922629664174b904d80F2C35"),
+                l2_output_oracle_proxy: Some(address!("56315b90c40730925ec5485cf004d835058518A0")),
+                optimism_mintable_erc20_factory_proxy: address!(
+                    "05cc379EBD9B30BbA19C6fA282AB29218EC61D84"
+                ),
+                optimism_portal_proxy: address!("49048044D57e1C92A77f79988d21Fa8fAF74E97e"),
+                system_config_proxy: address!("73a79Fab69143498Ed3712e519A88a918e1f4072"),
+                system_config_owner: address!("14536667Cd30e52C0b458BaACcB9faDA7046E056"),
+                proxy_admin: address!("0475cBCAebd9CE8AfA5025828d5b98DFb67E059E"),
+                proxy_admin_owner: address!("7bB41C3008B3f03FE483B28b8DB90e19Cf07595c"),
+                challenger: Some(address!("6F8C5bA3F59ea3E76300E3BEcDC231D656017824")),
+                guardian: address!("09f7150d8c019bef34450d6920f6b3608cefdaf2"),
+                anchor_state_registry_proxy: Some(address!(
+                    "db9091e48b1c42992a1213e6916184f9ebdbfedf"
+                )),
+                delayed_weth_proxy: Some(address!("a2f2ac6f5af72e494a227d79db20473cf7a1ffe8")),
+                dispute_game_factory_proxy: Some(address!(
+                    "43edb88c4b80fdd2adff2412a7bebf9df42cb40e"
+                )),
+                fault_dispute_game: Some(address!("cd3c0194db74c23807d4b90a5181e1b28cf7007c")),
+                mips: Some(address!("16e83ce5ce29bf90ad9da06d2fe6a15d5f344ce4")),
+                permissioned_dispute_game: Some(address!(
+                    "19009debf8954b610f207d5925eede827805986e"
+                )),
+                preimage_oracle: Some(address!("9c065e11870b891d214bc2da7ef1f9ddfa1be277")),
+            }),
+            gas_paying_token: None,
+        };
+        assert_eq!(*superchains.op_chains.get(&8453).unwrap(), base_config);
+    }
+
+    #[test]
+    fn test_read_rollup_configs() {
+        use op_alloy_genesis::OP_MAINNET_CONFIG;
+        let superchains = Registry::from_chain_list();
+        assert_eq!(*superchains.rollup_configs.get(&10).unwrap(), OP_MAINNET_CONFIG);
+    }
+}


### PR DESCRIPTION
### Description

Migrates `superchain-registry` crate into `op-alloy` so hardcoded configs and periphery methods in `op-alloy-genesis` can be removed.

Since `op-alloy-registry` is `no_std`, we can use the rollup configs parsed from the `ethereum-optimism/superchain-registry` directly
instead of defining custom hardcoded registries.