### PR TITLE
chore: revert maili deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           cache-on-failure: true
       - name: cargo hack
         run: |
-          cargo hack build --workspace --target wasm32-wasip1 --exclude op-alloy-network --exclude op-alloy-rpc-types --exclude op-alloy-provider
+          cargo hack build --workspace --target wasm32-wasip1 --exclude op-alloy-network --exclude op-alloy-rpc-types --exclude op-alloy-provider --exclude op-alloy-rpc-jsonrpsee
 
   no-std:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,12 +61,6 @@ alloy-rlp = { version = "0.3", default-features = false }
 alloy-sol-types = { version = "0.8.12", default-features = false }
 alloy-primitives = { version = "0.8.12", default-features = false }
 
-# Maili
-maili-protocol = { version = "0.1.6", default-features = false }
-maili-registry = { version = "0.1.6", default-features = false }
-maili-consensus = { version = "0.1.6", default-features = false }
-maili-rpc = { version = "0.1.6", default-features = false }
-
 # Revm
 revm = "19.0.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ op-alloy-network = { version = "0.9.5", path = "crates/network", default-feature
 op-alloy-provider = { version = "0.9.5", path = "crates/provider", default-features = false }
 op-alloy-rpc-types = { version = "0.9.5", path = "crates/rpc-types", default-features = false }
 op-alloy-rpc-types-engine = { version = "0.9.5", path = "crates/rpc-types-engine", default-features = false }
+op-alloy-rpc-jsonrpsee = { version = "0.9.5", path = "crates/rpc-jsonrpsee", default-features = false }
 
 # Alloy
 alloy-eips = { version = "0.9.2", default-features = false }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The following crates are provided by `op-alloy`.
 
 - [`op-alloy-consensus`][op-alloy-consensus]
 - [`op-alloy-network`][op-alloy-network]
+- [`op-alloy-rpc-jsonrpsee`][op-alloy-rpc-jsonrpsee]
 - [`op-alloy-rpc-types-engine`][op-alloy-rpc-types-engine]
 - [`op-alloy-rpc-types`][op-alloy-rpc-types]
 
@@ -88,5 +89,6 @@ shall be dual licensed as above, without any additional terms or conditions.
 
 [op-alloy-consensus]: https://crates.io/crates/op-alloy-consensus
 [op-alloy-network]: https://crates.io/crates/op-alloy-network
+[op-alloy-rpc-jsonrpsee]: https://crates.io/crates/op-alloy-rpc-jsonrpsee
 [op-alloy-rpc-types-engine]: https://crates.io/crates/op-alloy-rpc-types-engine
 [op-alloy-rpc-types]: https://crates.io/crates/op-alloy-rpc-types

--- a/book/src/links.md
+++ b/book/src/links.md
@@ -8,6 +8,7 @@
 [op-alloy-consensus]: https://crates.io/crates/op-alloy-consensus
 [op-alloy-network]: https://crates.io/crates/op-alloy-network
 [op-alloy-provider]: https://crates.io/crates/op-alloy-provider
+[op-alloy-rpc-jsonrpsee]: https://crates.io/crates/op-alloy-rpc-jsonrpsee
 [op-alloy-rpc-types-engine]: https://crates.io/crates/op-alloy-rpc-types-engine
 [op-alloy-rpc-types]: https://crates.io/crates/op-alloy-rpc-types
 

