### PR TITLE
chore(ci): Add missing no_std crates

### DIFF
--- a/crates/op-alloy/src/lib.rs
+++ b/crates/op-alloy/src/lib.rs
@@ -5,6 +5,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(any(feature = "full", feature = "std")), no_std)]
 
 #[cfg(feature = "consensus")]
 #[doc(inline)]

--- a/scripts/check_no_std.sh
+++ b/scripts/check_no_std.sh
@@ -2,8 +2,10 @@
 set -eo pipefail
 
 no_std_packages=(
+  op-alloy
   op-alloy-consensus
   op-alloy-protocol
+  op-alloy-registry
   op-alloy-genesis
   op-alloy-rpc-types
   op-alloy-rpc-types-engine


### PR DESCRIPTION
### Description

Adds missing crates to the `no_std` checks that support `no_std`.