### PR TITLE
Enable alloy-primitives/arbitrary in dev-deps

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -40,7 +40,7 @@ serde_json.workspace = true
 alloy-signer.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 arbitrary = { workspace = true, features = ["derive"] }
-alloy-primitives = { workspace = true, features = ["rand"] }
+alloy-primitives = { workspace = true, features = ["rand", "arbitrary"] }
 
 [features]
 default = ["std"]

--- a/crates/genesis/Cargo.toml
+++ b/crates/genesis/Cargo.toml
@@ -35,10 +35,17 @@ serde_repr = { workspace = true, optional = true }
 rand.workspace = true
 serde_json.workspace = true
 arbitrary = { workspace = true, features = ["derive"] }
-alloy-primitives = { workspace = true, features = ["rand"] }
+alloy-primitives = { workspace = true, features = ["rand", "arbitrary"] }
 
 [features]
 default = ["serde", "std"]
 std = []
-arbitrary = ["std", "dep:arbitrary", "alloy-consensus/arbitrary", "alloy-eips/arbitrary", "alloy-primitives/rand"]
+arbitrary = [
+    "std",
+    "dep:arbitrary",
+    "alloy-consensus/arbitrary",
+    "alloy-eips/arbitrary",
+    "alloy-primitives/rand",
+    "alloy-primitives/arbitrary",
+]
 serde = ["dep:serde", "dep:serde_repr", "alloy-primitives/serde", "alloy-eips/serde", "alloy-consensus/serde"]

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -60,6 +60,7 @@ alloy-sol-types.workspace = true
 tokio = { workspace = true, features = ["full"] }
 arbitrary = { workspace = true, features = ["derive"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
+alloy-primitives = { workspace = true, features = ["arbitrary"] }
 
 [features]
 default = ["serde", "std"]

--- a/crates/rpc-types-engine/Cargo.toml
+++ b/crates/rpc-types-engine/Cargo.toml
@@ -42,6 +42,7 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 arbtest.workspace = true
 serde_json.workspace = true
 arbitrary = { workspace = true, features = ["derive"] }
+alloy-primitives = { workspace = true, features = ["arbitrary"] }
 
 [features]
 default = ["std", "serde"]


### PR DESCRIPTION
Enables 

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Running tests individually locally fails.

## Solution

Enable `arbitrary` feature for `alloy-primtives` in dev-deps.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
