### PR TITLE
feat: upstream decode extradata fn

### DIFF
--- a/crates/consensus/src/eip1559.rs
+++ b/crates/consensus/src/eip1559.rs
@@ -14,11 +14,28 @@ pub fn decode_eip_1559_params(eip_1559_params: B64) -> (u32, u32) {
     (u32::from_be_bytes(elasticity), u32::from_be_bytes(denominator))
 }
 
-/// Extracts the `eip1559` parameters for the payload.
-pub fn decode_holocene_extra_data(
+/// Decodes the `eip1559` parameters from the `extradata` bytes.
+///
+/// Returns (`elasticity`, `denominator`)
+pub fn decode_holocene_extra_data(extra_data: &[u8]) -> Result<(u32, u32), EIP1559ParamError> {
+    if extra_data.len() < 9 {
+        return Err(EIP1559ParamError::NoEIP1559Params);
+    }
+
+    if extra_data[0] != 0 {
+        // version must be 0: https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#eip-1559-parameters-in-block-header
+        return Err(EIP1559ParamError::InvalidVersion(extra_data[0]));
+    }
+    // skip the first version byte
+    Ok(decode_eip_1559_params(B64::from_slice(&extra_data[1..9])))
+}
+
+/// Encodes the `eip1559` parameters for the payload.
+pub fn encode_holocene_extra_data(
     eip_1559_params: B64,
     default_base_fee_params: BaseFeeParams,
 ) -> Result<Bytes, EIP1559ParamError> {
+    // 9 bytes: 1 byte for version (0) and 8 bytes for eip1559 params
     let mut extra_data = [0u8; 9];
     // If eip 1559 params aren't set, use the canyon base fee param constants
     // otherwise use them
@@ -47,6 +64,9 @@ pub fn decode_holocene_extra_data(
 /// Error type for EIP-1559 parameters
 #[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
 pub enum EIP1559ParamError {
+    /// Thrown if the extra data begins with the wrong version byte.
+    #[error("Invalid EIP1559 version byte: {0}")]
+    InvalidVersion(u8),
     /// No EIP-1559 parameters provided.
     #[error("No EIP1559 parameters provided")]
     NoEIP1559Params,
@@ -66,14 +86,14 @@ mod tests {
     #[test]
     fn test_get_extra_data_post_holocene() {
         let eip_1559_params = B64::from_str("0x0000000800000008").unwrap();
-        let extra_data = decode_holocene_extra_data(eip_1559_params, BaseFeeParams::new(80, 60));
+        let extra_data = encode_holocene_extra_data(eip_1559_params, BaseFeeParams::new(80, 60));
         assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[0, 0, 0, 0, 8, 0, 0, 0, 8]));
     }
 
     #[test]
     fn test_get_extra_data_post_holocene_default() {
         let eip_1559_params = B64::ZERO;
-        let extra_data = decode_holocene_extra_data(eip_1559_params, BaseFeeParams::new(80, 60));
+        let extra_data = encode_holocene_extra_data(eip_1559_params, BaseFeeParams::new(80, 60));
         assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[0, 0, 0, 0, 80, 0, 0, 0, 60]));
     }
 }

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -19,8 +19,11 @@ pub use transaction::{
     DEPOSIT_TX_TYPE_ID,
 };
 
-mod eip1559;
-pub use eip1559::{decode_eip_1559_params, decode_holocene_extra_data, EIP1559ParamError};
+pub mod eip1559;
+pub use eip1559::{
+    decode_eip_1559_params, decode_holocene_extra_data, encode_holocene_extra_data,
+    EIP1559ParamError,
+};
 
 mod hardforks;
 pub use hardforks::{Ecotone, Fjord, Hardfork, Hardforks};

--- a/crates/rpc-types-engine/src/attributes.rs
+++ b/crates/rpc-types-engine/src/attributes.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use alloy_eips::eip1559::BaseFeeParams;
 use alloy_primitives::{Bytes, B64};
 use alloy_rpc_types_engine::PayloadAttributes;
-use op_alloy_consensus::{decode_eip_1559_params, decode_holocene_extra_data, EIP1559ParamError};
+use op_alloy_consensus::{decode_eip_1559_params, encode_holocene_extra_data, EIP1559ParamError};
 use op_alloy_protocol::L2BlockInfo;
 
 /// Optimism Payload Attributes
@@ -36,13 +36,13 @@ pub struct OpPayloadAttributes {
 }
 
 impl OpPayloadAttributes {
-    /// Extracts the `eip1559` parameters for the payload.
+    /// Encodes the `eip1559` parameters for the payload.
     pub fn get_holocene_extra_data(
         &self,
         default_base_fee_params: BaseFeeParams,
     ) -> Result<Bytes, EIP1559ParamError> {
         self.eip_1559_params
-            .map(|params| decode_holocene_extra_data(params, default_base_fee_params))
+            .map(|params| encode_holocene_extra_data(params, default_base_fee_params))
             .ok_or(EIP1559ParamError::NoEIP1559Params)?
     }
 


### PR DESCRIPTION
add reth function with was duplicated code

https://github.com/paradigmxyz/reth/blob/c816a3b758a39640388cc179abafd924ff9103b9/crates/optimism/chainspec/src/lib.rs#L268-L279

we already have the `decode_eip_1559_params` fn but were missing the decode from extradata slice.

this renames the previous `decode_holocene_extra_data` function to encode_ because this actually encodes