--- a/book/src/starting.md
+++ b/book/src/starting.md
@@ -64,6 +64,7 @@ so `op-alloy-consensus` types can be used from `op-alloy` through `op_alloy::con
 - [`op-alloy-network`][op-alloy-network]
 - [`op-alloy-provider`][op-alloy-protocol]
 - [`op-alloy-consensus`][op-alloy-consensus] (supports `no_std`)
+- [`op-alloy-rpc-jsonrpsee`][op-alloy-rpc-jsonrpsee]
 - [`op-alloy-rpc-types`][op-alloy-rpc-types] (supports `no_std`)
 - [`op-alloy-rpc-types-engine`][op-alloy-rpc-types-engine] (supports `no_std`)
 

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -22,7 +22,6 @@ alloy-consensus.workspace = true
 alloy-primitives = { workspace = true, features = ["rlp"] }
 
 # Maili
-maili-common.workspace = true
 
 # misc
 thiserror.workspace = true
@@ -50,7 +49,6 @@ default = ["std"]
 std = [
     "alloy-eips/std",
     "alloy-consensus/std",
-    "maili-common/std",
     "derive_more/std",
 ]
 k256 = ["alloy-primitives/k256", "alloy-consensus/k256"]
@@ -69,6 +67,5 @@ serde = [
     "alloy-primitives/serde",
     "alloy-consensus/serde",
     "alloy-eips/serde",
-    "maili-common/serde",
 ]
 serde-bincode-compat = ["serde_with"]

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -22,7 +22,7 @@ alloy-consensus.workspace = true
 alloy-primitives = { workspace = true, features = ["rlp"] }
 
 # Maili
-maili-consensus.workspace = true
+maili-common.workspace = true
 
 # misc
 thiserror.workspace = true
@@ -32,6 +32,7 @@ derive_more = { workspace = true, features = ["display"] }
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 
 # serde
+serde_with = { workspace = true, optional = true }
 alloy-serde = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 
@@ -49,7 +50,7 @@ default = ["std"]
 std = [
     "alloy-eips/std",
     "alloy-consensus/std",
-    "maili-consensus/std",
+    "maili-common/std",
     "derive_more/std",
 ]
 k256 = ["alloy-primitives/k256", "alloy-consensus/k256"]
@@ -61,7 +62,6 @@ arbitrary = [
     "alloy-eips/arbitrary",
     "alloy-primitives/rand",
     "alloy-primitives/arbitrary",
-    "maili-consensus/arbitrary",
 ]
 serde = [
     "dep:serde",
@@ -69,8 +69,6 @@ serde = [
     "alloy-primitives/serde",
     "alloy-consensus/serde",
     "alloy-eips/serde",
-    "maili-consensus/serde",
+    "maili-common/serde",
 ]
-serde-bincode-compat = [
-    "maili-consensus/serde-bincode-compat",
-]
+serde-bincode-compat = ["serde_with"]

--- a/crates/consensus/src/hardforks/ecotone.rs
+++ b/crates/consensus/src/hardforks/ecotone.rs
@@ -5,9 +5,9 @@
 use alloc::{string::String, vec::Vec};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{address, hex, Address, Bytes, TxKind, B256, U256};
-use maili_consensus::{TxDeposit, UpgradeDepositSource};
+use maili_common::UpgradeDepositSource;
 
-use crate::Hardfork;
+use crate::{Hardfork, TxDeposit};
 
 /// The Ecotone network upgrade transactions.
 #[derive(Debug, Default, Clone, Copy)]

--- a/crates/consensus/src/hardforks/ecotone.rs
+++ b/crates/consensus/src/hardforks/ecotone.rs
@@ -2,10 +2,10 @@
 //!
 //! [Transaction]: alloy_consensus::Transaction
 
+use crate::UpgradeDepositSource;
 use alloc::{string::String, vec::Vec};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{address, hex, Address, Bytes, TxKind, B256, U256};
-use maili_common::UpgradeDepositSource;
 
 use crate::{Hardfork, TxDeposit};
 

--- a/crates/consensus/src/hardforks/fjord.rs
+++ b/crates/consensus/src/hardforks/fjord.rs
@@ -5,9 +5,9 @@
 use alloc::{string::String, vec::Vec};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{address, hex, Address, Bytes, TxKind, B256, U256};
-use maili_consensus::{TxDeposit, UpgradeDepositSource};
+use maili_common::UpgradeDepositSource;
 
-use crate::Hardfork;
+use crate::{Hardfork, TxDeposit};
 
 /// The Fjord network upgrade transactions.
 #[derive(Debug, Default, Clone, Copy)]

--- a/crates/consensus/src/hardforks/fjord.rs
+++ b/crates/consensus/src/hardforks/fjord.rs
@@ -2,10 +2,10 @@
 //!
 //! [Transaction]: alloy_consensus::Transaction
 
+use crate::UpgradeDepositSource;
 use alloc::{string::String, vec::Vec};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{address, hex, Address, Bytes, TxKind, B256, U256};
-use maili_common::UpgradeDepositSource;
 
 use crate::{Hardfork, TxDeposit};
 

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -24,8 +24,11 @@ pub use eip1559::{
     EIP1559ParamError,
 };
 
-// mod hardforks;
-// pub use hardforks::{Ecotone, Fjord, Hardfork, Hardforks};
+mod hardforks;
+pub use hardforks::{Ecotone, Fjord, Hardfork, Hardforks};
+
+mod source;
+pub use source::*;
 
 mod block;
 pub use block::OpBlock;

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -9,14 +9,13 @@
 
 extern crate alloc;
 
-pub use maili_common::{DepositTransaction, DepositTxEnvelope};
-
 mod receipt;
 pub use receipt::{OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptEnvelope, OpTxReceipt};
 
 mod transaction;
 pub use transaction::{
-    OpPooledTransaction, OpTxEnvelope, OpTxType, OpTypedTransaction, TxDeposit, DEPOSIT_TX_TYPE_ID,
+    DepositTransaction, OpPooledTransaction, OpTxEnvelope, OpTxType, OpTypedTransaction, TxDeposit,
+    DEPOSIT_TX_TYPE_ID,
 };
 
 pub mod eip1559;
@@ -25,8 +24,8 @@ pub use eip1559::{
     EIP1559ParamError,
 };
 
-mod hardforks;
-pub use hardforks::{Ecotone, Fjord, Hardfork, Hardforks};
+// mod hardforks;
+// pub use hardforks::{Ecotone, Fjord, Hardfork, Hardforks};
 
 mod block;
 pub use block::OpBlock;

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -9,11 +9,15 @@
 
 extern crate alloc;
 
+pub use maili_common::{DepositTransaction, DepositTxEnvelope};
+
 mod receipt;
 pub use receipt::{OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptEnvelope, OpTxReceipt};
 
 mod transaction;
-pub use transaction::{OpPooledTransaction, OpTxEnvelope, OpTxType, OpTypedTransaction};
+pub use transaction::{
+    OpPooledTransaction, OpTxEnvelope, OpTxType, OpTypedTransaction, TxDeposit, DEPOSIT_TX_TYPE_ID,
+};
 
 pub mod eip1559;
 pub use eip1559::{
@@ -26,3 +30,18 @@ pub use hardforks::{Ecotone, Fjord, Hardfork, Hardforks};
 
 mod block;
 pub use block::OpBlock;
+
+#[cfg(feature = "serde")]
+pub use transaction::serde_deposit_tx_rpc;
+
+/// Bincode-compatible serde implementations for consensus types.
+///
+/// `bincode` crate doesn't work well with optionally serializable serde fields, but some of the
+/// consensus types require optional serialization for RPC compatibility. This module makes so that
+/// all fields are serialized.
+///
+/// Read more: <https://github.com/bincode-org/bincode/issues/326>
+#[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
+pub mod serde_bincode_compat {
+    pub use super::transaction::serde_bincode_compat::TxDeposit;
+}

--- a/crates/consensus/src/source.rs
+++ b/crates/consensus/src/source.rs
@@ -1,0 +1,163 @@
+//! Classification of deposit transaction source
+
+use alloc::string::String;
+use alloy_primitives::{keccak256, B256};
+
+/// Source domain identifiers for deposit transactions.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+#[repr(u8)]
+pub enum DepositSourceDomainIdentifier {
+    /// A user deposit source.
+    User = 0,
+    /// A L1 info deposit source.
+    L1Info = 1,
+    /// An upgrade deposit source.
+    Upgrade = 2,
+    /// Deposit context closing transaction.
+    DepositContext = 3,
+}
+
+/// Source domains for deposit transactions.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DepositSourceDomain {
+    /// A user deposit source.
+    User(UserDepositSource),
+    /// A L1 info deposit source.
+    L1Info(L1InfoDepositSource),
+    /// An upgrade deposit source.
+    Upgrade(UpgradeDepositSource),
+    /// A deposit context closing source
+    DepositContext(DepositContextDepositSource),
+}
+
+impl DepositSourceDomain {
+    /// Returns the source hash.
+    pub fn source_hash(&self) -> B256 {
+        match self {
+            Self::User(ds) => ds.source_hash(),
+            Self::L1Info(ds) => ds.source_hash(),
+            Self::Upgrade(ds) => ds.source_hash(),
+            Self::DepositContext(ds) => ds.source_hash(),
+        }
+    }
+}
+
+/// A deposit transaction source.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+pub struct UserDepositSource {
+    /// The L1 block hash.
+    pub l1_block_hash: B256,
+    /// The log index.
+    pub log_index: u64,
+}
+
+impl UserDepositSource {
+    /// Creates a new [UserDepositSource].
+    pub const fn new(l1_block_hash: B256, log_index: u64) -> Self {
+        Self { l1_block_hash, log_index }
+    }
+
+    /// Returns the source hash.
+    pub fn source_hash(&self) -> B256 {
+        let mut input = [0u8; 32 * 2];
+        input[..32].copy_from_slice(&self.l1_block_hash[..]);
+        input[32 * 2 - 8..].copy_from_slice(&self.log_index.to_be_bytes());
+        let deposit_id_hash = keccak256(input);
+        let mut domain_input = [0u8; 32 * 2];
+        let identifier_bytes: [u8; 8] = (DepositSourceDomainIdentifier::User as u64).to_be_bytes();
+        domain_input[32 - 8..32].copy_from_slice(&identifier_bytes);
+        domain_input[32..].copy_from_slice(&deposit_id_hash[..]);
+        keccak256(domain_input)
+    }
+}
+
+/// A L1 info deposit transaction source.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+pub struct L1InfoDepositSource {
+    /// The L1 block hash.
+    pub l1_block_hash: B256,
+    /// The sequence number.
+    pub seq_number: u64,
+}
+
+impl L1InfoDepositSource {
+    /// Creates a new [L1InfoDepositSource].
+    pub const fn new(l1_block_hash: B256, seq_number: u64) -> Self {
+        Self { l1_block_hash, seq_number }
+    }
+
+    /// Returns the source hash.
+    pub fn source_hash(&self) -> B256 {
+        let mut input = [0u8; 32 * 2];
+        input[..32].copy_from_slice(&self.l1_block_hash[..]);
+        input[32 * 2 - 8..].copy_from_slice(&self.seq_number.to_be_bytes());
+        let deposit_id_hash = keccak256(input);
+        let mut domain_input = [0u8; 32 * 2];
+        let identifier_bytes: [u8; 8] =
+            (DepositSourceDomainIdentifier::L1Info as u64).to_be_bytes();
+        domain_input[32 - 8..32].copy_from_slice(&identifier_bytes);
+        domain_input[32..].copy_from_slice(&deposit_id_hash[..]);
+        keccak256(domain_input)
+    }
+}
+
+/// An upgrade deposit transaction source.
+///
+/// This implements the translation of upgrade-tx identity information to a deposit source-hash,
+/// which makes the deposit uniquely identifiable.
+/// System-upgrade transactions have their own domain for source-hashes,
+/// to not conflict with user-deposits or deposited L1 information.
+/// The intent identifies the upgrade-tx uniquely, in a human-readable way.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UpgradeDepositSource {
+    /// The intent.
+    pub intent: String,
+}
+
+impl UpgradeDepositSource {
+    /// Creates a new [UpgradeDepositSource].
+    pub const fn new(intent: String) -> Self {
+        Self { intent }
+    }
+
+    /// Returns the source hash.
+    pub fn source_hash(&self) -> B256 {
+        let intent_hash = keccak256(self.intent.as_bytes());
+        let mut domain_input = [0u8; 32 * 2];
+        let identifier_bytes: [u8; 8] =
+            (DepositSourceDomainIdentifier::Upgrade as u64).to_be_bytes();
+        domain_input[32 - 8..32].copy_from_slice(&identifier_bytes);
+        domain_input[32..].copy_from_slice(&intent_hash[..]);
+        keccak256(domain_input)
+    }
+}
+
+/// A deposit context transaction source.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+pub struct DepositContextDepositSource {
+    /// The L1 block hash.
+    pub l1_block_hash: B256,
+    /// The sequence number.
+    pub seq_number: u64,
+}
+
+impl DepositContextDepositSource {
+    /// Creates a new [L1InfoDepositSource].
+    pub const fn new(l1_block_hash: B256, seq_number: u64) -> Self {
+        Self { l1_block_hash, seq_number }
+    }
+
+    /// Returns the source hash.
+    pub fn source_hash(&self) -> B256 {
+        let mut input = [0u8; 32 * 2];
+        input[..32].copy_from_slice(&self.l1_block_hash[..]);
+        input[32 * 2 - 8..].copy_from_slice(&self.seq_number.to_be_bytes());
+        let deposit_id_hash = keccak256(input);
+        let mut domain_input = [0u8; 32 * 2];
+        let identifier_bytes: [u8; 8] =
+            (DepositSourceDomainIdentifier::DepositContext as u64).to_be_bytes();
+        domain_input[32 - 8..32].copy_from_slice(&identifier_bytes);
+        domain_input[32..].copy_from_slice(&deposit_id_hash[..]);
+        keccak256(domain_input)
+    }
+}

--- a/crates/consensus/src/transaction/deposit.rs
+++ b/crates/consensus/src/transaction/deposit.rs
@@ -1,0 +1,670 @@
+//! Deposit Transaction type.
+
+use super::OpTxType;
+use alloc::vec::Vec;
+use alloy_consensus::{Sealable, Transaction, Typed2718};
+use alloy_eips::{
+    eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718},
+    eip2930::AccessList,
+};
+use alloy_primitives::{
+    keccak256, Address, Bytes, ChainId, PrimitiveSignature as Signature, TxHash, TxKind, B256, U256,
+};
+use alloy_rlp::{
+    Buf, BufMut, Decodable, Encodable, Error as DecodeError, Header, EMPTY_STRING_CODE,
+};
+use core::mem;
+use maili_common::DepositTransaction;
+
+/// Deposit transactions, also known as deposits are initiated on L1, and executed on L2.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct TxDeposit {
+    /// Hash that uniquely identifies the source of the deposit.
+    pub source_hash: B256,
+    /// The address of the sender account.
+    pub from: Address,
+    /// The address of the recipient account, or the null (zero-length) address if the deposited
+    /// transaction is a contract creation.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "TxKind::is_create"))]
+    pub to: TxKind,
+    /// The ETH value to mint on L2.
+    #[cfg_attr(feature = "serde", serde(default, with = "alloy_serde::quantity::opt"))]
+    pub mint: Option<u128>,
+    ///  The ETH value to send to the recipient account.
+    pub value: U256,
+    /// The gas limit for the L2 transaction.
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", rename = "gas"))]
+    pub gas_limit: u64,
+    /// Field indicating if this transaction is exempt from the L2 gas limit.
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            with = "alloy_serde::quantity",
+            rename = "isSystemTx",
+            skip_serializing_if = "core::ops::Not::not"
+        )
+    )]
+    pub is_system_transaction: bool,
+    /// Input has two uses depending if transaction is Create or Call (if `to` field is None or
+    /// Some).
+    pub input: Bytes,
+}
+
+impl DepositTransaction for TxDeposit {
+    #[inline]
+    fn source_hash(&self) -> Option<B256> {
+        Some(self.source_hash)
+    }
+
+    #[inline]
+    fn mint(&self) -> Option<u128> {
+        self.mint
+    }
+
+    #[inline]
+    fn is_system_transaction(&self) -> bool {
+        self.is_system_transaction
+    }
+}
+
+impl TxDeposit {
+    /// Decodes the inner [TxDeposit] fields from RLP bytes.
+    ///
+    /// NOTE: This assumes a RLP header has already been decoded, and _just_ decodes the following
+    /// RLP fields in the following order:
+    ///
+    /// - `source_hash`
+    /// - `from`
+    /// - `to`
+    /// - `mint`
+    /// - `value`
+    /// - `gas_limit`
+    /// - `is_system_transaction`
+    /// - `input`
+    pub fn rlp_decode_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Ok(Self {
+            source_hash: Decodable::decode(buf)?,
+            from: Decodable::decode(buf)?,
+            to: Decodable::decode(buf)?,
+            mint: if *buf.first().ok_or(DecodeError::InputTooShort)? == EMPTY_STRING_CODE {
+                buf.advance(1);
+                None
+            } else {
+                Some(Decodable::decode(buf)?)
+            },
+            value: Decodable::decode(buf)?,
+            gas_limit: Decodable::decode(buf)?,
+            is_system_transaction: Decodable::decode(buf)?,
+            input: Decodable::decode(buf)?,
+        })
+    }
+
+    /// Decodes the transaction from RLP bytes.
+    pub fn rlp_decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let remaining = buf.len();
+
+        if header.payload_length > remaining {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+
+        let this = Self::rlp_decode_fields(buf)?;
+
+        if buf.len() + header.payload_length != remaining {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+
+        Ok(this)
+    }
+
+    /// Outputs the length of the transaction's fields, without a RLP header or length of the
+    /// eip155 fields.
+    pub(crate) fn rlp_encoded_fields_length(&self) -> usize {
+        self.source_hash.length()
+            + self.from.length()
+            + self.to.length()
+            + self.mint.map_or(1, |mint| mint.length())
+            + self.value.length()
+            + self.gas_limit.length()
+            + self.is_system_transaction.length()
+            + self.input.0.length()
+    }
+
+    /// Encodes only the transaction's fields into the desired buffer, without a RLP header.
+    /// <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/deposits.md#the-deposited-transaction-type>
+    pub(crate) fn rlp_encode_fields(&self, out: &mut dyn alloy_rlp::BufMut) {
+        self.source_hash.encode(out);
+        self.from.encode(out);
+        self.to.encode(out);
+        if let Some(mint) = self.mint {
+            mint.encode(out);
+        } else {
+            out.put_u8(EMPTY_STRING_CODE);
+        }
+        self.value.encode(out);
+        self.gas_limit.encode(out);
+        self.is_system_transaction.encode(out);
+        self.input.encode(out);
+    }
+
+    /// Calculates a heuristic for the in-memory size of the [TxDeposit] transaction.
+    #[inline]
+    pub fn size(&self) -> usize {
+        mem::size_of::<B256>() + // source_hash
+        mem::size_of::<Address>() + // from
+        self.to.size() + // to
+        mem::size_of::<Option<u128>>() + // mint
+        mem::size_of::<U256>() + // value
+        mem::size_of::<u128>() + // gas_limit
+        mem::size_of::<bool>() + // is_system_transaction
+        self.input.len() // input
+    }
+
+    /// Get the transaction type
+    pub(crate) const fn tx_type(&self) -> OpTxType {
+        OpTxType::Deposit
+    }
+
+    /// Create an rlp header for the transaction.
+    fn rlp_header(&self) -> Header {
+        Header { list: true, payload_length: self.rlp_encoded_fields_length() }
+    }
+
+    /// RLP encodes the transaction.
+    pub fn rlp_encode(&self, out: &mut dyn BufMut) {
+        self.rlp_header().encode(out);
+        self.rlp_encode_fields(out);
+    }
+
+    /// Get the length of the transaction when RLP encoded.
+    pub fn rlp_encoded_length(&self) -> usize {
+        self.rlp_header().length_with_payload()
+    }
+
+    /// Get the length of the transaction when EIP-2718 encoded. This is the
+    /// 1 byte type flag + the length of the RLP encoded transaction.
+    pub fn eip2718_encoded_length(&self) -> usize {
+        self.rlp_encoded_length() + 1
+    }
+
+    fn network_header(&self) -> Header {
+        Header { list: false, payload_length: self.eip2718_encoded_length() }
+    }
+
+    /// Get the length of the transaction when network encoded. This is the
+    /// EIP-2718 encoded length with an outer RLP header.
+    pub fn network_encoded_length(&self) -> usize {
+        self.network_header().length_with_payload()
+    }
+
+    /// Network encode the transaction with the given signature.
+    pub fn network_encode(&self, out: &mut dyn BufMut) {
+        self.network_header().encode(out);
+        self.encode_2718(out);
+    }
+
+    /// Calculate the transaction hash.
+    pub fn tx_hash(&self) -> TxHash {
+        let mut buf = Vec::with_capacity(self.eip2718_encoded_length());
+        self.encode_2718(&mut buf);
+        keccak256(&buf)
+    }
+
+    /// Returns the signature for the optimism deposit transactions, which don't include a
+    /// signature.
+    pub fn signature() -> Signature {
+        Signature::new(U256::ZERO, U256::ZERO, false)
+    }
+}
+
+impl Typed2718 for TxDeposit {
+    fn ty(&self) -> u8 {
+        OpTxType::Deposit as u8
+    }
+}
+
+impl Transaction for TxDeposit {
+    fn chain_id(&self) -> Option<ChainId> {
+        None
+    }
+
+    fn nonce(&self) -> u64 {
+        0u64
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.gas_limit
+    }
+
+    fn gas_price(&self) -> Option<u128> {
+        None
+    }
+
+    fn max_fee_per_gas(&self) -> u128 {
+        0
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        None
+    }
+
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        None
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        0
+    }
+
+    fn effective_gas_price(&self, _: Option<u64>) -> u128 {
+        0
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        false
+    }
+
+    fn kind(&self) -> TxKind {
+        self.to
+    }
+
+    fn is_create(&self) -> bool {
+        self.to.is_create()
+    }
+
+    fn value(&self) -> U256 {
+        self.value
+    }
+
+    fn input(&self) -> &Bytes {
+        &self.input
+    }
+
+    fn access_list(&self) -> Option<&AccessList> {
+        None
+    }
+
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        None
+    }
+
+    fn authorization_list(&self) -> Option<&[alloy_eips::eip7702::SignedAuthorization]> {
+        None
+    }
+}
+
+impl Encodable2718 for TxDeposit {
+    fn type_flag(&self) -> Option<u8> {
+        Some(OpTxType::Deposit as u8)
+    }
+
+    fn encode_2718_len(&self) -> usize {
+        self.eip2718_encoded_length()
+    }
+
+    fn encode_2718(&self, out: &mut dyn alloy_rlp::BufMut) {
+        out.put_u8(self.tx_type() as u8);
+        self.rlp_encode(out);
+    }
+}
+
+impl Decodable2718 for TxDeposit {
+    fn typed_decode(ty: u8, data: &mut &[u8]) -> Eip2718Result<Self> {
+        let ty: OpTxType = ty.try_into().map_err(|_| Eip2718Error::UnexpectedType(ty))?;
+        if ty != OpTxType::Deposit as u8 {
+            return Err(Eip2718Error::UnexpectedType(ty as u8));
+        }
+        let tx = Self::decode(data)?;
+        Ok(tx)
+    }
+
+    fn fallback_decode(data: &mut &[u8]) -> Eip2718Result<Self> {
+        let tx = Self::decode(data)?;
+        Ok(tx)
+    }
+}
+
+impl Encodable for TxDeposit {
+    fn encode(&self, out: &mut dyn BufMut) {
+        Header { list: true, payload_length: self.rlp_encoded_fields_length() }.encode(out);
+        self.rlp_encode_fields(out);
+    }
+
+    fn length(&self) -> usize {
+        let payload_length = self.rlp_encoded_fields_length();
+        Header { list: true, payload_length }.length() + payload_length
+    }
+}
+
+impl Decodable for TxDeposit {
+    fn decode(data: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Self::rlp_decode(data)
+    }
+}
+
+impl Sealable for TxDeposit {
+    fn hash_slow(&self) -> B256 {
+        self.tx_hash()
+    }
+}
+
+/// Deposit transactions don't have a signature, however, we include an empty signature in the
+/// response for better compatibility.
+///
+/// This function can be used as `serialize_with` serde attribute for the [`TxDeposit`] and will
+/// flatten [`TxDeposit::signature`] into response.
+#[cfg(feature = "serde")]
+pub fn serde_deposit_tx_rpc<T: serde::Serialize, S: serde::Serializer>(
+    value: &T,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct SerdeHelper<'a, T> {
+        #[serde(flatten)]
+        value: &'a T,
+        #[serde(flatten)]
+        signature: Signature,
+    }
+
+    SerdeHelper { value, signature: TxDeposit::signature() }.serialize(serializer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::hex;
+    use alloy_rlp::BytesMut;
+
+    #[test]
+    fn test_deposit_transaction_trait() {
+        let tx = TxDeposit {
+            source_hash: B256::with_last_byte(42),
+            from: Address::default(),
+            to: TxKind::default(),
+            mint: Some(100),
+            value: U256::from(1000),
+            gas_limit: 50000,
+            is_system_transaction: true,
+            input: Bytes::default(),
+        };
+
+        assert_eq!(tx.source_hash(), Some(B256::with_last_byte(42)));
+        assert_eq!(tx.mint(), Some(100));
+        assert!(tx.is_system_transaction());
+        assert!(tx.is_deposit());
+    }
+
+    #[test]
+    fn test_deposit_transaction_without_mint() {
+        let tx = TxDeposit {
+            source_hash: B256::default(),
+            from: Address::default(),
+            to: TxKind::default(),
+            mint: None,
+            value: U256::default(),
+            gas_limit: 50000,
+            is_system_transaction: false,
+            input: Bytes::default(),
+        };
+
+        assert_eq!(tx.source_hash(), Some(B256::default()));
+        assert_eq!(tx.mint(), None);
+        assert!(!tx.is_system_transaction());
+        assert!(tx.is_deposit());
+    }
+
+    #[test]
+    fn test_deposit_transaction_to_contract() {
+        let contract_address = Address::with_last_byte(0xFF);
+        let tx = TxDeposit {
+            source_hash: B256::default(),
+            from: Address::default(),
+            to: TxKind::Call(contract_address),
+            mint: Some(200),
+            value: U256::from(500),
+            gas_limit: 100000,
+            is_system_transaction: false,
+            input: Bytes::from_static(&[1, 2, 3]),
+        };
+
+        assert_eq!(tx.source_hash(), Some(B256::default()));
+        assert_eq!(tx.mint(), Some(200));
+        assert!(!tx.is_system_transaction());
+        assert!(tx.is_deposit());
+        assert_eq!(tx.kind(), TxKind::Call(contract_address));
+    }
+
+    #[test]
+    fn test_rlp_roundtrip() {
+        let bytes = Bytes::from_static(&hex!("7ef9015aa044bae9d41b8380d781187b426c6fe43df5fb2fb57bd4466ef6a701e1f01e015694deaddeaddeaddeaddeaddeaddeaddeaddead000194420000000000000000000000000000000000001580808408f0d18001b90104015d8eb900000000000000000000000000000000000000000000000000000000008057650000000000000000000000000000000000000000000000000000000063d96d10000000000000000000000000000000000000000000000000000000000009f35273d89754a1e0387b89520d989d3be9c37c1f32495a88faf1ea05c61121ab0d1900000000000000000000000000000000000000000000000000000000000000010000000000000000000000002d679b567db6187c0c8323fa982cfb88b74dbcc7000000000000000000000000000000000000000000000000000000000000083400000000000000000000000000000000000000000000000000000000000f4240"));
+        let tx_a = TxDeposit::decode(&mut bytes[1..].as_ref()).unwrap();
+        let mut buf_a = BytesMut::default();
+        tx_a.encode(&mut buf_a);
+        assert_eq!(&buf_a[..], &bytes[1..]);
+    }
+
+    #[test]
+    fn test_encode_decode_fields() {
+        let original = TxDeposit {
+            source_hash: B256::default(),
+            from: Address::default(),
+            to: TxKind::default(),
+            mint: Some(100),
+            value: U256::default(),
+            gas_limit: 50000,
+            is_system_transaction: true,
+            input: Bytes::default(),
+        };
+
+        let mut buffer = BytesMut::new();
+        original.rlp_encode_fields(&mut buffer);
+        let decoded = TxDeposit::rlp_decode_fields(&mut &buffer[..]).expect("Failed to decode");
+
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_encode_with_and_without_header() {
+        let tx_deposit = TxDeposit {
+            source_hash: B256::default(),
+            from: Address::default(),
+            to: TxKind::default(),
+            mint: Some(100),
+            value: U256::default(),
+            gas_limit: 50000,
+            is_system_transaction: true,
+            input: Bytes::default(),
+        };
+
+        let mut buffer_with_header = BytesMut::new();
+        tx_deposit.encode(&mut buffer_with_header);
+
+        let mut buffer_without_header = BytesMut::new();
+        tx_deposit.rlp_encode_fields(&mut buffer_without_header);
+
+        assert!(buffer_with_header.len() > buffer_without_header.len());
+    }
+
+    #[test]
+    fn test_payload_length() {
+        let tx_deposit = TxDeposit {
+            source_hash: B256::default(),
+            from: Address::default(),
+            to: TxKind::default(),
+            mint: Some(100),
+            value: U256::default(),
+            gas_limit: 50000,
+            is_system_transaction: true,
+            input: Bytes::default(),
+        };
+
+        assert!(tx_deposit.size() > tx_deposit.rlp_encoded_fields_length());
+    }
+
+    #[test]
+    fn test_encode_inner_with_and_without_header() {
+        let tx_deposit = TxDeposit {
+            source_hash: B256::default(),
+            from: Address::default(),
+            to: TxKind::default(),
+            mint: Some(100),
+            value: U256::default(),
+            gas_limit: 50000,
+            is_system_transaction: true,
+            input: Bytes::default(),
+        };
+
+        let mut buffer_with_header = BytesMut::new();
+        tx_deposit.network_encode(&mut buffer_with_header);
+
+        let mut buffer_without_header = BytesMut::new();
+        tx_deposit.encode_2718(&mut buffer_without_header);
+
+        assert!(buffer_with_header.len() > buffer_without_header.len());
+    }
+
+    #[test]
+    fn test_payload_length_header() {
+        let tx_deposit = TxDeposit {
+            source_hash: B256::default(),
+            from: Address::default(),
+            to: TxKind::default(),
+            mint: Some(100),
+            value: U256::default(),
+            gas_limit: 50000,
+            is_system_transaction: true,
+            input: Bytes::default(),
+        };
+
+        let total_len = tx_deposit.network_encoded_length();
+        let len_without_header = tx_deposit.eip2718_encoded_length();
+
+        assert!(total_len > len_without_header);
+    }
+}
+
+/// Bincode-compatible [`TxDeposit`] serde implementation.
+#[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
+pub(super) mod serde_bincode_compat {
+    use alloc::borrow::Cow;
+    use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde_with::{DeserializeAs, SerializeAs};
+
+    /// Bincode-compatible [`super::TxDeposit`] serde implementation.
+    ///
+    /// Intended to use with the [`serde_with::serde_as`] macro in the following way:
+    /// ```rust
+    /// use op_alloy_consensus::{serde_bincode_compat, TxDeposit};
+    /// use serde::{Deserialize, Serialize};
+    /// use serde_with::serde_as;
+    ///
+    /// #[serde_as]
+    /// #[derive(Serialize, Deserialize)]
+    /// struct Data {
+    ///     #[serde_as(as = "serde_bincode_compat::TxDeposit")]
+    ///     transaction: TxDeposit,
+    /// }
+    /// ```
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct TxDeposit<'a> {
+        source_hash: B256,
+        from: Address,
+        #[serde(default)]
+        to: TxKind,
+        #[serde(default)]
+        mint: Option<u128>,
+        value: U256,
+        gas_limit: u64,
+        is_system_transaction: bool,
+        input: Cow<'a, Bytes>,
+    }
+
+    impl<'a> From<&'a super::TxDeposit> for TxDeposit<'a> {
+        fn from(value: &'a super::TxDeposit) -> Self {
+            Self {
+                source_hash: value.source_hash,
+                from: value.from,
+                to: value.to,
+                mint: value.mint,
+                value: value.value,
+                gas_limit: value.gas_limit,
+                is_system_transaction: value.is_system_transaction,
+                input: Cow::Borrowed(&value.input),
+            }
+        }
+    }
+
+    impl<'a> From<TxDeposit<'a>> for super::TxDeposit {
+        fn from(value: TxDeposit<'a>) -> Self {
+            Self {
+                source_hash: value.source_hash,
+                from: value.from,
+                to: value.to,
+                mint: value.mint,
+                value: value.value,
+                gas_limit: value.gas_limit,
+                is_system_transaction: value.is_system_transaction,
+                input: value.input.into_owned(),
+            }
+        }
+    }
+
+    impl SerializeAs<super::TxDeposit> for TxDeposit<'_> {
+        fn serialize_as<S>(source: &super::TxDeposit, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            TxDeposit::from(source).serialize(serializer)
+        }
+    }
+
+    impl<'de> DeserializeAs<'de, super::TxDeposit> for TxDeposit<'de> {
+        fn deserialize_as<D>(deserializer: D) -> Result<super::TxDeposit, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            TxDeposit::deserialize(deserializer).map(Into::into)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use arbitrary::Arbitrary;
+        use rand::Rng;
+        use serde::{Deserialize, Serialize};
+        use serde_with::serde_as;
+
+        use super::super::{serde_bincode_compat, TxDeposit};
+
+        #[test]
+        fn test_tx_deposit_bincode_roundtrip() {
+            #[serde_as]
+            #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+            struct Data {
+                #[serde_as(as = "serde_bincode_compat::TxDeposit")]
+                transaction: TxDeposit,
+            }
+
+            let mut bytes = [0u8; 1024];
+            rand::thread_rng().fill(bytes.as_mut_slice());
+            let data = Data {
+                transaction: TxDeposit::arbitrary(&mut arbitrary::Unstructured::new(&bytes))
+                    .unwrap(),
+            };
+
+            let encoded = bincode::serialize(&data).unwrap();
+            let decoded: Data = bincode::deserialize(&encoded).unwrap();
+            assert_eq!(decoded, data);
+        }
+    }
+}

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1,3 +1,4 @@
+use crate::{OpTxType, TxDeposit};
 use alloy_consensus::{
     transaction::RlpEcdsaTx, Sealable, Sealed, Signed, Transaction, TxEip1559, TxEip2930,
     TxEip7702, TxLegacy, Typed2718,
@@ -9,9 +10,6 @@ use alloy_eips::{
 };
 use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
 use alloy_rlp::{Decodable, Encodable};
-use maili_common::DepositTxEnvelope;
-
-use crate::{OpTxType, TxDeposit};
 
 /// The Ethereum [EIP-2718] Transaction Envelope, modified for OP Stack chains.
 ///
@@ -333,6 +331,14 @@ impl OpTxEnvelope {
         }
     }
 
