### PR TITLE
feat(consensus): add is_deposit to OpTxEnvelope

### DIFF
--- a/crates/rpc-types/src/transaction.rs
+++ b/crates/rpc-types/src/transaction.rs
@@ -4,7 +4,6 @@ use alloy_consensus::{Transaction as _, Typed2718};
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{Address, BlockHash, Bytes, ChainId, TxKind, B256, U256};
 use alloy_serde::OtherFields;
-use maili_consensus::DepositTxEnvelope;
 use op_alloy_consensus::OpTxEnvelope;
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
## Motivation

This is a useful helper method for when you have a concrete `OpTxEnvelope` and want to know whether or not it's a deposit transaction.

## Solution

Adds `fn is_deposit`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
