### PR TITLE
fix: op-alloy-provider

### DIFF
--- a/crates/op-alloy/Cargo.toml
+++ b/crates/op-alloy/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 [dependencies]
 # Workspace
 op-alloy-consensus = { workspace = true, optional = true }
+op-alloy-provider = { workspace = true, optional = true }
 op-alloy-network = { workspace = true, optional = true }
 op-alloy-rpc-types-engine = { workspace = true, optional = true }
 op-alloy-rpc-types = { workspace = true, optional = true }
@@ -62,3 +63,4 @@ rpc-types-engine = ["dep:op-alloy-rpc-types-engine"]
 
 # std features
 network = ["dep:op-alloy-network"]
+provider = ["dep:op-alloy-provider"]

--- a/crates/op-alloy/src/lib.rs
+++ b/crates/op-alloy/src/lib.rs
@@ -11,6 +11,10 @@
 #[doc(inline)]
 pub use op_alloy_consensus as consensus;
 
+#[cfg(feature = "provider")]
+#[doc(inline)]
+pub use op_alloy_provider as provider;
+
 #[cfg(feature = "network")]
 #[doc(inline)]
 pub use op_alloy_network as network;


### PR DESCRIPTION
### Description

Adds `op-alloy-provider` back to the `op-alloy` crate.