+    /// Returns the [`TxEip1559`] variant if the transaction is an EIP-1559 transaction.
+    pub const fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
+        match self {
+            Self::Deposit(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
     /// Return the [`OpTxType`] of the inner txn.
     pub const fn tx_type(&self) -> OpTxType {
         match self {
@@ -443,24 +449,6 @@ impl Encodable2718 for OpTxEnvelope {
             Self::Eip2930(tx) => *tx.hash(),
             Self::Eip7702(tx) => *tx.hash(),
             Self::Deposit(tx) => tx.seal(),
-        }
-    }
-}
-
-impl DepositTxEnvelope for OpTxEnvelope {
-    type DepositTx = TxDeposit;
-
-    /// Returns true if the transaction is a deposit transaction.
-    #[inline]
-    fn is_deposit(&self) -> bool {
-        matches!(self, Self::Deposit(_))
-    }
-
-    /// Returns the [`TxDeposit`] variant if the transaction is a deposit transaction.
-    fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
-        match self {
-            Self::Deposit(tx) => Some(tx),
-            _ => None,
         }
     }
 }

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -9,9 +9,9 @@ use alloy_eips::{
 };
 use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
 use alloy_rlp::{Decodable, Encodable};
-use maili_consensus::{DepositTxEnvelope, TxDeposit};
+use maili_common::DepositTxEnvelope;
 
-use crate::OpTxType;
+use crate::{OpTxType, TxDeposit};
 
 /// The Ethereum [EIP-2718] Transaction Envelope, modified for OP Stack chains.
 ///
@@ -448,6 +448,8 @@ impl Encodable2718 for OpTxEnvelope {
 }
 
 impl DepositTxEnvelope for OpTxEnvelope {
+    type DepositTx = TxDeposit;
+
     /// Returns true if the transaction is a deposit transaction.
     #[inline]
     fn is_deposit(&self) -> bool {
@@ -499,11 +501,7 @@ mod serde_from {
         Eip1559(Signed<TxEip1559>),
         #[serde(rename = "0x4", alias = "0x04")]
         Eip7702(Signed<TxEip7702>),
-        #[serde(
-            rename = "0x7e",
-            alias = "0x7E",
-            serialize_with = "maili_consensus::serde_deposit_tx_rpc"
-        )]
+        #[serde(rename = "0x7e", alias = "0x7E", serialize_with = "crate::serde_deposit_tx_rpc")]
         Deposit(Sealed<TxDeposit>),
     }
 

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -1,7 +1,7 @@
 //! Tramsaction types for Optimism.
 
 mod deposit;
-pub use deposit::TxDeposit;
+pub use deposit::{DepositTransaction, TxDeposit};
 
 mod tx_type;
 pub use tx_type::{OpTxType, DEPOSIT_TX_TYPE_ID};

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -1,7 +1,10 @@
 //! Tramsaction types for Optimism.
 
+mod deposit;
+pub use deposit::TxDeposit;
+
 mod tx_type;
-pub use tx_type::OpTxType;
+pub use tx_type::{OpTxType, DEPOSIT_TX_TYPE_ID};
 
 mod envelope;
 pub use envelope::OpTxEnvelope;
@@ -11,3 +14,12 @@ pub use typed::OpTypedTransaction;
 
 mod pooled;
 pub use pooled::OpPooledTransaction;
+
+#[cfg(feature = "serde")]
+pub use deposit::serde_deposit_tx_rpc;
+
+/// Bincode-compatible serde implementations for transaction types.
+#[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
+pub(super) mod serde_bincode_compat {
+    pub use super::deposit::serde_bincode_compat::TxDeposit;
+}

--- a/crates/consensus/src/transaction/tx_type.rs
+++ b/crates/consensus/src/transaction/tx_type.rs
@@ -6,6 +6,9 @@ use alloy_primitives::{U64, U8};
 use alloy_rlp::{BufMut, Decodable, Encodable};
 use derive_more::Display;
 
+/// Identifier for an Optimism deposit transaction
+pub const DEPOSIT_TX_TYPE_ID: u8 = 126; // 0x7E
+
 /// Optimism `TransactionType` flags as specified in EIPs [2718], [1559], and
 /// [2930], as well as the [deposit transaction spec][deposit-spec]
 ///

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -1,8 +1,7 @@
-use crate::{OpTxEnvelope, OpTxType};
+use crate::{OpTxEnvelope, OpTxType, TxDeposit};
 use alloy_consensus::{Transaction, TxEip1559, TxEip2930, TxEip7702, TxLegacy, Typed2718};
 use alloy_eips::eip2930::AccessList;
 use alloy_primitives::{Address, Bytes, TxKind};
-use maili_consensus::TxDeposit;
 
 /// The TypedTransaction enum represents all Ethereum transaction request types, modified for the OP
 /// Stack.
@@ -354,11 +353,7 @@ mod serde_from {
         #[serde(rename = "0x04", alias = "0x4")]
         Eip7702(TxEip7702),
         /// Deposit transaction
-        #[serde(
-            rename = "0x7e",
-            alias = "0x7E",
-            serialize_with = "maili_consensus::serde_deposit_tx_rpc"
-        )]
+        #[serde(rename = "0x7e", alias = "0x7E", serialize_with = "crate::serde_deposit_tx_rpc")]
         Deposit(TxDeposit),
     }
 

