### PR TITLE
feat: add bincode compat support for depositreceipts

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -48,5 +48,8 @@ pub use transaction::serde_deposit_tx_rpc;
 /// Read more: <https://github.com/bincode-org/bincode/issues/326>
 #[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
 pub mod serde_bincode_compat {
-    pub use super::transaction::serde_bincode_compat::TxDeposit;
+    pub use super::{
+        receipt::receipts::serde_bincode_compat::OpDepositReceipt,
+        transaction::serde_bincode_compat::TxDeposit,
+    };
 }

--- a/crates/consensus/src/receipt/mod.rs
+++ b/crates/consensus/src/receipt/mod.rs
@@ -5,7 +5,7 @@ use alloy_consensus::TxReceipt;
 mod envelope;
 pub use envelope::OpReceiptEnvelope;
 
-mod receipts;
+pub(crate) mod receipts;
 pub use receipts::{OpDepositReceipt, OpDepositReceiptWithBloom};
 
 /// Receipt is the result of a transaction execution.

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -215,7 +215,7 @@ where
 /// Bincode-compatible [`OpDepositReceipt`] serde implementation.
 #[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
 pub(crate) mod serde_bincode_compat {
-    use alloc::borrow::Cow;
+    use alloc::{borrow::Cow, vec::Vec};
     use alloy_consensus::Receipt;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -271,7 +271,7 @@ pub(crate) mod serde_bincode_compat {
         }
     }
 
-    impl<'a, T: Serialize + Clone> SerializeAs<super::OpDepositReceipt<T>> for OpDepositReceipt<'a, T> {
+    impl<T: Serialize + Clone> SerializeAs<super::OpDepositReceipt<T>> for OpDepositReceipt<'_, T> {
         fn serialize_as<S>(
             source: &super::OpDepositReceipt<T>,
             serializer: S,

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -212,6 +212,120 @@ where
     }
 }
 
