### PR TITLE
chore(workspace): Remove Hand-rolled Display Error Impls

### DIFF
--- a/crates/consensus/src/eip1559.rs
+++ b/crates/consensus/src/eip1559.rs
@@ -47,26 +47,15 @@ pub fn decode_holocene_extra_data(
 /// Error type for EIP-1559 parameters
 #[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
 pub enum EIP1559ParamError {
-    /// No EIP-1559 parameters provided
+    /// No EIP-1559 parameters provided.
+    #[error("No EIP1559 parameters provided")]
     NoEIP1559Params,
-    /// Denominator overflow
+    /// Denominator overflow.
+    #[error("Denominator overflow")]
     DenominatorOverflow,
-    /// Elasticity overflow
+    /// Elasticity overflow.
+    #[error("Elasticity overflow")]
     ElasticityOverflow,
-}
-
-impl core::fmt::Display for EIP1559ParamError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::NoEIP1559Params => {
-                write!(f, "No EIP1559 parameters provided")
-            }
-            Self::DenominatorOverflow => write!(f, "Denominator overflow"),
-            Self::ElasticityOverflow => {
-                write!(f, "Elasticity overflow")
-            }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/genesis/src/system.rs
+++ b/crates/genesis/src/system.rs
@@ -329,27 +329,20 @@ impl SystemConfig {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SystemConfigUpdateError {
     /// An error occurred while processing the update log.
+    #[error("Log processing error: {0}")]
     LogProcessing(LogProcessingError),
     /// A batcher update error.
+    #[error("Batcher update error: {0}")]
     Batcher(BatcherUpdateError),
     /// A gas config update error.
+    #[error("Gas config update error: {0}")]
     GasConfig(GasConfigUpdateError),
     /// A gas limit update error.
+    #[error("Gas limit update error: {0}")]
     GasLimit(GasLimitUpdateError),
     /// An EIP-1559 parameter update error.
+    #[error("EIP-1559 parameter update error: {0}")]
     Eip1559(EIP1559UpdateError),
-}
-
-impl core::fmt::Display for SystemConfigUpdateError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::LogProcessing(err) => write!(f, "Log processing error: {}", err),
-            Self::Batcher(err) => write!(f, "Batcher update error: {}", err),
-            Self::GasConfig(err) => write!(f, "Gas config update error: {}", err),
-            Self::GasLimit(err) => write!(f, "Gas limit update error: {}", err),
-            Self::Eip1559(err) => write!(f, "EIP-1559 parameter update error: {}", err),
-        }
-    }
 }
 
 /// An error occurred while processing the update log.
@@ -357,35 +350,20 @@ impl core::fmt::Display for SystemConfigUpdateError {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum LogProcessingError {
     /// Received an incorrect number of log topics.
+    #[error("Invalid config update log: invalid topic length: {0}")]
     InvalidTopicLen(usize),
     /// The log topic is invalid.
+    #[error("Invalid config update log: invalid topic")]
     InvalidTopic,
     /// The config update log version is unsupported.
+    #[error("Invalid config update log: unsupported version: {0}")]
     UnsupportedVersion(B256),
     /// Failed to decode the update type from the config update log.
+    #[error("Failed to decode config update log: update type")]
     UpdateTypeDecodingError,
     /// An invalid system config update type.
+    #[error("Invalid system config update type: {0}")]
     InvalidSystemConfigUpdateType(u64),
-}
-
-impl core::fmt::Display for LogProcessingError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::InvalidTopicLen(len) => {
-                write!(f, "Invalid config update log: invalid topic length: {}", len)
-            }
-            Self::InvalidTopic => write!(f, "Invalid config update log: invalid topic"),
-            Self::UnsupportedVersion(version) => {
-                write!(f, "Invalid config update log: unsupported version: {}", version)
-            }
-            Self::UpdateTypeDecodingError => {
-                write!(f, "Failed to decode config update log: update type")
-            }
-            Self::InvalidSystemConfigUpdateType(value) => {
-                write!(f, "Invalid system config update type: {}", value)
-            }
-        }
-    }
 }
 
 /// An error for updating the batcher address on the [SystemConfig].