--- a/crates/op-alloy/Cargo.toml
+++ b/crates/op-alloy/Cargo.toml
@@ -22,6 +22,7 @@ workspace = true
 op-alloy-consensus = { workspace = true, optional = true }
 op-alloy-provider = { workspace = true, optional = true }
 op-alloy-network = { workspace = true, optional = true }
+op-alloy-rpc-jsonrpsee = { workspace = true, optional = true }
 op-alloy-rpc-types-engine = { workspace = true, optional = true }
 op-alloy-rpc-types = { workspace = true, optional = true }
 
@@ -39,6 +40,7 @@ full = [
   "network",
   "rpc-types",
   "rpc-types-engine",
+  "rpc-jsonrpsee",
 ]
 
 k256 = [
@@ -63,4 +65,5 @@ rpc-types-engine = ["dep:op-alloy-rpc-types-engine"]
 
 # std features
 network = ["dep:op-alloy-network"]
+rpc-jsonrpsee = ["dep:op-alloy-rpc-jsonrpsee"]
 provider = ["dep:op-alloy-provider"]

--- a/crates/op-alloy/README.md
+++ b/crates/op-alloy/README.md
@@ -87,5 +87,6 @@ shall be dual licensed as above, without any additional terms or conditions.
 
 [op-alloy-consensus]: https://crates.io/crates/op-alloy-consensus
 [op-alloy-network]: https://crates.io/crates/op-alloy-network
+[op-alloy-rpc-jsonrpsee]: https://crates.io/crates/op-alloy-rpc-jsonrpsee
 [op-alloy-rpc-types-engine]: https://crates.io/crates/op-alloy-rpc-types-engine
 [op-alloy-rpc-types]: https://crates.io/crates/op-alloy-rpc-types

--- a/crates/op-alloy/src/lib.rs
+++ b/crates/op-alloy/src/lib.rs
@@ -26,3 +26,7 @@ pub use op_alloy_rpc_types as rpc_types;
 #[cfg(feature = "rpc-types-engine")]
 #[doc(inline)]
 pub use op_alloy_rpc_types_engine as rpc_types_engine;
+
+#[cfg(feature = "rpc-jsonrpsee")]
+#[doc(inline)]
+pub use op_alloy_rpc_jsonrpsee as rpc_jsonrpsee;

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -25,8 +25,5 @@ alloy-transport.workspace = true
 alloy-primitives = { workspace = true, features = ["rlp", "serde"] }
 alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
 
-# Maili
-maili-provider.workspace = true
-
 # misc
 async-trait.workspace = true

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -25,5 +25,8 @@ alloy-transport.workspace = true
 alloy-primitives = { workspace = true, features = ["rlp", "serde"] }
 alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
 
+# Maili
+maili-provider.workspace = true
+
 # misc
 async-trait.workspace = true

--- a/crates/provider/src/ext/engine.rs
+++ b/crates/provider/src/ext/engine.rs
@@ -6,7 +6,6 @@ use alloy_rpc_types_engine::{
     ExecutionPayloadV3, ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus,
 };
 use alloy_transport::{Transport, TransportResult};
-use maili_provider::ext::engine::EngineExtApi;
 use op_alloy_rpc_types_engine::{
     OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpPayloadAttributes,
 };
@@ -20,7 +19,7 @@ use op_alloy_rpc_types_engine::{
 /// <https://specs.optimism.io/protocol/exec-engine.html#engine-api>
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait OpEngineApi<N, T>: EngineExtApi<N, T> {
+pub trait OpEngineApi<N, T> {
     /// Sends the given payload to the execution layer client, as specified for the Shanghai fork.
     ///
     /// See also <https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/shanghai.md#engine_newpayloadv2>

--- a/crates/provider/src/ext/engine.rs
+++ b/crates/provider/src/ext/engine.rs
@@ -6,6 +6,7 @@ use alloy_rpc_types_engine::{
     ExecutionPayloadV3, ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus,
 };
 use alloy_transport::{Transport, TransportResult};
+use maili_provider::ext::engine::EngineExtApi;
 use op_alloy_rpc_types_engine::{
     OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpPayloadAttributes,
 };
@@ -19,7 +20,7 @@ use op_alloy_rpc_types_engine::{
 /// <https://specs.optimism.io/protocol/exec-engine.html#engine-api>
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait OpEngineApi<N, T> {
+pub trait OpEngineApi<N, T>: EngineExtApi<N, T> {
     /// Sends the given payload to the execution layer client, as specified for the Shanghai fork.
     ///
     /// See also <https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/shanghai.md#engine_newpayloadv2>

--- a/crates/rpc-jsonrpsee/Cargo.toml
+++ b/crates/rpc-jsonrpsee/Cargo.toml
@@ -16,13 +16,7 @@ workspace = true
 
 [dependencies]
 # Alloy
-op-alloy-rpc-types.workspace = true
-op-alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
-alloy-eips.workspace = true
 alloy-primitives.workspace = true
-
-# Maili
-maili-protocol.workspace = true
 
 # rpc
 jsonrpsee.workspace = true
@@ -30,9 +24,6 @@ jsonrpsee.workspace = true
 [features]
 default = ["std"]
 std = [
-    "op-alloy-rpc-types/std",
-    "op-alloy-rpc-types-engine/std",
-    "alloy-eips/std",
     "alloy-primitives/std",
 ]
 client = [

--- a/crates/rpc-jsonrpsee/Cargo.toml
+++ b/crates/rpc-jsonrpsee/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "op-alloy-rpc-jsonrpsee"
+description = "Optimism RPC Client"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+authors.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Alloy
+op-alloy-rpc-types.workspace = true
+op-alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
+alloy-eips.workspace = true
+alloy-primitives.workspace = true
+
+# Maili
+maili-protocol.workspace = true
+
+# rpc
+jsonrpsee.workspace = true
+
+[features]
+default = ["std"]
+std = [
+    "op-alloy-rpc-types/std",
+    "op-alloy-rpc-types-engine/std",
+    "alloy-eips/std",
+    "alloy-primitives/std",
+]
+client = [
+    "jsonrpsee/client",
+    "jsonrpsee/async-client",
+]

--- a/crates/rpc-jsonrpsee/Cargo.toml
+++ b/crates/rpc-jsonrpsee/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 # Alloy
-alloy-primitives.workspace = true
+alloy-primitives = { workspace = true, features = ["serde"] }
 
 # rpc
 jsonrpsee.workspace = true

--- a/crates/rpc-jsonrpsee/Cargo.toml
+++ b/crates/rpc-jsonrpsee/Cargo.toml
@@ -22,10 +22,6 @@ alloy-primitives = { workspace = true, features = ["serde"] }
 jsonrpsee.workspace = true
 
 [features]
-default = ["std"]
-std = [
-    "alloy-primitives/std",
-]
 client = [
     "jsonrpsee/client",
     "jsonrpsee/async-client",

--- a/crates/rpc-jsonrpsee/README.md
+++ b/crates/rpc-jsonrpsee/README.md
@@ -1,0 +1,10 @@
+## `op-alloy-rpc-jsonrpsee`
+
+<a href="https://github.com/alloy-rs/op-alloy/actions/workflows/ci.yml"><img src="https://github.com/alloy-rs/op-alloy/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
+<a href="https://crates.io/crates/op-alloy-rpc-jsonrpsee"><img src="https://img.shields.io/crates/v/op-alloy-rpc-jsonrpsee.svg" alt="op-alloy-rpc-jsonrpsee crate"></a>
+<a href="https://github.com/alloy-rs/op-alloy/blob/main/LICENSE-MIT"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="MIT License"></a>
+<a href="https://github.com/alloy-rs/op-alloy/blob/main/LICENSE-APACHE"><img src="https://img.shields.io/badge/License-APACHE-d1d1f6.svg?label=license&labelColor=2a2f35" alt="Apache License"></a>
+<a href="https://alloy-rs.github.io/op-alloy"><img src="https://img.shields.io/badge/Book-854a15?logo=mdBook&labelColor=2a2f35" alt="Book"></a>
+
+
+Low-level Optimism JSON-RPC server and client implementations.

--- a/crates/rpc-jsonrpsee/src/lib.rs
+++ b/crates/rpc-jsonrpsee/src/lib.rs
@@ -1,0 +1,12 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/alloy.jpg",
+    html_favicon_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/favicon.ico"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+pub mod traits;

--- a/crates/rpc-jsonrpsee/src/lib.rs
+++ b/crates/rpc-jsonrpsee/src/lib.rs
@@ -5,6 +5,5 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod traits;

--- a/crates/rpc-jsonrpsee/src/lib.rs
+++ b/crates/rpc-jsonrpsee/src/lib.rs
@@ -7,6 +7,4 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate alloc;
-
 pub mod traits;

--- a/crates/rpc-jsonrpsee/src/traits.rs
+++ b/crates/rpc-jsonrpsee/src/traits.rs
@@ -1,107 +1,9 @@
 #![allow(missing_docs)]
 
-//! Rollup Node
+//! Various `jsonrpsee` docs
 
-use alloc::{boxed::Box, string::String, vec::Vec};
-use core::net::IpAddr;
-
-use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{B256, U64};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use maili_protocol::{ExecutingMessage, SafetyLevel};
-use op_alloy_rpc_types::{
-    OutputResponse, PeerDump, PeerInfo, PeerStats, RollupConfig, SafeHeadResponse, SyncStatus,
-};
-use op_alloy_rpc_types_engine::{ProtocolVersion, SuperchainSignal};
-
-/// Optimism specified rpc interface.
-///
-/// https://docs.optimism.io/builders/node-operators/json-rpc
-/// https://github.com/ethereum-optimism/optimism/blob/8dd17a7b114a7c25505cd2e15ce4e3d0f7e3f7c1/op-node/node/api.go#L114
-#[cfg_attr(not(feature = "client"), rpc(server, namespace = "optimism"))]
-#[cfg_attr(feature = "client", rpc(server, client, namespace = "optimism"))]
-pub trait RollupNode {
-    /// Get the output root at a specific block.
-    #[method(name = "outputAtBlock")]
-    async fn op_output_at_block(&self, block_number: BlockNumberOrTag)
-        -> RpcResult<OutputResponse>;
-
-    /// Gets the safe head at an L1 block height.
-    #[method(name = "safeHeadAtL1Block")]
-    async fn op_safe_head_at_l1_block(
-        &self,
-        block_number: BlockNumberOrTag,
-    ) -> RpcResult<SafeHeadResponse>;
-
-    /// Get the synchronization status.
-    #[method(name = "syncStatus")]
-    async fn op_sync_status(&self) -> RpcResult<SyncStatus>;
-
-    /// Get the rollup configuration parameters.
-    #[method(name = "rollupConfig")]
-    async fn op_rollup_config(&self) -> RpcResult<RollupConfig>;
-
-    /// Get the software version.
-    #[method(name = "version")]
-    async fn op_version(&self) -> RpcResult<String>;
-}
-
-/// The opp2p namespace handles peer interactions.
-#[cfg_attr(not(feature = "client"), rpc(server, namespace = "opp2p"))]
-#[cfg_attr(feature = "client", rpc(server, client, namespace = "opp2p"))]
-pub trait OpP2PApi {
-    /// Returns information of node
-    #[method(name = "self")]
-    async fn opp2p_self(&self) -> RpcResult<PeerInfo>;
-
-    #[method(name = "peers")]
-    async fn opp2p_peers(&self) -> RpcResult<PeerDump>;
-
-    #[method(name = "peerStats")]
-    async fn opp2p_peer_stats(&self) -> RpcResult<PeerStats>;
-
-    #[method(name = "discoveryTable")]
-    async fn opp2p_discovery_table(&self) -> RpcResult<Vec<String>>;
-
-    #[method(name = "blockPeer")]
-    async fn opp2p_block_peer(&self, peer: String) -> RpcResult<()>;
-
-    #[method(name = "listBlockedPeers")]
-    async fn opp2p_list_blocked_peers(&self) -> RpcResult<Vec<String>>;
-
-    #[method(name = "blocAddr")]
-    async fn opp2p_block_addr(&self, ip: IpAddr) -> RpcResult<()>;
-
-    #[method(name = "unblockAddr")]
-    async fn opp2p_unblock_addr(&self, ip: IpAddr) -> RpcResult<()>;
-
-    #[method(name = "listBlockedAddrs")]
-    async fn opp2p_list_blocked_addrs(&self) -> RpcResult<Vec<IpAddr>>;
-
-    /// todo: should be IPNet?
-    #[method(name = "blockSubnet")]
-    async fn opp2p_block_subnet(&self, subnet: String) -> RpcResult<()>;
-
-    /// todo: should be IPNet?
-    #[method(name = "unblockSubnet")]
-    async fn opp2p_unblock_subnet(&self, subnet: String) -> RpcResult<()>;
-
-    /// todo: should be IPNet?
-    #[method(name = "listBlockedSubnets")]
-    async fn opp2p_list_blocked_subnets(&self) -> RpcResult<Vec<String>>;
-
-    #[method(name = "protectPeer")]
-    async fn opp2p_protect_peer(&self, peer: String) -> RpcResult<()>;
-
-    #[method(name = "unprotectPeer")]
-    async fn opp2p_unprotect_peer(&self, peer: String) -> RpcResult<()>;
-
-    #[method(name = "connectPeer")]
-    async fn opp2p_connect_peer(&self, peer: String) -> RpcResult<()>;
-
-    #[method(name = "disconnectPeer")]
-    async fn opp2p_disconnect_peer(&self, peer: String) -> RpcResult<()>;
-}
 
 /// The admin namespace endpoints
 /// https://github.com/ethereum-optimism/optimism/blob/c7ad0ebae5dca3bf8aa6f219367a95c15a15ae41/op-node/node/api.go#L28-L36
@@ -121,24 +23,6 @@ pub trait OpAdminApi {
     async fn admin_sequencer_active(&self) -> RpcResult<bool>;
 }
 
-/// Engine API extension for Optimism superchain signaling
-#[cfg_attr(not(feature = "client"), rpc(server, namespace = "engine"))]
-#[cfg_attr(feature = "client", rpc(server, client, namespace = "engine"))]
-pub trait EngineApiExt {
-    /// Signal superchain v1 message
-    ///
-    /// The execution engine SHOULD warn when the recommended version is newer than the current
-    /// version. The execution engine SHOULD take safety precautions if it does not meet
-    /// the required version.
-    ///
-    /// # Returns
-    /// The latest supported OP-Stack protocol version of the execution engine.
-    ///
-    /// See: <https://specs.optimism.io/protocol/exec-engine.html#engine_signalsuperchainv1>
-    #[method(name = "signalSuperchainV1")]
-    async fn signal_superchain_v1(&self, signal: SuperchainSignal) -> RpcResult<ProtocolVersion>;
-}
-
 /// Op API extension for controlling the miner.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "miner"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "miner"))]
@@ -147,16 +31,4 @@ pub trait MinerApiExt {
     /// data size of the block. 0 means no maximum.
     #[method(name = "setMaxDASize")]
     async fn set_max_da_size(&self, max_tx_size: U64, max_block_size: U64) -> RpcResult<bool>;
-}
-
-/// Supervisor API for interop.
-#[rpc(client, namespace = "supervisor")]
-pub trait SupervisorApi {
-    /// Checks if the given messages meet the given minimum safety level.
-    #[method(name = "checkMessages")]
-    async fn check_messages(
-        &self,
-        messages: Vec<ExecutingMessage>,
-        min_safety: SafetyLevel,
-    ) -> RpcResult<()>;
 }

--- a/crates/rpc-jsonrpsee/src/traits.rs
+++ b/crates/rpc-jsonrpsee/src/traits.rs
@@ -1,0 +1,162 @@
+#![allow(missing_docs)]
+
+//! Rollup Node
+
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::net::IpAddr;
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::{B256, U64};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use maili_protocol::{ExecutingMessage, SafetyLevel};
+use op_alloy_rpc_types::{
+    OutputResponse, PeerDump, PeerInfo, PeerStats, RollupConfig, SafeHeadResponse, SyncStatus,
+};
+use op_alloy_rpc_types_engine::{ProtocolVersion, SuperchainSignal};
+
+/// Optimism specified rpc interface.
+///
+/// https://docs.optimism.io/builders/node-operators/json-rpc
+/// https://github.com/ethereum-optimism/optimism/blob/8dd17a7b114a7c25505cd2e15ce4e3d0f7e3f7c1/op-node/node/api.go#L114
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "optimism"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "optimism"))]
+pub trait RollupNode {
+    /// Get the output root at a specific block.
+    #[method(name = "outputAtBlock")]
+    async fn op_output_at_block(&self, block_number: BlockNumberOrTag)
+        -> RpcResult<OutputResponse>;
+
+    /// Gets the safe head at an L1 block height.
+    #[method(name = "safeHeadAtL1Block")]
+    async fn op_safe_head_at_l1_block(
+        &self,
+        block_number: BlockNumberOrTag,
+    ) -> RpcResult<SafeHeadResponse>;
+
+    /// Get the synchronization status.
+    #[method(name = "syncStatus")]
+    async fn op_sync_status(&self) -> RpcResult<SyncStatus>;
+
+    /// Get the rollup configuration parameters.
+    #[method(name = "rollupConfig")]
+    async fn op_rollup_config(&self) -> RpcResult<RollupConfig>;
+
+    /// Get the software version.
+    #[method(name = "version")]
+    async fn op_version(&self) -> RpcResult<String>;
+}
+
+/// The opp2p namespace handles peer interactions.
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "opp2p"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "opp2p"))]
+pub trait OpP2PApi {
+    /// Returns information of node
+    #[method(name = "self")]
+    async fn opp2p_self(&self) -> RpcResult<PeerInfo>;
+
+    #[method(name = "peers")]
+    async fn opp2p_peers(&self) -> RpcResult<PeerDump>;
+
+    #[method(name = "peerStats")]
+    async fn opp2p_peer_stats(&self) -> RpcResult<PeerStats>;
+
+    #[method(name = "discoveryTable")]
+    async fn opp2p_discovery_table(&self) -> RpcResult<Vec<String>>;
+
+    #[method(name = "blockPeer")]
+    async fn opp2p_block_peer(&self, peer: String) -> RpcResult<()>;
+
+    #[method(name = "listBlockedPeers")]
+    async fn opp2p_list_blocked_peers(&self) -> RpcResult<Vec<String>>;
+
+    #[method(name = "blocAddr")]
+    async fn opp2p_block_addr(&self, ip: IpAddr) -> RpcResult<()>;
+
+    #[method(name = "unblockAddr")]
+    async fn opp2p_unblock_addr(&self, ip: IpAddr) -> RpcResult<()>;
+
+    #[method(name = "listBlockedAddrs")]
+    async fn opp2p_list_blocked_addrs(&self) -> RpcResult<Vec<IpAddr>>;
+
+    /// todo: should be IPNet?
+    #[method(name = "blockSubnet")]
+    async fn opp2p_block_subnet(&self, subnet: String) -> RpcResult<()>;
+
+    /// todo: should be IPNet?
+    #[method(name = "unblockSubnet")]
+    async fn opp2p_unblock_subnet(&self, subnet: String) -> RpcResult<()>;
+
+    /// todo: should be IPNet?
+    #[method(name = "listBlockedSubnets")]
+    async fn opp2p_list_blocked_subnets(&self) -> RpcResult<Vec<String>>;
+
+    #[method(name = "protectPeer")]
+    async fn opp2p_protect_peer(&self, peer: String) -> RpcResult<()>;
+
+    #[method(name = "unprotectPeer")]
+    async fn opp2p_unprotect_peer(&self, peer: String) -> RpcResult<()>;
+
+    #[method(name = "connectPeer")]
+    async fn opp2p_connect_peer(&self, peer: String) -> RpcResult<()>;
+
+    #[method(name = "disconnectPeer")]
+    async fn opp2p_disconnect_peer(&self, peer: String) -> RpcResult<()>;
+}
+
+/// The admin namespace endpoints
+/// https://github.com/ethereum-optimism/optimism/blob/c7ad0ebae5dca3bf8aa6f219367a95c15a15ae41/op-node/node/api.go#L28-L36
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "admin"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "admin"))]
+pub trait OpAdminApi {
+    #[method(name = "resetDerivationPipeline")]
+    async fn admin_reset_derivation_pipeline(&self) -> RpcResult<()>;
+
+    #[method(name = "startSequencer")]
+    async fn admin_start_sequencer(&self, block_hash: B256) -> RpcResult<()>;
+
+    #[method(name = "stopSequencer")]
+    async fn admin_stop_sequencer(&self) -> RpcResult<B256>;
+
+    #[method(name = "sequencerActive")]
+    async fn admin_sequencer_active(&self) -> RpcResult<bool>;
+}
+
+/// Engine API extension for Optimism superchain signaling
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "engine"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "engine"))]
+pub trait EngineApiExt {
+    /// Signal superchain v1 message
+    ///
+    /// The execution engine SHOULD warn when the recommended version is newer than the current
+    /// version. The execution engine SHOULD take safety precautions if it does not meet
+    /// the required version.
+    ///
+    /// # Returns
+    /// The latest supported OP-Stack protocol version of the execution engine.
+    ///
+    /// See: <https://specs.optimism.io/protocol/exec-engine.html#engine_signalsuperchainv1>
+    #[method(name = "signalSuperchainV1")]
+    async fn signal_superchain_v1(&self, signal: SuperchainSignal) -> RpcResult<ProtocolVersion>;
+}
+
+/// Op API extension for controlling the miner.
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "miner"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "miner"))]
+pub trait MinerApiExt {
+    /// Sets the maximum data availability size of any tx allowed in a block, and the total max l1
+    /// data size of the block. 0 means no maximum.
+    #[method(name = "setMaxDASize")]
+    async fn set_max_da_size(&self, max_tx_size: U64, max_block_size: U64) -> RpcResult<bool>;
+}
+
+/// Supervisor API for interop.
+#[rpc(client, namespace = "supervisor")]
+pub trait SupervisorApi {
+    /// Checks if the given messages meet the given minimum safety level.
+    #[method(name = "checkMessages")]
+    async fn check_messages(
+        &self,
+        messages: Vec<ExecutingMessage>,
+        min_safety: SafetyLevel,
+    ) -> RpcResult<()>;
+}

