### PR TITLE
chore: Bump `maili-*` to `0.1.6`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,10 +62,10 @@ alloy-sol-types = { version = "0.8.12", default-features = false }
 alloy-primitives = { version = "0.8.12", default-features = false }
 
 # Maili
-maili-protocol = { version = "0.1.5", default-features = false }
-maili-registry = { version = "0.1.5", default-features = false }
-maili-consensus = { version = "0.1.5", default-features = false }
-maili-rpc = { version = "0.1.5", default-features = false }
+maili-protocol = { version = "0.1.6", default-features = false }
+maili-registry = { version = "0.1.6", default-features = false }
+maili-consensus = { version = "0.1.6", default-features = false }
+maili-rpc = { version = "0.1.6", default-features = false }
 
 # Revm
 revm = "19.0.0"


### PR DESCRIPTION
## Overview

Bumps the version of `maili` crates in the workspace to the latest release.