### PR TITLE
chore(rpc): `no_std` support `op-alloy-rpc-jsonrpsee`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           cache-on-failure: true
       - name: cargo hack
         run: |
-          cargo hack build --workspace --target wasm32-wasi --exclude op-alloy-network --exclude op-alloy-rpc-types --exclude op-alloy-rpc-jsonrpsee --exclude op-alloy-provider
+          cargo hack build --workspace --target wasm32-wasi --exclude op-alloy-network --exclude op-alloy-rpc-types --exclude op-alloy-provider
 
   no-std:
     runs-on: ubuntu-latest

--- a/crates/rpc-jsonrpsee/Cargo.toml
+++ b/crates/rpc-jsonrpsee/Cargo.toml
@@ -25,6 +25,13 @@ alloy-primitives.workspace = true
 jsonrpsee.workspace = true
 
 [features]
+default = ["std"]
+std = [
+    "op-alloy-rpc-types/std",
+    "op-alloy-rpc-types-engine/std",
+    "alloy-eips/std",
+    "alloy-primitives/std",
+]
 client = [
     "jsonrpsee/client",
     "jsonrpsee/async-client",

--- a/crates/rpc-jsonrpsee/src/lib.rs
+++ b/crates/rpc-jsonrpsee/src/lib.rs
@@ -5,5 +5,8 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 
 pub mod traits;

--- a/crates/rpc-jsonrpsee/src/traits.rs
+++ b/crates/rpc-jsonrpsee/src/traits.rs
@@ -2,6 +2,9 @@
 
 //! Rollup Node
 
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::net::IpAddr;
+
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{B256, U64};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
@@ -9,7 +12,6 @@ use op_alloy_rpc_types::{
     OutputResponse, PeerDump, PeerInfo, PeerStats, RollupConfig, SafeHeadResponse, SyncStatus,
 };
 use op_alloy_rpc_types_engine::{ProtocolVersion, SuperchainSignal};
-use std::net::IpAddr;
 
 /// Optimism specified rpc interface.
 ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes https://github.com/alloy-rs/op-alloy/issues/355

## Solution

Adds `no_std` support `op-alloy-rpc-jsonrpsee`, and removes exclusion from CI wasm check 

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
