### PR TITLE
fix(op-alloy): Add Missing Registry Crate

### DIFF
--- a/crates/op-alloy/Cargo.toml
+++ b/crates/op-alloy/Cargo.toml
@@ -23,6 +23,7 @@ op-alloy-consensus = { workspace = true, optional = true }
 op-alloy-genesis = { workspace = true, optional = true }
 op-alloy-network = { workspace = true, optional = true }
 op-alloy-protocol = { workspace = true, optional = true }
+op-alloy-registry = { workspace = true, optional = true }
 op-alloy-provider = { workspace = true, optional = true }
 op-alloy-rpc-jsonrpsee = { workspace = true, optional = true }
 op-alloy-rpc-types-engine = { workspace = true, optional = true }
@@ -35,6 +36,7 @@ std = [
   "op-alloy-consensus?/std",
   "op-alloy-genesis?/std",
   "op-alloy-protocol?/std",
+  "op-alloy-registry?/std",
   "op-alloy-rpc-types?/std",
   "op-alloy-rpc-types-engine?/std",
 ]
@@ -43,6 +45,7 @@ full = [
   "consensus",
   "genesis",
   "provider",
+  "registry",
   "network",
   "protocol",
   "rpc-types",
@@ -72,6 +75,7 @@ serde = [
 # `no_std` support
 consensus = ["dep:op-alloy-consensus"]
 genesis = ["dep:op-alloy-genesis"]
+registry = ["dep:op-alloy-registry"]
 protocol = ["dep:op-alloy-protocol"]
 rpc-types = ["dep:op-alloy-rpc-types"]
 rpc-types-engine = ["dep:op-alloy-rpc-types-engine"]

--- a/crates/op-alloy/src/lib.rs
+++ b/crates/op-alloy/src/lib.rs
@@ -22,6 +22,10 @@ pub use op_alloy_network as network;
 #[doc(inline)]
 pub use op_alloy_protocol as protocol;
 
+#[cfg(feature = "registry")]
+#[doc(inline)]
+pub use op_alloy_registry as registry;
+
 #[cfg(feature = "provider")]
 #[doc(inline)]
 pub use op_alloy_provider as provider;


### PR DESCRIPTION
### Description

Adds the missing `op-alloy-registry` to the `op-alloy` aggregator crate under the `registry` feature flag.