@@ -393,42 +371,23 @@ impl core::fmt::Display for LogProcessingError {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BatcherUpdateError {
     /// Invalid data length.
+    #[error("Invalid config update log: invalid data length: {0}")]
     InvalidDataLen(usize),
     /// Failed to decode the data pointer argument from the batcher update log.
+    #[error("Failed to decode batcher update log: data pointer")]
     PointerDecodingError,
     /// The data pointer is invalid.
+    #[error("Invalid config update log: invalid data pointer: {0}")]
     InvalidDataPointer(u64),
     /// Failed to decode the data length argument from the batcher update log.
+    #[error("Failed to decode batcher update log: data length")]
     LengthDecodingError,
     /// The data length is invalid.
+    #[error("Invalid config update log: invalid data length: {0}")]
     InvalidDataLength(u64),
     /// Failed to decode the batcher address argument from the batcher update log.
+    #[error("Failed to decode batcher update log: batcher address")]
     BatcherAddressDecodingError,
-}
-
-impl core::fmt::Display for BatcherUpdateError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::InvalidDataLen(len) => {
-                write!(f, "Invalid config update log: invalid data length: {}", len)
-            }
-            Self::PointerDecodingError => {
-                write!(f, "Failed to decode batcher update log: data pointer")
-            }
-            Self::InvalidDataPointer(pointer) => {
-                write!(f, "Invalid config update log: invalid data pointer: {}", pointer)
-            }
-            Self::LengthDecodingError => {
-                write!(f, "Failed to decode batcher update log: data length")
-            }
-            Self::InvalidDataLength(length) => {
-                write!(f, "Invalid config update log: invalid data length: {}", length)
-            }
-            Self::BatcherAddressDecodingError => {
-                write!(f, "Failed to decode batcher update log: batcher address")
-            }
-        }
-    }
 }
 
 /// An error for updating the gas config on the [SystemConfig].
@@ -436,47 +395,26 @@ impl core::fmt::Display for BatcherUpdateError {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum GasConfigUpdateError {
     /// Invalid data length.
+    #[error("Invalid config update log: invalid data length: {0}")]
     InvalidDataLen(usize),
     /// Failed to decode the data pointer argument from the gas config update log.
+    #[error("Failed to decode gas config update log: data pointer")]
     PointerDecodingError,
     /// The data pointer is invalid.
+    #[error("Invalid config update log: invalid data pointer: {0}")]
     InvalidDataPointer(u64),
     /// Failed to decode the data length argument from the gas config update log.
+    #[error("Failed to decode gas config update log: data length")]
     LengthDecodingError,
     /// The data length is invalid.
+    #[error("Invalid config update log: invalid data length: {0}")]
     InvalidDataLength(u64),
     /// Failed to decode the overhead argument from the gas config update log.
+    #[error("Failed to decode gas config update log: overhead")]
     OverheadDecodingError,
     /// Failed to decode the scalar argument from the gas config update log.
+    #[error("Failed to decode gas config update log: scalar")]
     ScalarDecodingError,
-}
-
-impl core::fmt::Display for GasConfigUpdateError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::InvalidDataLen(len) => {
-                write!(f, "Invalid config update log: invalid data length: {}", len)
-            }
-            Self::PointerDecodingError => {
-                write!(f, "Failed to decode gas config update log: data pointer")
-            }
-            Self::InvalidDataPointer(pointer) => {
-                write!(f, "Invalid config update log: invalid data pointer: {}", pointer)
-            }
-            Self::LengthDecodingError => {
-                write!(f, "Failed to decode gas config update log: data length")
-            }
-            Self::InvalidDataLength(length) => {
-                write!(f, "Invalid config update log: invalid data length: {}", length)
-            }
-            Self::OverheadDecodingError => {
-                write!(f, "Failed to decode gas config update log: overhead")
-            }
-            Self::ScalarDecodingError => {
-                write!(f, "Failed to decode gas config update log: scalar")
-            }
-        }
-    }
 }
 
 /// An error for updating the gas limit on the [SystemConfig].
