### PR TITLE
Remove deprecated key lint from manifests

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -11,9 +11,6 @@ homepage.workspace = true
 repository.workspace = true
 exclude.workspace = true
 
-[lints]
-workspace = true
-
 [dependencies]
 # Alloy
 alloy-rlp.workspace = true

--- a/crates/flz/Cargo.toml
+++ b/crates/flz/Cargo.toml
@@ -11,9 +11,6 @@ homepage.workspace = true
 repository.workspace = true
 exclude.workspace = true
 
-[lints]
-workspace = true
-
 [dependencies]
 fastlz = { version = "0.1.0", optional = true }
 

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -11,9 +11,6 @@ homepage.workspace = true
 repository.workspace = true
 exclude.workspace = true
 
-[lints]
-workspace = true
-
 [dependencies]
 # Workspace
 op-alloy-consensus.workspace = true

--- a/crates/op-alloy/Cargo.toml
+++ b/crates/op-alloy/Cargo.toml
@@ -14,9 +14,6 @@ exclude.workspace = true
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
-[lints]
-workspace = true
-
 [dependencies]
 # Workspace
 op-alloy-consensus = { workspace = true, optional = true }

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -11,9 +11,6 @@ authors.workspace = true
 repository.workspace = true
 exclude.workspace = true
 
-[lints]
-workspace = true
-
 [dependencies]
 # Workspace
 op-alloy-rpc-types-engine = { workspace = true, features = ["serde"] }

--- a/crates/rpc-jsonrpsee/Cargo.toml
+++ b/crates/rpc-jsonrpsee/Cargo.toml
@@ -11,9 +11,6 @@ authors.workspace = true
 repository.workspace = true
 exclude.workspace = true
 
-[lints]
-workspace = true
-
 [dependencies]
 # Alloy
 alloy-primitives = { workspace = true, features = ["serde"] }

--- a/crates/rpc-types-engine/Cargo.toml
+++ b/crates/rpc-types-engine/Cargo.toml
@@ -11,9 +11,6 @@ authors.workspace = true
 repository.workspace = true
 exclude.workspace = true
 
-[lints]
-workspace = true
-
 [dependencies]
 # Workspace
 op-alloy-consensus.workspace = true

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -11,9 +11,6 @@ authors.workspace = true
 repository.workspace = true
 exclude.workspace = true
 
-[lints]
-workspace = true
-
 [dependencies]
 # Workspace
 op-alloy-consensus = { workspace = true, features = ["serde"] }


### PR DESCRIPTION
Fixes "unused manifest key `lints`" error: https://github.com/alloy-rs/op-alloy/actions/runs/13541694801/job/37844009342?pr=455