### PR TITLE
chore: add serde-bincode-compat for re-export features

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -71,3 +71,6 @@ serde = [
     "alloy-eips/serde",
     "maili-consensus/serde",
 ]
+serde-bincode-compat = [
+    "maili-consensus/serde-bincode-compat",
+]


### PR DESCRIPTION
## Motivation

Until reth completely moves off of `op-alloy-consensus`, and onto `maili-consensus`, we'll want to enable this transitive dependency feature from the `op-alloy-consensus` dep.

## Solution

Add `serde-bincode-compat` feature to `op-alloy-consensus` and propagate to `maili-consensus`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