@@ -484,42 +422,23 @@ impl core::fmt::Display for GasConfigUpdateError {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum GasLimitUpdateError {
     /// Invalid data length.
+    #[error("Invalid config update log: invalid data length: {0}")]
     InvalidDataLen(usize),
     /// Failed to decode the data pointer argument from the gas limit update log.
+    #[error("Failed to decode gas limit update log: data pointer")]
     PointerDecodingError,
     /// The data pointer is invalid.
+    #[error("Invalid config update log: invalid data pointer: {0}")]
     InvalidDataPointer(u64),
     /// Failed to decode the data length argument from the gas limit update log.
+    #[error("Failed to decode gas limit update log: data length")]
     LengthDecodingError,
     /// The data length is invalid.
+    #[error("Invalid config update log: invalid data length: {0}")]
     InvalidDataLength(u64),
     /// Failed to decode the gas limit argument from the gas limit update log.
+    #[error("Failed to decode gas limit update log: gas limit")]
     GasLimitDecodingError,
-}
-
-impl core::fmt::Display for GasLimitUpdateError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::InvalidDataLen(len) => {
-                write!(f, "Invalid config update log: invalid data length: {}", len)
-            }
-            Self::PointerDecodingError => {
-                write!(f, "Failed to decode gas limit update log: data pointer")
-            }
-            Self::InvalidDataPointer(pointer) => {
-                write!(f, "Invalid config update log: invalid data pointer: {}", pointer)
-            }
-            Self::LengthDecodingError => {
-                write!(f, "Failed to decode gas limit update log: data length")
-            }
-            Self::InvalidDataLength(length) => {
-                write!(f, "Invalid config update log: invalid data length: {}", length)
-            }
-            Self::GasLimitDecodingError => {
-                write!(f, "Failed to decode gas limit update log: gas limit")
-            }
-        }
-    }
 }
 
 /// An error for updating the EIP-1559 parameters on the [SystemConfig].
@@ -527,45 +446,23 @@ impl core::fmt::Display for GasLimitUpdateError {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum EIP1559UpdateError {
     /// Invalid data length.
+    #[error("Invalid config update log: invalid data length: {0}")]
     InvalidDataLen(usize),
     /// Failed to decode the data pointer argument from the eip 1559 update log.
+    #[error("Failed to decode eip1559 parameter update log: data pointer")]
     PointerDecodingError,
     /// The data pointer is invalid.
+    #[error("Invalid config update log: invalid data pointer: {0}")]
     InvalidDataPointer(u64),
     /// Failed to decode the data length argument from the eip 1559 update log.
+    #[error("Failed to decode eip1559 parameter update log: data length")]
     LengthDecodingError,
     /// The data length is invalid.
+    #[error("Invalid config update log: invalid data length: {0}")]
     InvalidDataLength(u64),
     /// Failed to decode the eip1559 params argument from the eip 1559 update log.
+    #[error("Failed to decode eip1559 parameter update log: eip1559 parameters")]
     EIP1559DecodingError,
-}
-
-impl core::fmt::Display for EIP1559UpdateError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::InvalidDataLen(len) => {
-                write!(f, "Invalid config update log: invalid data length: {}", len)
-            }
-            Self::PointerDecodingError => {
-                write!(f, "Failed to decode eip1559 parameter update log: data pointer")
-            }
-            Self::InvalidDataPointer(pointer) => {
-                write!(f, "Invalid config update log: invalid data pointer: {}", pointer)
-            }
-            Self::LengthDecodingError => {
-                write!(f, "Failed to decode eip1559 parameter update log: data length")
-            }
-            Self::InvalidDataLength(length) => {
-                write!(f, "Invalid config update log: invalid data length: {}", length)
-            }
-            Self::EIP1559DecodingError => {
-                write!(
-                    f,
-                    "Failed to decode eip1559 parameter update log: eip1559 parameters invalid"
-                )
-            }
-        }
-    }
 }
 
 /// System accounts

