### PR TITLE
chore(consensus): EIP-2718 Encoding Trait Impls

### DIFF
--- a/crates/consensus/src/hardforks/ecotone.rs
+++ b/crates/consensus/src/hardforks/ecotone.rs
@@ -3,6 +3,7 @@
 //! [Transaction]: alloy_consensus::Transaction
 
 use alloc::{string::String, vec::Vec};
+use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{address, hex, Address, Bytes, TxKind, B256, U256};
 
 use crate::{Hardfork, TxDeposit, UpgradeDepositSource};
@@ -160,7 +161,7 @@ impl Hardfork for Ecotone {
     fn txs(&self) -> impl Iterator<Item = Bytes> + '_ {
         Self::deposits().map(|tx| {
             let mut encoded = Vec::new();
-            tx.eip2718_encode(&mut encoded);
+            tx.encode_2718(&mut encoded);
             Bytes::from(encoded)
         })
     }

--- a/crates/consensus/src/hardforks/fjord.rs
+++ b/crates/consensus/src/hardforks/fjord.rs
@@ -3,6 +3,7 @@
 //! [Transaction]: alloy_consensus::Transaction
 
 use alloc::{string::String, vec::Vec};
+use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{address, hex, Address, Bytes, TxKind, B256, U256};
 
 use crate::{Hardfork, TxDeposit, UpgradeDepositSource};
@@ -98,7 +99,7 @@ impl Hardfork for Fjord {
     fn txs(&self) -> impl Iterator<Item = Bytes> + '_ {
         Self::deposits().map(|tx| {
             let mut encoded = Vec::new();
-            tx.eip2718_encode(&mut encoded);
+            tx.encode_2718(&mut encoded);
             Bytes::from(encoded)
         })
     }

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -415,7 +415,7 @@ impl Encodable2718 for OpTxEnvelope {
                 tx.eip2718_encode(out);
             }
             Self::Deposit(tx) => {
-                tx.eip2718_encode(out);
+                tx.encode_2718(out);
             }
         }
     }

--- a/crates/protocol/src/deposits.rs
+++ b/crates/protocol/src/deposits.rs
@@ -1,6 +1,7 @@
 //! Contains deposit transaction types and helper methods.
 
 use alloc::{string::String, vec::Vec};
+use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{b256, keccak256, Address, Bytes, Log, TxKind, B256, U256, U64};
 use core::fmt::Display;
 use op_alloy_consensus::TxDeposit;
@@ -334,7 +335,7 @@ pub fn decode_deposit(block_hash: B256, index: usize, log: &Log) -> Result<Bytes
 
     // Re-encode the deposit transaction
     let mut buffer = Vec::with_capacity(deposit_tx.eip2718_encoded_length());
-    deposit_tx.eip2718_encode(&mut buffer);
+    deposit_tx.encode_2718(&mut buffer);
     Ok(Bytes::from(buffer))
 }
 


### PR DESCRIPTION
### Description

Moves custom EIP-2718 encoding and decoding methods on `TxDeposit` into trait impls for the alloy eip traits.