### PR TITLE
feat(rpc-types-engine): SSZ Payload Encoding

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -448,19 +448,19 @@ impl OpTxEnvelope {
     }
 
     /// Returns the inner transaction hash.
-    pub fn hash(&self) -> &B256 {
+    pub fn hash(&self) -> B256 {
         match self {
-            Self::Legacy(tx) => tx.hash(),
-            Self::Eip1559(tx) => tx.hash(),
-            Self::Eip2930(tx) => tx.hash(),
-            Self::Eip7702(tx) => tx.hash(),
-            Self::Deposit(tx) => tx.hash_ref(),
+            Self::Legacy(tx) => *tx.hash(),
+            Self::Eip1559(tx) => *tx.hash(),
+            Self::Eip2930(tx) => *tx.hash(),
+            Self::Eip7702(tx) => *tx.hash(),
+            Self::Deposit(tx) => tx.hash(),
         }
     }
 
     /// Returns the inner transaction hash.
     pub fn tx_hash(&self) -> B256 {
-        *self.hash()
+        self.hash()
     }
 
     /// Return the length of the inner txn, including type byte length

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -448,19 +448,19 @@ impl OpTxEnvelope {
     }
 
     /// Returns the inner transaction hash.
-    pub fn hash(&self) -> B256 {
+    pub fn hash(&self) -> &B256 {
         match self {
-            Self::Legacy(tx) => *tx.hash(),
-            Self::Eip1559(tx) => *tx.hash(),
-            Self::Eip2930(tx) => *tx.hash(),
-            Self::Eip7702(tx) => *tx.hash(),
-            Self::Deposit(tx) => tx.hash(),
+            Self::Legacy(tx) => tx.hash(),
+            Self::Eip1559(tx) => tx.hash(),
+            Self::Eip2930(tx) => tx.hash(),
+            Self::Eip7702(tx) => tx.hash(),
+            Self::Deposit(tx) => tx.hash_ref(),
         }
     }
 
     /// Returns the inner transaction hash.
     pub fn tx_hash(&self) -> B256 {
-        self.hash()
+        *self.hash()
     }
 
     /// Return the length of the inner txn, including type byte length

--- a/crates/rpc-types-engine/src/envelope.rs
+++ b/crates/rpc-types-engine/src/envelope.rs
@@ -299,6 +299,7 @@ pub enum PayloadEnvelopeEncodeError {
     WrongVersion,
     /// An error occured during snap encoding.
     #[error(transparent)]
+    #[cfg(feature = "std")]
     SnapEncoding(#[from] snap::Error),
 }
 

--- a/crates/rpc-types-engine/src/envelope.rs
+++ b/crates/rpc-types-engine/src/envelope.rs
@@ -181,27 +181,20 @@ impl OpNetworkPayloadEnvelope {
     /// Encodes a payload envelope as a snappy-compressed byte array.
     #[cfg(feature = "std")]
     pub fn encode_v1(&self) -> Result<Vec<u8>, PayloadEnvelopeEncodeError> {
+        use ssz::Encode;
         let execution_payload_v1 = match &self.payload {
             OpExecutionPayload::V1(execution_payload_v1) => execution_payload_v1,
             _ => return Err(PayloadEnvelopeEncodeError::WrongVersion),
         };
 
-        use ssz::Encode;
         let mut data = Vec::new();
-        let mut sig_bytes = self.signature.as_bytes();
-        // Normalize parity bit
-        if self.signature.v() {
-            sig_bytes[64] = 0x01;
-        } else {
-            sig_bytes[64] = 0x00;
-        }
-        data.extend_from_slice(&sig_bytes[..]);
+        let mut sig = self.signature.as_bytes();
+        sig[64] = self.signature.v() as u8;
+        data.extend_from_slice(&sig[..]);
         let block_data = execution_payload_v1.as_ssz_bytes();
         data.extend_from_slice(block_data.as_slice());
 
-        // Compress the data using snap
-        let compressed = snap::raw::Encoder::new().compress_vec(&data)?;
-        Ok(compressed)
+        Ok(snap::raw::Encoder::new().compress_vec(&data)?)
     }
 
     /// Decode a payload envelope from a snappy-compressed byte array.
@@ -232,27 +225,20 @@ impl OpNetworkPayloadEnvelope {
     /// Encodes a payload envelope as a snappy-compressed byte array.
     #[cfg(feature = "std")]
     pub fn encode_v2(&self) -> Result<Vec<u8>, PayloadEnvelopeEncodeError> {
+        use ssz::Encode;
         let execution_payload_v2 = match &self.payload {
             OpExecutionPayload::V2(execution_payload_v2) => execution_payload_v2,
             _ => return Err(PayloadEnvelopeEncodeError::WrongVersion),
         };
 
-        use ssz::Encode;
         let mut data = Vec::new();
-        let mut sig_bytes = self.signature.as_bytes();
-        // Normalize parity bit
-        if self.signature.v() {
-            sig_bytes[64] = 0x01;
-        } else {
-            sig_bytes[64] = 0x00;
-        }
-        data.extend_from_slice(&sig_bytes[..]);
+        let mut sig = self.signature.as_bytes();
+        sig[64] = self.signature.v() as u8;
+        data.extend_from_slice(&sig[..]);
         let block_data = execution_payload_v2.as_ssz_bytes();
         data.extend_from_slice(block_data.as_slice());
 
-        // Compress the data using snap
-        let compressed = snap::raw::Encoder::new().compress_vec(&data)?;
-        Ok(compressed)
+        Ok(snap::raw::Encoder::new().compress_vec(&data)?)
     }
 
     /// Decode a payload envelope from a snappy-compressed byte array.
@@ -292,28 +278,21 @@ impl OpNetworkPayloadEnvelope {
     /// Encodes a payload envelope as a snappy-compressed byte array.
     #[cfg(feature = "std")]
     pub fn encode_v3(&self) -> Result<Vec<u8>, PayloadEnvelopeEncodeError> {
+        use ssz::Encode;
         let execution_payload_v3 = match &self.payload {
             OpExecutionPayload::V3(execution_payload_v3) => execution_payload_v3,
             _ => return Err(PayloadEnvelopeEncodeError::WrongVersion),
         };
 
-        use ssz::Encode;
         let mut data = Vec::new();
-        let mut sig_bytes = self.signature.as_bytes();
-        // Normalize parity bit
-        if self.signature.v() {
-            sig_bytes[64] = 0x01;
-        } else {
-            sig_bytes[64] = 0x00;
-        }
-        data.extend_from_slice(&sig_bytes[..]);
+        let mut sig = self.signature.as_bytes();
+        sig[64] = self.signature.v() as u8;
+        data.extend_from_slice(&sig[..]);
         data.extend_from_slice(self.parent_beacon_block_root.as_ref().unwrap().as_slice());
         let block_data = execution_payload_v3.as_ssz_bytes();
         data.extend_from_slice(block_data.as_slice());
 
-        // Compress the data using snap
-        let compressed = snap::raw::Encoder::new().compress_vec(&data)?;
-        Ok(compressed)
+        Ok(snap::raw::Encoder::new().compress_vec(&data)?)
     }
 
     /// Decode a payload envelope from a snappy-compressed byte array.
@@ -351,28 +330,21 @@ impl OpNetworkPayloadEnvelope {
     /// Encodes a payload envelope as a snappy-compressed byte array.
     #[cfg(feature = "std")]
     pub fn encode_v4(&self) -> Result<Vec<u8>, PayloadEnvelopeEncodeError> {
+        use ssz::Encode;
         let execution_payload_v4 = match &self.payload {
             OpExecutionPayload::V4(execution_payload_v4) => execution_payload_v4,
             _ => return Err(PayloadEnvelopeEncodeError::WrongVersion),
         };
 
-        use ssz::Encode;
         let mut data = Vec::new();
-        let mut sig_bytes = self.signature.as_bytes();
-        // Normalize parity bit
-        if self.signature.v() {
-            sig_bytes[64] = 0x01;
-        } else {
-            sig_bytes[64] = 0x00;
-        }
-        data.extend_from_slice(&sig_bytes[..]);
+        let mut sig = self.signature.as_bytes();
+        sig[64] = self.signature.v() as u8;
+        data.extend_from_slice(&sig[..]);
         data.extend_from_slice(self.parent_beacon_block_root.as_ref().unwrap().as_slice());
         let block_data = execution_payload_v4.as_ssz_bytes();
         data.extend_from_slice(block_data.as_slice());
 
-        // Compress the data using snap
-        let compressed = snap::raw::Encoder::new().compress_vec(&data)?;
-        Ok(compressed)
+        Ok(snap::raw::Encoder::new().compress_vec(&data)?)
     }
 }
 

--- a/crates/rpc-types-engine/src/envelope.rs
+++ b/crates/rpc-types-engine/src/envelope.rs
@@ -178,6 +178,32 @@ impl OpNetworkPayloadEnvelope {
         Ok(Self { payload, signature, payload_hash: hash, parent_beacon_block_root: None })
     }
 
+    /// Encodes a payload envelope as a snappy-compressed byte array.
+    #[cfg(feature = "std")]
+    pub fn encode_v1(&self) -> Result<Vec<u8>, PayloadEnvelopeEncodeError> {
+        let execution_payload_v1 = match &self.payload {
+            OpExecutionPayload::V1(execution_payload_v1) => execution_payload_v1,
+            _ => return Err(PayloadEnvelopeEncodeError::WrongVersion),
+        };
+
+        use ssz::Encode;
+        let mut data = Vec::new();
+        let mut sig_bytes = self.signature.as_bytes();
+        // Normalize parity bit
+        if self.signature.v() {
+            sig_bytes[64] = 0x01;
+        } else {
+            sig_bytes[64] = 0x00;
+        }
+        data.extend_from_slice(&sig_bytes[..]);
+        let block_data = execution_payload_v1.as_ssz_bytes();
+        data.extend_from_slice(block_data.as_slice());
+
+        // Compress the data using snap
+        let compressed = snap::raw::Encoder::new().compress_vec(&data)?;
+        Ok(compressed)
+    }
+
     /// Decode a payload envelope from a snappy-compressed byte array.
     /// The payload version decoded is `ExecutionPayloadV2` from SSZ bytes.
     #[cfg(feature = "std")]
@@ -201,6 +227,32 @@ impl OpNetworkPayloadEnvelope {
         );
 
         Ok(Self { payload, signature, payload_hash: hash, parent_beacon_block_root: None })
+    }
+
+    /// Encodes a payload envelope as a snappy-compressed byte array.
+    #[cfg(feature = "std")]
+    pub fn encode_v2(&self) -> Result<Vec<u8>, PayloadEnvelopeEncodeError> {
+        let execution_payload_v2 = match &self.payload {
+            OpExecutionPayload::V2(execution_payload_v2) => execution_payload_v2,
+            _ => return Err(PayloadEnvelopeEncodeError::WrongVersion),
+        };
+
+        use ssz::Encode;
+        let mut data = Vec::new();
+        let mut sig_bytes = self.signature.as_bytes();
+        // Normalize parity bit
+        if self.signature.v() {
+            sig_bytes[64] = 0x01;
+        } else {
+            sig_bytes[64] = 0x00;
+        }
+        data.extend_from_slice(&sig_bytes[..]);
+        let block_data = execution_payload_v2.as_ssz_bytes();
+        data.extend_from_slice(block_data.as_slice());
+
+        // Compress the data using snap
+        let compressed = snap::raw::Encoder::new().compress_vec(&data)?;
+        Ok(compressed)
     }
 
     /// Decode a payload envelope from a snappy-compressed byte array.
@@ -247,7 +299,13 @@ impl OpNetworkPayloadEnvelope {
 
         use ssz::Encode;
         let mut data = Vec::new();
-        let sig_bytes = self.signature.as_bytes();
+        let mut sig_bytes = self.signature.as_bytes();
+        // Normalize parity bit
+        if self.signature.v() {
+            sig_bytes[64] = 0x01;
+        } else {
+            sig_bytes[64] = 0x00;
+        }
         data.extend_from_slice(&sig_bytes[..]);
         data.extend_from_slice(self.parent_beacon_block_root.as_ref().unwrap().as_slice());
         let block_data = execution_payload_v3.as_ssz_bytes();
@@ -288,6 +346,33 @@ impl OpNetworkPayloadEnvelope {
             payload_hash: hash,
             parent_beacon_block_root: Some(parent_beacon_block_root),
         })
+    }
+
+    /// Encodes a payload envelope as a snappy-compressed byte array.
+    #[cfg(feature = "std")]
+    pub fn encode_v4(&self) -> Result<Vec<u8>, PayloadEnvelopeEncodeError> {
+        let execution_payload_v4 = match &self.payload {
+            OpExecutionPayload::V4(execution_payload_v4) => execution_payload_v4,
+            _ => return Err(PayloadEnvelopeEncodeError::WrongVersion),
+        };
+
+        use ssz::Encode;
+        let mut data = Vec::new();
+        let mut sig_bytes = self.signature.as_bytes();
+        // Normalize parity bit
+        if self.signature.v() {
+            sig_bytes[64] = 0x01;
+        } else {
+            sig_bytes[64] = 0x00;
+        }
+        data.extend_from_slice(&sig_bytes[..]);
+        data.extend_from_slice(self.parent_beacon_block_root.as_ref().unwrap().as_slice());
+        let block_data = execution_payload_v4.as_ssz_bytes();
+        data.extend_from_slice(block_data.as_slice());
+
+        // Compress the data using snap
+        let compressed = snap::raw::Encoder::new().compress_vec(&data)?;
+        Ok(compressed)
     }
 }
 
@@ -388,49 +473,45 @@ mod tests {
 
     #[test]
     #[cfg(feature = "std")]
-    fn test_roundtrip_encode_envelope_v3() {
-        use alloy_primitives::{Bytes, hex};
-        let data = hex::decode("0xf104f0434442b9eb38b259f5b23826e6b623e829d2fb878dac70187a1aecf42a3f9bedfd29793d1fcb5822324be0d3e12340a95855553a65d64b83e5579dffb31470df5d010000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000cc588d465219504100201067601007cfece77b89685f60e3663b6e0faf2de0734674eb91339700c4858c773a8ff921e014401043e0100").unwrap();
-        let payload_envelop = OpNetworkPayloadEnvelope::decode_v3(&data).unwrap();
-        let encoded = payload_envelop.encode_v3().unwrap();
-        let expected = hex::decode("0xf104f0434442b9eb38b259f5b23826e6b623e829d2fb878dac70187a1aecf42a3f9bedfd29793d1fcb5822324be0d3e12340a95855553a65d64b83e5579dffb31470df5d010000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000cc588d465219504100201067601007cfece77b89685f60e3663b6e0faf2de0734674eb91339700c4858c773a8ff921e014401043e0100").unwrap();
-        assert_eq!(Bytes::from(expected), Bytes::from(encoded));
-    }
-
-    #[test]
-    #[cfg(feature = "std")]
-    fn decode_payload_v1() {
+    fn test_roundtrip_encode_envelope_v1() {
         use alloy_primitives::hex;
         let data = hex::decode("0xbd04f043128457c6ccf35128497167442bcc0f8cce78cda8b366e6a12e526d938d1e4c1046acffffbfc542a7e212bb7d80d3a4b2f84f7b196d935398a24eb84c519789b401000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c4a8fd56621ad04fc0101067601008ce60be0005b220117c32c0f3b394b346c2aa42cfa8157cd41f891aa0bec485a62fc010000").unwrap();
         let payload_envelop = OpNetworkPayloadEnvelope::decode_v1(&data).unwrap();
         assert_eq!(1725271882, payload_envelop.payload.timestamp());
+        let encoded = payload_envelop.encode_v1().unwrap();
+        assert_eq!(data, encoded);
     }
 
     #[test]
     #[cfg(feature = "std")]
-    fn decode_payload_v2() {
+    fn test_roundtrip_encode_envelope_v2() {
         use alloy_primitives::hex;
         let data = hex::decode("0xc104f0433805080eb36c0b130a7cc1dc74c3f721af4e249aa6f61bb89d1557143e971bb738a3f3b98df7c457e74048e9d2d7e5cd82bb45e3760467e2270e9db86d1271a700000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c6b89d46525ad000205067201009cda69cb5b9b73fc4eb2458b37d37f04ff507fe6c9cd2ab704a05ea9dae3cd61760002000000020000").unwrap();
         let payload_envelop = OpNetworkPayloadEnvelope::decode_v2(&data).unwrap();
         assert_eq!(1708427627, payload_envelop.payload.timestamp());
+        let encoded = payload_envelop.encode_v2().unwrap();
+        assert_eq!(data, encoded);
     }
 
     #[test]
     #[cfg(feature = "std")]
-    fn decode_payload_v3() {
+    fn test_roundtrip_encode_envelope_v3() {
         use alloy_primitives::hex;
         let data = hex::decode("0xf104f0434442b9eb38b259f5b23826e6b623e829d2fb878dac70187a1aecf42a3f9bedfd29793d1fcb5822324be0d3e12340a95855553a65d64b83e5579dffb31470df5d010000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000cc588d465219504100201067601007cfece77b89685f60e3663b6e0faf2de0734674eb91339700c4858c773a8ff921e014401043e0100").unwrap();
         let payload_envelop = OpNetworkPayloadEnvelope::decode_v3(&data).unwrap();
         assert_eq!(1708427461, payload_envelop.payload.timestamp());
+        let encoded = payload_envelop.encode_v3().unwrap();
+        assert_eq!(data, encoded);
     }
 
     #[test]
     #[cfg(feature = "std")]
-    fn decode_payload_v4() {
+    fn test_roundtrip_encode_envelope_v4() {
         use alloy_primitives::hex;
-
         let data = hex::decode("0x9105f043cee25401b6853202950d1d8a082f31a80c4fef5782c049a731f5d104b1b9b9aa7618605b420438ae98b44c8aaaebd482854473c2ae57c079286bb634bece5210000000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000c5766d26721950430020106f6010001440104b60100049876").unwrap();
         let payload_envelop = OpNetworkPayloadEnvelope::decode_v4(&data).unwrap();
         assert_eq!(1741842007, payload_envelop.payload.timestamp());
+        let encoded = payload_envelop.encode_v4().unwrap();
+        assert_eq!(data, encoded);
     }
 }

--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -15,7 +15,10 @@ mod attributes;
 pub use attributes::OpPayloadAttributes;
 
 mod envelope;
-pub use envelope::{OpExecutionData, OpNetworkPayloadEnvelope, PayloadEnvelopeError, PayloadHash};
+pub use envelope::{
+    OpExecutionData, OpNetworkPayloadEnvelope, PayloadEnvelopeEncodeError, PayloadEnvelopeError,
+    PayloadHash,
+};
 
 mod sidecar;
 pub use sidecar::OpExecutionPayloadSidecar;


### PR DESCRIPTION
### Description

Implements ssz payload encoding for gossiping `OpNetworkPayloadEnvelope`s via consensus p2p.