### PR TITLE
chore: rm bad non_exhaustive

### DIFF
--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -23,7 +23,6 @@ use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable};
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
-#[non_exhaustive]
 pub enum OpReceiptEnvelope<T = Log> {
     /// Receipt envelope with no type flag.
     #[cfg_attr(feature = "serde", serde(rename = "0x0", alias = "0x00"))]

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -29,7 +29,6 @@ use alloy_rlp::{Decodable, Encodable};
     serde(into = "serde_from::TaggedTxEnvelope", from = "serde_from::MaybeTaggedTxEnvelope")
 )]
 #[cfg_attr(all(any(test, feature = "arbitrary"), feature = "k256"), derive(arbitrary::Arbitrary))]
-#[non_exhaustive]
 pub enum OpTxEnvelope {
     /// An untagged [`TxLegacy`].
     Legacy(Signed<TxLegacy>),

--- a/crates/rpc-types/src/receipt.rs
+++ b/crates/rpc-types/src/receipt.rs
@@ -225,7 +225,6 @@ impl From<OpTransactionReceipt> for OpReceiptEnvelope<alloy_primitives::Log> {
                 };
                 Self::Deposit(consensus_receipt)
             }
-            _ => unreachable!("Unsupported OpReceiptEnvelope variant"),
         }
     }
 }


### PR DESCRIPTION
these are sleeping timebombs because these require the user to add an unreachable arm