--- a/crates/protocol/src/channel.rs
+++ b/crates/protocol/src/channel.rs
@@ -143,29 +143,20 @@ pub const MAX_RLP_BYTES_PER_CHANNEL: u64 = 10_000_000;
 pub const FJORD_MAX_RLP_BYTES_PER_CHANNEL: u64 = 100_000_000;
 
 /// An error returned when adding a frame to a channel.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ChannelError {
     /// The frame id does not match the channel id.
+    #[error("Frame id does not match channel id")]
     FrameIdMismatch,
     /// The channel is closed.
+    #[error("Channel is closed")]
     ChannelClosed,
     /// The frame number is already in the channel.
+    #[error("Frame number {0} already exists")]
     FrameNumberExists(usize),
     /// The frame number is beyond the end frame.
+    #[error("Frame number {0} is beyond end frame")]
     FrameBeyondEndFrame(usize),
-}
-
-impl core::fmt::Display for ChannelError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::FrameIdMismatch => write!(f, "Frame id does not match channel id"),
-            Self::ChannelClosed => write!(f, "Channel is closed"),
-            Self::FrameNumberExists(n) => write!(f, "Frame number {} already exists", n),
-            Self::FrameBeyondEndFrame(n) => {
-                write!(f, "Frame number {} is beyond end frame", n)
-            }
-        }
-    }
 }
 
 /// A Channel is a set of batches that are split into at least one, but possibly multiple frames.

--- a/crates/protocol/src/deposits.rs
+++ b/crates/protocol/src/deposits.rs
@@ -3,7 +3,6 @@
 use alloc::{string::String, vec::Vec};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{b256, keccak256, Address, Bytes, Log, TxKind, B256, U256, U64};
-use core::fmt::Display;
 use op_alloy_consensus::TxDeposit;
 
 /// Deposit log event abi signature.
