### PR TITLE
chore(ci): Run examples in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,19 @@ jobs:
           components: rustfmt
       - run: just fmt-check
 
+  examples:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: taiki-e/install-action@just
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly
+      - run: just examples
+
   cfg-check:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/Justfile
+++ b/Justfile
@@ -5,6 +5,7 @@ alias f := fmtf
 alias b := build
 alias h := hack
 alias c := check
+alias e := examples
 
 # default recipe to display help information
 default:
@@ -62,3 +63,11 @@ source:
 # Generate file bindings for super-registry
 bind:
   @just --justfile ./crates/registry/Justfile bind
+
+# List all available examples and run each one
+examples:
+  example_list=$(cargo build --example 2>&1); \
+  example_list=$(echo "$example_list" | tail -n +3 | sed 's/^[ \t]*//;s/[ \t]*$//'); \
+  for example in $example_list; do \
+    cargo run --example $example; \
+  done


### PR DESCRIPTION
### Description

Adds a `Justfile` target that runs all examples and executes `just examples` in ci. Ensures examples succeed on pull request.