### PR TITLE
chore(workspace): Remove Deprecated Methods for Next Minor Release

### DIFF
--- a/crates/consensus/src/hardforks/forks.rs
+++ b/crates/consensus/src/hardforks/forks.rs
@@ -1,7 +1,6 @@
-//! Contains all hardforks represented in the [Hardfork] type.
+//! Contains all hardforks represented in the [crate::Hardfork] type.
 
-use crate::{Ecotone, Fjord, Hardfork};
-use alloc::vec::Vec;
+use crate::{Ecotone, Fjord};
 
 /// Optimism Hardforks
 ///
@@ -34,23 +33,12 @@ impl Hardforks {
 
     /// The fjord hardfork upgrade transactions.
     pub const FJORD: Fjord = Fjord;
-
-    /// Returns the ecotone hardfork upgrade transactions.
-    #[deprecated]
-    pub fn ecotone_txs() -> Vec<alloy_primitives::Bytes> {
-        Ecotone.txs().collect()
-    }
-
-    /// Returns the fjord hardfork upgrade transactions.
-    #[deprecated]
-    pub fn fjord_txs() -> Vec<alloy_primitives::Bytes> {
-        Fjord.txs().collect()
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Hardfork;
 
     #[test]
     fn test_hardforks() {

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -38,8 +38,6 @@ mod genesis;
 pub use genesis::ChainGenesis;
 
 mod rollup;
-#[allow(deprecated)]
-pub use rollup::rollup_config_from_chain_id;
 pub use rollup::{
     RollupConfig, FJORD_MAX_SEQUENCER_DRIFT, GRANITE_CHANNEL_TIMEOUT,
     MAX_RLP_BYTES_PER_CHANNEL_BEDROCK, MAX_RLP_BYTES_PER_CHANNEL_FJORD,

--- a/crates/genesis/src/rollup.rs
+++ b/crates/genesis/src/rollup.rs
@@ -21,12 +21,6 @@ const fn default_granite_channel_timeout() -> u64 {
     GRANITE_CHANNEL_TIMEOUT
 }
 
-/// Returns the rollup config for the given chain ID.
-#[deprecated(since = "0.6.7", note = "Use the `op-alloy-registry` crate instead")]
-pub const fn rollup_config_from_chain_id(_: u64) -> Result<RollupConfig, &'static str> {
-    Err("Use the `op-alloy-registry` crate instead")
-}
-
 /// The Rollup configuration.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -284,12 +278,6 @@ impl RollupConfig {
                 Err("Unrecognized scalar version")
             }
         }
-    }
-
-    /// Returns the [RollupConfig] for the given L2 chain ID.
-    #[deprecated(since = "0.6.7", note = "Use the `op-alloy-registry` crate instead")]
-    pub const fn from_l2_chain_id(_: u64) -> Option<Self> {
-        None
     }
 }
 


### PR DESCRIPTION
### Description

Drafting this up so as to not forget.

Want to delete deprecated methods in the next minor release.
We haven't been strictly following semver keeping breaking api changes to major, but I figure this is better than breaking through a patch.