### PR TITLE
chore: Remove deposit context source

### DIFF
--- a/crates/consensus/src/source.rs
+++ b/crates/consensus/src/source.rs
@@ -13,8 +13,6 @@ pub enum DepositSourceDomainIdentifier {
     L1Info = 1,
     /// An upgrade deposit source.
     Upgrade = 2,
-    /// Deposit context closing transaction.
-    DepositContext = 3,
 }
 
 /// Source domains for deposit transactions.
@@ -26,8 +24,6 @@ pub enum DepositSourceDomain {
     L1Info(L1InfoDepositSource),
     /// An upgrade deposit source.
     Upgrade(UpgradeDepositSource),
-    /// A deposit context closing source
-    DepositContext(DepositContextDepositSource),
 }
 
 impl DepositSourceDomain {
@@ -37,7 +33,6 @@ impl DepositSourceDomain {
             Self::User(ds) => ds.source_hash(),
             Self::L1Info(ds) => ds.source_hash(),
             Self::Upgrade(ds) => ds.source_hash(),
-            Self::DepositContext(ds) => ds.source_hash(),
         }
     }
 }
@@ -128,36 +123,6 @@ impl UpgradeDepositSource {
             (DepositSourceDomainIdentifier::Upgrade as u64).to_be_bytes();
         domain_input[32 - 8..32].copy_from_slice(&identifier_bytes);
         domain_input[32..].copy_from_slice(&intent_hash[..]);
-        keccak256(domain_input)
-    }
-}
-
-/// A deposit context transaction source.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
-pub struct DepositContextDepositSource {
-    /// The L1 block hash.
-    pub l1_block_hash: B256,
-    /// The sequence number.
-    pub seq_number: u64,
-}
-
-impl DepositContextDepositSource {
-    /// Creates a new [L1InfoDepositSource].
-    pub const fn new(l1_block_hash: B256, seq_number: u64) -> Self {
-        Self { l1_block_hash, seq_number }
-    }
-
-    /// Returns the source hash.
-    pub fn source_hash(&self) -> B256 {
-        let mut input = [0u8; 32 * 2];
-        input[..32].copy_from_slice(&self.l1_block_hash[..]);
-        input[32 * 2 - 8..].copy_from_slice(&self.seq_number.to_be_bytes());
-        let deposit_id_hash = keccak256(input);
-        let mut domain_input = [0u8; 32 * 2];
-        let identifier_bytes: [u8; 8] =
-            (DepositSourceDomainIdentifier::DepositContext as u64).to_be_bytes();
-        domain_input[32 - 8..32].copy_from_slice(&identifier_bytes);
-        domain_input[32..].copy_from_slice(&deposit_id_hash[..]);
         keccak256(domain_input)
     }
 }

--- a/crates/consensus/src/transaction/deposit.rs
+++ b/crates/consensus/src/transaction/deposit.rs
@@ -201,7 +201,7 @@ impl TxDeposit {
 
     /// Returns the signature for the optimism deposit transactions, which don't include a
     /// signature.
-    pub fn signature() -> Signature {
+    pub const fn signature() -> Signature {
         Signature::new(U256::ZERO, U256::ZERO, false)
     }
 }


### PR DESCRIPTION
## Overview

Removes the deposit context source, which is no longer necessary as a part of the interop upgrade.