@@ -23,92 +22,50 @@ pub const DEPOSIT_EVENT_VERSION_0: B256 = B256::ZERO;
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum DepositError {
     /// Unexpected number of deposit event log topics.
+    #[error("Unexpected number of deposit event log topics: {0}")]
     UnexpectedTopicsLen(usize),
     /// Invalid deposit event selector.
     /// Expected: [B256] (deposit event selector), Actual: [B256] (event log topic).
+    #[error("Invalid deposit event selector: {1}, expected {0}")]
     InvalidSelector(B256, B256),
     /// Incomplete opaqueData slice header (incomplete length).
+    #[error("Incomplete opaqueData slice header (incomplete length): {0}")]
     IncompleteOpaqueData(usize),
     /// The log data is not aligned to 32 bytes.
+    #[error("Unaligned log data, expected multiple of 32 bytes, got: {0}")]
     UnalignedData(usize),
     /// Failed to decode the `from` field of the deposit event (the second topic).
+    #[error("Failed to decode the `from` address of the deposit log topic: {0}")]
     FromDecode(B256),
     /// Failed to decode the `to` field of the deposit event (the third topic).
+    #[error("Failed to decode the `to` address of the deposit log topic: {0}")]
     ToDecode(B256),
     /// Invalid opaque data content offset.
+    #[error("Invalid u64 opaque data content offset: {0}")]
     InvalidOpaqueDataOffset(Bytes),
     /// Invalid opaque data content length.
+    #[error("Invalid u64 opaque data content length: {0}")]
     InvalidOpaqueDataLength(Bytes),
     /// Opaque data length exceeds the deposit log event data length.
     /// Specified: [usize] (data length), Actual: [usize] (opaque data length).
+    #[error("Specified opaque data length {1} exceeds the deposit log event data length {0}")]
     OpaqueDataOverflow(usize, usize),
     /// Opaque data with padding exceeds the specified data length.
+    /// Specified: [usize] (data length), Actual: [usize] (opaque data length).
+    #[error("Opaque data with padding exceeds the specified data length: {1} > {0}")]
     PaddedOpaqueDataOverflow(usize, usize),
     /// An invalid deposit version.
+    #[error("Invalid deposit version: {0}")]
     InvalidVersion(B256),
-    /// Unexpected opaque data length
+    /// Unexpected opaque data length.
+    #[error("Unexpected opaque data length: {0}")]
     UnexpectedOpaqueDataLen(usize),
     /// Failed to decode the deposit mint value.
+    #[error("Failed to decode the u128 deposit mint value: {0}")]
     MintDecode(Bytes),
     /// Failed to decode the deposit gas value.
+    #[error("Failed to decode the u64 deposit gas value: {0}")]
     GasDecode(Bytes),
-}
-
-impl Display for DepositError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::UnexpectedTopicsLen(len) => {
-                write!(f, "Unexpected number of deposit event log topics: {}", len)
-            }
-            Self::InvalidSelector(expected, actual) => {
-                write!(f, "Invalid deposit event selector: {}, expected {}", actual, expected)
-            }
-            Self::IncompleteOpaqueData(len) => {
-                write!(f, "Incomplete opaqueData slice header (incomplete length): {}", len)
-            }
-            Self::UnalignedData(data) => {
-                write!(f, "Unaligned log data, expected multiple of 32 bytes, got: {}", data)
-            }
-            Self::FromDecode(topic) => {
-                write!(f, "Failed to decode the `from` address of the deposit log topic: {}", topic)
-            }
-            Self::ToDecode(topic) => {
-                write!(f, "Failed to decode the `to` address of the deposit log topic: {}", topic)
-            }
-            Self::InvalidOpaqueDataOffset(offset) => {
-                write!(f, "Invalid u64 opaque data content offset: {:?}", offset)
-            }
-            Self::InvalidOpaqueDataLength(length) => {
-                write!(f, "Invalid u64 opaque data content length: {:?}", length)
-            }
-            Self::OpaqueDataOverflow(data_len, opaque_len) => {
-                write!(
-                    f,
-                    "Specified opaque data length {} exceeds the deposit log event data length {}",
-                    opaque_len, data_len
-                )
-            }
-            Self::PaddedOpaqueDataOverflow(data_len, opaque_len) => {
-                write!(
-                    f,
-                    "Opaque data with padding exceeds the specified data length: {} > {}",
-                    opaque_len, data_len
-                )
-            }
-            Self::InvalidVersion(version) => {
-                write!(f, "Invalid deposit version: {}", version)
-            }
-            Self::UnexpectedOpaqueDataLen(len) => {
-                write!(f, "Unexpected opaque data length: {}", len)
-            }
-            Self::MintDecode(data) => {
-                write!(f, "Failed to decode the u128 deposit mint value: {:?}", data)
-            }
-            Self::GasDecode(data) => {
-                write!(f, "Failed to decode the u64 deposit gas value: {:?}", data)
-            }
-        }
-    }
 }
 
 /// Source domain identifiers for deposit transactions.

--- a/crates/protocol/src/frame.rs
+++ b/crates/protocol/src/frame.rs
@@ -16,61 +16,43 @@ pub const FRAME_OVERHEAD: usize = 200;
 pub const MAX_FRAME_LEN: usize = 1_000_000;
 
 /// A frame decoding error.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FrameDecodingError {
     /// The frame data is too large.
+    #[error("Frame data too large: {0} bytes")]
     DataTooLarge(usize),
     /// The frame data is too short.
+    #[error("Frame data too short: {0} bytes")]
     DataTooShort(usize),
     /// Error decoding the frame id.
+    #[error("Invalid frame id")]
     InvalidId,
     /// Error decoding the frame number.
+    #[error("Invalid frame number")]
     InvalidNumber,
     /// Error decoding the frame data length.
+    #[error("Invalid frame data length")]
     InvalidDataLength,
 }
 
-impl core::fmt::Display for FrameDecodingError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::DataTooLarge(size) => {
-                write!(f, "Frame data too large: {} bytes", size)
-            }
-            Self::DataTooShort(size) => {
-                write!(f, "Frame data too short: {} bytes", size)
-            }
-            Self::InvalidId => write!(f, "Invalid frame id"),
-            Self::InvalidNumber => write!(f, "Invalid frame number"),
-            Self::InvalidDataLength => write!(f, "Invalid frame data length"),
-        }
-    }
-}
-
 /// Frame parsing error.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FrameParseError {
     /// Error parsing the frame data.
