### PR TITLE
chore: reuse methods for receipt rlp

### DIFF
--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -56,20 +56,16 @@ impl OpDepositReceipt {
 }
 
 impl<T: Encodable> OpDepositReceipt<T> {
-    fn rlp_encoded_fields_length_with_bloom(&self, bloom: &Bloom) -> usize {
-        self.inner.status.length()
-            + self.inner.cumulative_gas_used.length()
-            + bloom.length()
-            + self.inner.logs.length()
+    /// Returns length of RLP-encoded receipt fields with the given [`Bloom`] without an RLP header.
+    pub fn rlp_encoded_fields_length_with_bloom(&self, bloom: &Bloom) -> usize {
+        self.inner.rlp_encoded_fields_length_with_bloom(bloom)
             + self.deposit_nonce.map_or(0, |nonce| nonce.length())
             + self.deposit_receipt_version.map_or(0, |version| version.length())
     }
 
-    fn rlp_encode_fields_with_bloom(&self, bloom: &Bloom, out: &mut dyn BufMut) {
-        self.inner.status.encode(out);
-        self.inner.cumulative_gas_used.encode(out);
-        bloom.encode(out);
-        self.inner.logs.encode(out);
+    /// RLP-encodes receipt fields with the given [`Bloom`] without an RLP header.
+    pub fn rlp_encode_fields_with_bloom(&self, bloom: &Bloom, out: &mut dyn BufMut) {
+        self.inner.rlp_encode_fields_with_bloom(bloom, out);
 
         if let Some(nonce) = self.deposit_nonce {
             nonce.encode(out);
@@ -79,29 +75,27 @@ impl<T: Encodable> OpDepositReceipt<T> {
         }
     }
 
-    fn rlp_header_with_bloom(&self, bloom: &Bloom) -> Header {
+    /// Returns RLP header for this receipt encoding with the given [`Bloom`].
+    pub fn rlp_header_with_bloom(&self, bloom: &Bloom) -> Header {
         Header { list: true, payload_length: self.rlp_encoded_fields_length_with_bloom(bloom) }
     }
 }
 
 impl<T: Decodable> OpDepositReceipt<T> {
-    fn rlp_decode_fields_with_bloom(buf: &mut &[u8]) -> alloy_rlp::Result<ReceiptWithBloom<Self>> {
-        let status = Decodable::decode(buf)?;
-        let cumulative_gas_used = Decodable::decode(buf)?;
-        let logs_bloom = Decodable::decode(buf)?;
-        let logs = Decodable::decode(buf)?;
+    /// RLP-decodes receipt's field with a [`Bloom`].
+    ///
+    /// Does not expect an RLP header.
+    pub fn rlp_decode_fields_with_bloom(buf: &mut &[u8]) -> alloy_rlp::Result<ReceiptWithBloom<Self>> {
+        let ReceiptWithBloom { receipt: inner, logs_bloom } =
+            Receipt::rlp_decode_fields_with_bloom(buf)?;
 
         let deposit_nonce = (!buf.is_empty()).then(|| Decodable::decode(buf)).transpose()?;
         let deposit_receipt_version =
             (!buf.is_empty()).then(|| Decodable::decode(buf)).transpose()?;
 
         Ok(ReceiptWithBloom {
-            receipt: Self {
-                inner: Receipt { status, cumulative_gas_used, logs },
-                deposit_nonce,
-                deposit_receipt_version,
-            },
             logs_bloom,
+            receipt: Self { inner, deposit_nonce, deposit_receipt_version },
         })
     }
 }

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -85,7 +85,9 @@ impl<T: Decodable> OpDepositReceipt<T> {
     /// RLP-decodes receipt's field with a [`Bloom`].
     ///
     /// Does not expect an RLP header.
-    pub fn rlp_decode_fields_with_bloom(buf: &mut &[u8]) -> alloy_rlp::Result<ReceiptWithBloom<Self>> {
+    pub fn rlp_decode_fields_with_bloom(
+        buf: &mut &[u8],
+    ) -> alloy_rlp::Result<ReceiptWithBloom<Self>> {
         let ReceiptWithBloom { receipt: inner, logs_bloom } =
             Receipt::rlp_decode_fields_with_bloom(buf)?;
 


### PR DESCRIPTION
Reuses methods from alloy receipt for deposit receipt and makes them pub for reuse in reth