### PR TITLE
fix: Use maili-rpc-types-engine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ alloy-primitives = { version = "0.8.12", default-features = false }
 # Maili
 maili-provider = { version = "0.1.0", default-features = false }
 maili-protocol = { version = "0.1.0", default-features = false }
-maili = { version = "0.1.0", default-features = false, features = ["rpc-types-engine"] }
+maili-rpc-types-engine = { version = "0.1.0", default-features = false }
 
 # Revm
 revm = "19.0.0"

--- a/crates/rpc-types-engine/Cargo.toml
+++ b/crates/rpc-types-engine/Cargo.toml
@@ -25,7 +25,7 @@ alloy-eips.workspace = true
 alloy-rpc-types-engine.workspace = true
 
 # Maili
-maili = { workspace = true, default-features = false, features = ["rpc-types-engine"] }
+maili-rpc-types-engine = { workspace = true, default-features = false }
 
 # Encoding
 snap = { workspace = true, optional = true }
@@ -55,19 +55,18 @@ std = [
   "alloy-rpc-types-engine/std",
   "op-alloy-consensus/std",
   "op-alloy-protocol/std",
-  "maili/std",
+  "maili-rpc-types-engine/std",
 ]
 serde = [
   "dep:serde",
   "dep:alloy-serde",
   "op-alloy-protocol/serde",
   "alloy-rpc-types-engine/serde",
-  "maili/serde",
+  "maili-rpc-types-engine/serde",
 ]
 arbitrary = [
   "std",
   "dep:arbitrary",
   "alloy-primitives/arbitrary",
   "alloy-primitives/rand",
-  "maili/arbitrary",
 ]

--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -10,7 +10,7 @@
 extern crate alloc;
 
 pub use alloy_rpc_types_engine::ForkchoiceUpdateVersion;
-pub use maili::rpc_types_engine::*;
+pub use maili_rpc_types_engine::*;
 
 mod attributes;
 pub use attributes::{OpAttributesWithParent, OpPayloadAttributes};


### PR DESCRIPTION
### Description

Touches up #367 to use `maili-rpc-types-engine` instead of `maili`.