### PR TITLE
Remove redundant method for v4 payload

### DIFF
--- a/crates/rpc-types-engine/src/envelope.rs
+++ b/crates/rpc-types-engine/src/envelope.rs
@@ -85,7 +85,7 @@ impl OpExecutionData {
                 Some(execution_payload_v3.withdrawals())
             }
             OpExecutionPayload::V4(op_execution_payload_v4) => {
-                Some(op_execution_payload_v4.withdrawals())
+                Some(op_execution_payload_v4.payload_inner.withdrawals())
             }
         }
     }

--- a/crates/rpc-types-engine/src/payload/v4.rs
+++ b/crates/rpc-types-engine/src/payload/v4.rs
@@ -2,7 +2,7 @@
 
 use alloc::vec::Vec;
 use alloy_consensus::Block;
-use alloy_eips::{eip4895::Withdrawal, Decodable2718};
+use alloy_eips::Decodable2718;
 use alloy_primitives::{Bytes, B256, U256};
 use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV3, PayloadError};
 
@@ -35,11 +35,6 @@ impl OpExecutionPayloadV4 {
         base_block.header.withdrawals_root = Some(self.withdrawals_root);
 
         Ok(base_block)
-    }
-
-    /// Returns the withdrawals for the payload.
-    pub const fn withdrawals(&self) -> &Vec<Withdrawal> {
-        self.payload_inner.withdrawals()
     }
 }
 


### PR DESCRIPTION
No need for method `OpExecutionPayloadV4::withdrawals` and the types it imports, since the inner payload is in a publicly accessible field anyways. This list of withdrawals should always be empty.