+/// Bincode-compatible [`OpDepositReceipt`] serde implementation.
+#[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
+pub(crate) mod serde_bincode_compat {
+    use alloc::borrow::Cow;
+    use alloy_consensus::Receipt;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde_with::{DeserializeAs, SerializeAs};
+
+    /// Bincode-compatible [`super::OpDepositReceipt`] serde implementation.
+    ///
+    /// Intended to use with the [`serde_with::serde_as`] macro in the following way:
+    /// ```rust
+    /// use op_alloy_consensus::{serde_bincode_compat, OpDepositReceipt};
+    /// use serde::{de::DeserializeOwned, Deserialize, Serialize};
+    /// use serde_with::serde_as;
+    ///
+    /// #[serde_as]
+    /// #[derive(Serialize, Deserialize)]
+    /// struct Data<T: Serialize + DeserializeOwned + Clone + 'static> {
+    ///     #[serde_as(as = "serde_bincode_compat::OpDepositReceipt<'_, T>")]
+    ///     receipt: OpDepositReceipt<T>,
+    /// }
+    /// ```
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct OpDepositReceipt<'a, T: Clone> {
+        logs: Cow<'a, Vec<T>>,
+        status: bool,
+        cumulative_gas_used: u64,
+        deposit_nonce: Option<u64>,
+        deposit_receipt_version: Option<u64>,
+    }
+
+    impl<'a, T: Clone> From<&'a super::OpDepositReceipt<T>> for OpDepositReceipt<'a, T> {
+        fn from(value: &'a super::OpDepositReceipt<T>) -> Self {
+            Self {
+                logs: Cow::Borrowed(&value.inner.logs),
+                // OP has no post state root variant
+                status: value.inner.status.coerce_status(),
+                cumulative_gas_used: value.inner.cumulative_gas_used,
+                deposit_nonce: value.deposit_nonce,
+                deposit_receipt_version: value.deposit_receipt_version,
+            }
+        }
+    }
+
+    impl<'a, T: Clone> From<OpDepositReceipt<'a, T>> for super::OpDepositReceipt<T> {
+        fn from(value: OpDepositReceipt<'a, T>) -> Self {
+            Self {
+                inner: Receipt {
+                    status: value.status.into(),
+                    cumulative_gas_used: value.cumulative_gas_used,
+                    logs: value.logs.into_owned(),
+                },
+                deposit_nonce: value.deposit_nonce,
+                deposit_receipt_version: value.deposit_receipt_version,
+            }
+        }
+    }
+
+    impl<'a, T: Serialize + Clone> SerializeAs<super::OpDepositReceipt<T>> for OpDepositReceipt<'a, T> {
+        fn serialize_as<S>(
+            source: &super::OpDepositReceipt<T>,
+            serializer: S,
+        ) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            OpDepositReceipt::<'_, T>::from(source).serialize(serializer)
+        }
+    }
+
+    impl<'de, T: Deserialize<'de> + Clone> DeserializeAs<'de, super::OpDepositReceipt<T>>
+        for OpDepositReceipt<'de, T>
+    {
+        fn deserialize_as<D>(deserializer: D) -> Result<super::OpDepositReceipt<T>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            OpDepositReceipt::<'_, T>::deserialize(deserializer).map(Into::into)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::super::{serde_bincode_compat, OpDepositReceipt};
+        use alloy_primitives::Log;
+        use arbitrary::Arbitrary;
+        use rand::Rng;
+        use serde::{de::DeserializeOwned, Deserialize, Serialize};
+        use serde_with::serde_as;
+
+        #[test]
+        fn test_tx_deposit_bincode_roundtrip() {
+            #[serde_as]
+            #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+            struct Data<T: Serialize + DeserializeOwned + Clone + 'static> {
+                #[serde_as(as = "serde_bincode_compat::OpDepositReceipt<'_,T>")]
+                transaction: OpDepositReceipt<T>,
+            }
+
+            let mut bytes = [0u8; 1024];
+            rand::thread_rng().fill(bytes.as_mut_slice());
+            let data = Data {
+                transaction: OpDepositReceipt::arbitrary(&mut arbitrary::Unstructured::new(&bytes))
+                    .unwrap(),
+            };
+
+            let encoded = bincode::serialize(&data).unwrap();
+            let decoded: Data<Log> = bincode::deserialize(&encoded).unwrap();
+            assert_eq!(decoded, data);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -1,7 +1,9 @@
 use crate::{OpTxEnvelope, OpTxType, TxDeposit};
-use alloy_consensus::{Transaction, TxEip1559, TxEip2930, TxEip7702, TxLegacy, Typed2718};
+use alloy_consensus::{
+    SignableTransaction, Transaction, TxEip1559, TxEip2930, TxEip7702, TxLegacy, Typed2718,
+};
 use alloy_eips::eip2930::AccessList;
-use alloy_primitives::{Address, Bytes, TxKind};
+use alloy_primitives::{Address, Bytes, TxKind, B256};
 
 /// The TypedTransaction enum represents all Ethereum transaction request types, modified for the OP
 /// Stack.
@@ -85,6 +87,19 @@ impl OpTypedTransaction {
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
             Self::Deposit(_) => OpTxType::Deposit,
+        }
+    }
+
+    /// Calculates the signing hash for the transaction.
+    ///
+    /// Returns `None` if the tx is a deposit transaction.
+    pub fn signature_hash(&self) -> Option<B256> {
+        match self {
+            OpTypedTransaction::Legacy(tx) => Some(tx.signature_hash()),
+            OpTypedTransaction::Eip2930(tx) => Some(tx.signature_hash()),
+            OpTypedTransaction::Eip1559(tx) => Some(tx.signature_hash()),
+            OpTypedTransaction::Eip7702(tx) => Some(tx.signature_hash()),
+            OpTypedTransaction::Deposit(_) => None,
         }
     }
 

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -95,11 +95,11 @@ impl OpTypedTransaction {
     /// Returns `None` if the tx is a deposit transaction.
     pub fn signature_hash(&self) -> Option<B256> {
         match self {
-            OpTypedTransaction::Legacy(tx) => Some(tx.signature_hash()),
-            OpTypedTransaction::Eip2930(tx) => Some(tx.signature_hash()),
-            OpTypedTransaction::Eip1559(tx) => Some(tx.signature_hash()),
-            OpTypedTransaction::Eip7702(tx) => Some(tx.signature_hash()),
-            OpTypedTransaction::Deposit(_) => None,
+            Self::Legacy(tx) => Some(tx.signature_hash()),
+            Self::Eip2930(tx) => Some(tx.signature_hash()),
+            Self::Eip1559(tx) => Some(tx.signature_hash()),
+            Self::Eip7702(tx) => Some(tx.signature_hash()),
+            Self::Deposit(_) => None,
         }
     }
 


### PR DESCRIPTION
closes #424

ensures this type can be used when doing bincode style serde where flatten or skipped fields are not supported

this is so annoying ...