### PR TITLE
feat(isthmus): define `OpExecutionData`

### DIFF
--- a/crates/rpc-types-engine/src/envelope.rs
+++ b/crates/rpc-types-engine/src/envelope.rs
@@ -6,6 +6,19 @@
 use alloy_primitives::{keccak256, PrimitiveSignature as Signature, B256};
 use alloy_rpc_types_engine::ExecutionPayload;
 
+use crate::{OpExecutionPayload, OpExecutionPayloadSidecar};
+
+/// Struct aggregating [`OpExecutionPayload`] and [`OpExecutionPayloadSidecar`] and encapsulating
+/// complete payload supplied for execution.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct OpExecutionData {
+    /// Execution payload.
+    pub payload: OpExecutionPayload,
+    /// Additional fork-specific fields.
+    pub sidecar: OpExecutionPayloadSidecar,
+}
+
 /// Optimism execution payload envelope in network format.
 ///
 /// This struct is used to represent payloads that are sent over the Optimism

--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -15,7 +15,7 @@ mod attributes;
 pub use attributes::OpPayloadAttributes;
 
 mod envelope;
-pub use envelope::{OpNetworkPayloadEnvelope, PayloadEnvelopeError, PayloadHash};
+pub use envelope::{OpExecutionData, OpNetworkPayloadEnvelope, PayloadEnvelopeError, PayloadHash};
 
 mod sidecar;
 pub use sidecar::{IsthmusPayloadFields, MaybeIsthmusPayloadFields, OpExecutionPayloadSidecar};

--- a/crates/rpc-types-engine/src/payload/mod.rs
+++ b/crates/rpc-types-engine/src/payload/mod.rs
@@ -9,7 +9,7 @@ use alloy_rpc_types_engine::{ExecutionPayloadV2, ExecutionPayloadV3};
 /// An execution payload, which can be either [`ExecutionPayloadV2`], [`ExecutionPayloadV3`], or
 /// [`OpExecutionPayloadV4`].
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
 pub enum OpExecutionPayload {
     /// V2 payload


### PR DESCRIPTION
Closes https://github.com/alloy-rs/op-alloy/issues/417

- Defines `OpExecutionData` which wraps `OpExecutionPayload` and `OpExecutionPayloadSidecar`
- Debugs `OpExecutionPayload`
- Removes `OpExecutionPayloadV4`, since the l2 withdrawals root goes in sidecar, it doesn't add an extra field to the header