--- a/crates/rpc-types-engine/Cargo.toml
+++ b/crates/rpc-types-engine/Cargo.toml
@@ -23,9 +23,6 @@ alloy-primitives.workspace = true
 alloy-eips.workspace = true
 alloy-rpc-types-engine.workspace = true
 
-# Maili
-maili-protocol.workspace = true
-
 # Encoding
 snap = { workspace = true, optional = true }
 ethereum_ssz = { workspace = true, optional = true }
@@ -53,12 +50,10 @@ std = [
   "alloy-primitives/std",
   "alloy-rpc-types-engine/std",
   "op-alloy-consensus/std",
-  "maili-protocol/std",
 ]
 serde = [
   "dep:serde",
   "dep:alloy-serde",
-  "maili-protocol/serde",
   "alloy-rpc-types-engine/serde",
 ]
 arbitrary = [

--- a/crates/rpc-types-engine/src/attributes.rs
+++ b/crates/rpc-types-engine/src/attributes.rs
@@ -4,7 +4,6 @@ use alloc::vec::Vec;
 use alloy_eips::eip1559::BaseFeeParams;
 use alloy_primitives::{Bytes, B64};
 use alloy_rpc_types_engine::PayloadAttributes;
-use maili_protocol::L2BlockInfo;
 use op_alloy_consensus::{decode_eip_1559_params, encode_holocene_extra_data, EIP1559ParamError};
 
 /// Optimism Payload Attributes
@@ -52,44 +51,6 @@ impl OpPayloadAttributes {
     /// Returns (`elasticity`, `denominator`)
     pub fn decode_eip_1559_params(&self) -> Option<(u32, u32)> {
         self.eip_1559_params.map(decode_eip_1559_params)
-    }
-}
-
-/// Optimism Payload Attributes with parent block reference.
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct OpAttributesWithParent {
-    /// The payload attributes.
-    pub attributes: OpPayloadAttributes,
-    /// The parent block reference.
-    pub parent: L2BlockInfo,
-    /// Whether the current batch is the last in its span.
-    pub is_last_in_span: bool,
-}
-
-impl OpAttributesWithParent {
-    /// Create a new [OpAttributesWithParent] instance.
-    pub const fn new(
-        attributes: OpPayloadAttributes,
-        parent: L2BlockInfo,
-        is_last_in_span: bool,
-    ) -> Self {
-        Self { attributes, parent, is_last_in_span }
-    }
-
-    /// Returns the payload attributes.
-    pub const fn attributes(&self) -> &OpPayloadAttributes {
-        &self.attributes
-    }
-
-    /// Returns the parent block reference.
-    pub const fn parent(&self) -> &L2BlockInfo {
-        &self.parent
-    }
-
-    /// Returns whether the current batch is the last in its span.
-    pub const fn is_last_in_span(&self) -> bool {
-        self.is_last_in_span
     }
 }
 

--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -12,7 +12,7 @@ extern crate alloc;
 pub use alloy_rpc_types_engine::ForkchoiceUpdateVersion;
 
 mod attributes;
-pub use attributes::{OpPayloadAttributes};
+pub use attributes::OpPayloadAttributes;
 
 mod envelope;
 pub use envelope::{OpNetworkPayloadEnvelope, PayloadEnvelopeError, PayloadHash};

--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -12,7 +12,7 @@ extern crate alloc;
 pub use alloy_rpc_types_engine::ForkchoiceUpdateVersion;
 
 mod attributes;
-pub use attributes::{OpAttributesWithParent, OpPayloadAttributes};
+pub use attributes::{OpPayloadAttributes};
 
 mod envelope;
 pub use envelope::{OpNetworkPayloadEnvelope, PayloadEnvelopeError, PayloadHash};

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -26,9 +26,6 @@ alloy-eips = { workspace = true, features = ["serde"] }
 alloy-rpc-types-eth = { workspace = true, features = ["serde"] }
 alloy-primitives = { workspace = true, features = ["map", "rlp", "serde"] }
 
-# Maili
-maili-consensus.workspace = true
-
 # Serde
 serde_json.workspace = true
 serde = { workspace = true, features = ["derive"] }
@@ -53,7 +50,6 @@ std = [
   "alloy-eips/std",
   "alloy-primitives/std",
   "alloy-rpc-types-eth/std",
-  "maili-consensus/std",
 ]
 arbitrary = [
   "std",

--- a/crates/rpc-types/src/transaction.rs
+++ b/crates/rpc-types/src/transaction.rs
@@ -4,7 +4,7 @@ use alloy_consensus::{Transaction as _, Typed2718};
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{Address, BlockHash, Bytes, ChainId, TxKind, B256, U256};
 use alloy_serde::OtherFields;
-use op_alloy_consensus::OpTxEnvelope;
+use op_alloy_consensus::{DepositTxEnvelope, OpTxEnvelope};
 use serde::{Deserialize, Serialize};
 
 mod request;
@@ -167,7 +167,7 @@ mod tx_serde {
     //! Helper module for serializing and deserializing OP [`Transaction`].
     //!
     //! This is needed because we might need to deserialize the `from` field into both
-    //! [`alloy_rpc_types_eth::Transaction::from`] and [`maili_consensus::TxDeposit::from`].
+    //! [`alloy_rpc_types_eth::Transaction::from`] and [`op_alloy_consensus::TxDeposit::from`].
     //!
     //! Additionaly, we need similar logic for the `gasPrice` field
     use super::*;

--- a/crates/rpc-types/src/transaction.rs
+++ b/crates/rpc-types/src/transaction.rs
@@ -4,7 +4,7 @@ use alloy_consensus::{Transaction as _, Typed2718};
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{Address, BlockHash, Bytes, ChainId, TxKind, B256, U256};
 use alloy_serde::OtherFields;
-use op_alloy_consensus::{DepositTxEnvelope, OpTxEnvelope};
+use op_alloy_consensus::OpTxEnvelope;
 use serde::{Deserialize, Serialize};
 
 mod request;

--- a/crates/rpc-types/src/transaction/request.rs
+++ b/crates/rpc-types/src/transaction/request.rs
@@ -6,8 +6,7 @@ use alloy_eips::eip7702::SignedAuthorization;
 use alloy_network_primitives::TransactionBuilder7702;
 use alloy_primitives::{Address, PrimitiveSignature as Signature, TxKind, U256};
 use alloy_rpc_types_eth::{AccessList, TransactionInput, TransactionRequest};
-use maili_consensus::TxDeposit;
-use op_alloy_consensus::{OpTxEnvelope, OpTypedTransaction};
+use op_alloy_consensus::{OpTxEnvelope, OpTypedTransaction, TxDeposit};
 use serde::{Deserialize, Serialize};
 
 /// Builder for [`OpTypedTransaction`].


### PR DESCRIPTION
Closes https://github.com/alloy-rs/op-alloy/issues/398

this reverts a bunch of stuff and removes all maili dependencies.

this is definitely incomplete but is the first step towards restoring op-alloy as a maili independent repo.

the dep graph looks now as follows:
alloy -> op-alloy -> maili

maili can have all types limited to protocol impls (although debatable if this is actually beneficial, imo this just slows down development atm).

next steps are invert deps on maili side and clean things up there.

this repo would benefit from the flz stuff, so I suggest we move this crate in here and only keep the brotli stuff in maili