### PR TITLE
feat(l2-withdrawals): Add `OpPayloadError` variants for blob transactions and l1 withdrawals

### DIFF
--- a/crates/rpc-types-engine/src/payload/error.rs
+++ b/crates/rpc-types-engine/src/payload/error.rs
@@ -5,6 +5,12 @@ use alloy_rpc_types_engine::PayloadError;
 /// Extends [`PayloadError`] for Optimism.
 #[derive(Debug, thiserror::Error)]
 pub enum OpPayloadError {
+    /// Non-empty list of L1 withdrawals (Shanghai).
+    #[error("non-empty L1 withdrawals")]
+    NonEmptyL1Withdrawals,
+    /// Contains unsupported blob transaction type EIP-4844.
+    #[error("contains blob transaction")]
+    BlobTransaction,
     /// Non-empty list of execution layer requests.
     #[error("non-empty EL requests")]
     NonEmptyELRequests,


### PR DESCRIPTION
Pre-req for l2-withdrawals is that the payload validation diverges from l1 payload validation. Adds stateless payload checks to `OpExecutionPayload::try_into_block`