### PR TITLE
chore(consensus): AsRef<OpTxEnvelope>

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -42,6 +42,12 @@ pub enum OpTxEnvelope {
     Deposit(Sealed<TxDeposit>),
 }
 
+impl AsRef<Self> for OpTxEnvelope {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 impl From<Signed<TxLegacy>> for OpTxEnvelope {
     fn from(v: Signed<TxLegacy>) -> Self {
         Self::Legacy(v)


### PR DESCRIPTION
### Description

Implements `AsRef<OpTxEnvelope>` over itself so a generic tx type that implements `AsRef<OpTxEnvelope>` can be specified.

Basically, we need a way to convert the [`op_alloy_rpc_types::Transaction`](https://docs.rs/op-alloy-rpc-types/latest/op_alloy_rpc_types/struct.Transaction.html#impl-AsRef%3COpTxEnvelope%3E-for-Transaction)
type into an `OpTxEnvelope`. Since it implements `AsRef<OpTxEnvelope>`, we can just implement `AsRef` over `OpTxEnvelope` itself so we can restrict a generic
`T: AsRef<OpTxEnvelope>` and use either `OpTxEnvelope` or `op_alloy_rpc_types::Transaction`.

#### Provenance

See: https://github.com/op-rs/kona/pull/1176