+    #[error("Frame decoding error: {0}")]
     FrameDecodingError(FrameDecodingError),
     /// No frames to parse.
+    #[error("No frames to parse")]
     NoFrames,
     /// Unsupported derivation version.
+    #[error("Unsupported derivation version")]
     UnsupportedVersion,
     /// Frame data length mismatch.
+    #[error("Frame data length mismatch")]
     DataLengthMismatch,
     /// No frames decoded.
+    #[error("No frames decoded")]
     NoFramesDecoded,
-}
-
-impl core::fmt::Display for FrameParseError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::FrameDecodingError(e) => write!(f, "Frame decoding error: {}", e),
-            Self::NoFrames => write!(f, "No frames to parse"),
-            Self::UnsupportedVersion => write!(f, "Unsupported derivation version"),
-            Self::DataLengthMismatch => write!(f, "Frame data length mismatch"),
-            Self::NoFramesDecoded => write!(f, "No frames decoded"),
-        }
-    }
 }
 
 /// A channel frame is a segment of a channel's data.

--- a/crates/protocol/src/info/errors.rs
+++ b/crates/protocol/src/info/errors.rs
@@ -6,49 +6,29 @@ use alloc::string::String;
 #[derive(Debug, thiserror::Error, Copy, Clone)]
 pub enum BlockInfoError {
     /// Failed to parse the L1 blob base fee scalar.
+    #[error("Failed to parse the L1 blob base fee scalar")]
     L1BlobBaseFeeScalar,
     /// Failed to parse the base fee scalar.
+    #[error("Failed to parse the base fee scalar")]
     BaseFeeScalar,
     /// Failed to parse the EIP-1559 denominator.
+    #[error("Failed to parse the EIP-1559 denominator")]
     Eip1559Denominator,
     /// Failed to parse the EIP-1559 elasticity parameter.
+    #[error("Failed to parse the EIP-1559 elasticity parameter")]
     Eip1559Elasticity,
-}
-
-impl core::fmt::Display for BlockInfoError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::L1BlobBaseFeeScalar => {
-                write!(f, "Failed to parse the L1 blob base fee scalar")
-            }
-            Self::BaseFeeScalar => write!(f, "Failed to parse the base fee scalar"),
-            Self::Eip1559Denominator => {
-                write!(f, "Failed to parse the EIP-1559 denominator")
-            }
-            Self::Eip1559Elasticity => {
-                write!(f, "Failed to parse the EIP-1559 elasticity parameter")
-            }
-        }
-    }
 }
 
 /// An error decoding an L1 block info transaction.
 #[derive(Debug, thiserror::Error)]
 pub enum DecodeError {
-    /// Invalid selector for the L1 info transaction
+    /// Invalid selector for the L1 info transaction.
+    #[error("Invalid L1 info transaction selector")]
     InvalidSelector,
-    /// Parse error for the L1 info transaction
+    /// Parse error for the L1 info transaction.
+    #[error("Parse error: {0}")]
     ParseError(String),
-    /// Invalid length for the L1 info transaction
+    /// Invalid length for the L1 info transaction.
+    #[error("Invalid data length: {0}")]
     InvalidLength(String),
-}
-
-impl core::fmt::Display for DecodeError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::InvalidSelector => write!(f, "Invalid L1 info transaction selector"),
-            Self::ParseError(msg) => write!(f, "Parse error: {}", msg),
-            Self::InvalidLength(msg) => write!(f, "Invalid data length: {}", msg), /* Handle display for length errors */
-        }
-    }
 }


### PR DESCRIPTION
### Description

When using [`thiserror::Error`][error] with `#[error(..)]` attributes, a `Display` impl [is generated for the error](https://github.com/dtolnay/thiserror?tab=readme-ov-file#details).

This PR removes all hand-rolled Display impls for errors, using `thiserror::Error` with `#[error]` attributes on variants.

[error]: https://docs.rs/thiserror/latest/thiserror/derive.Error.html