### PR TITLE
chore: implement serde_bincode_compat for envelope

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -15,16 +15,16 @@ mod alloy_compat;
 mod receipt;
 pub use receipt::{OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptEnvelope, OpTxReceipt};
 
-mod transaction;
+pub mod transaction;
 pub use transaction::{
-    DEPOSIT_TX_TYPE_ID, DepositTransaction, OpPooledTransaction, OpTxEnvelope, OpTxType,
-    OpTypedTransaction, TxDeposit,
+    DepositTransaction, OpPooledTransaction, OpTxEnvelope, OpTxType, OpTypedTransaction, TxDeposit,
+    DEPOSIT_TX_TYPE_ID,
 };
 
 pub mod eip1559;
 pub use eip1559::{
-    EIP1559ParamError, decode_eip_1559_params, decode_holocene_extra_data,
-    encode_holocene_extra_data,
+    decode_eip_1559_params, decode_holocene_extra_data, encode_holocene_extra_data,
+    EIP1559ParamError,
 };
 
 mod source;
@@ -49,6 +49,6 @@ pub use transaction::serde_deposit_tx_rpc;
 pub mod serde_bincode_compat {
     pub use super::{
         receipt::receipts::serde_bincode_compat::OpDepositReceipt,
-        transaction::serde_bincode_compat::TxDeposit,
+        transaction::{serde_bincode_compat as transaction, serde_bincode_compat::TxDeposit},
     };
 }

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1,14 +1,14 @@
 use crate::{OpTxType, OpTypedTransaction, TxDeposit};
 use alloy_consensus::{
-    Sealable, Sealed, Signed, Transaction, TxEip1559, TxEip2930, TxEip7702, TxEnvelope, TxLegacy,
-    Typed2718, transaction::RlpEcdsaDecodableTx,
+    transaction::RlpEcdsaDecodableTx, Sealable, Sealed, Signed, Transaction, TxEip1559, TxEip2930,
+    TxEip7702, TxEnvelope, TxLegacy, Typed2718,
 };
 use alloy_eips::{
     eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718},
     eip2930::AccessList,
     eip7702::SignedAuthorization,
 };
-use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
+use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
 use alloy_rlp::{Decodable, Encodable};
 
 /// The Ethereum [EIP-2718] Transaction Envelope, modified for OP Stack chains.
@@ -629,12 +629,173 @@ mod serde_from {
     }
 }
 
+/// Bincode-compatible serde implementation for OpTxEnvelope.
+#[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
+pub mod serde_bincode_compat {
+    use crate::serde_bincode_compat::TxDeposit;
+    use alloy_consensus::{
+        transaction::serde_bincode_compat::{TxEip1559, TxEip2930, TxEip7702, TxLegacy},
+        Sealed, Signed,
+    };
+    use alloy_primitives::{PrimitiveSignature as Signature, B256};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde_with::{DeserializeAs, SerializeAs};
+
+    /// Bincode-compatible representation of an OpTxEnvelope.
+    #[derive(Debug, Serialize, Deserialize)]
+    pub enum OpTxEnvelope<'a> {
+        /// Legacy variant.
+        Legacy {
+            /// Transaction signature.
+            signature: Signature,
+            /// Borrowed legacy transaction data.
+            #[serde(borrow)]
+            transaction: TxLegacy<'a>,
+        },
+        /// EIP-2930 variant.
+        Eip2930 {
+            /// Transaction signature.
+            signature: Signature,
+            /// Borrowed EIP-2930 transaction data.
+            #[serde(borrow)]
+            transaction: TxEip2930<'a>,
+        },
+        /// EIP-1559 variant.
+        Eip1559 {
+            /// Transaction signature.
+            signature: Signature,
+            /// Borrowed EIP-1559 transaction data.
+            #[serde(borrow)]
+            transaction: TxEip1559<'a>,
+        },
+        /// EIP-7702 variant.
+        Eip7702 {
+            /// Transaction signature.
+            signature: Signature,
+            /// Borrowed EIP-7702 transaction data.
+            #[serde(borrow)]
+            transaction: TxEip7702<'a>,
+        },
+        /// Deposit variant.
+        Deposit {
+            /// Precomputed hash.
+            hash: B256,
+            /// Borrowed deposit transaction data.
+            #[serde(borrow)]
+            transaction: TxDeposit<'a>,
+        },
+    }
+
+    impl<'a> From<&'a super::OpTxEnvelope> for OpTxEnvelope<'a> {
+        fn from(value: &'a super::OpTxEnvelope) -> Self {
+            match value {
+                super::OpTxEnvelope::Legacy(signed_legacy) => Self::Legacy {
+                    signature: *signed_legacy.signature(),
+                    transaction: signed_legacy.tx().into(),
+                },
+                super::OpTxEnvelope::Eip2930(signed_2930) => Self::Eip2930 {
+                    signature: *signed_2930.signature(),
+                    transaction: signed_2930.tx().into(),
+                },
+                super::OpTxEnvelope::Eip1559(signed_1559) => Self::Eip1559 {
+                    signature: *signed_1559.signature(),
+                    transaction: signed_1559.tx().into(),
+                },
+                super::OpTxEnvelope::Eip7702(signed_7702) => Self::Eip7702 {
+                    signature: *signed_7702.signature(),
+                    transaction: signed_7702.tx().into(),
+                },
+                super::OpTxEnvelope::Deposit(sealed_deposit) => Self::Deposit {
+                    hash: sealed_deposit.seal(),
+                    transaction: sealed_deposit.inner().into(),
+                },
+            }
+        }
+    }
+
+    impl<'a> From<OpTxEnvelope<'a>> for super::OpTxEnvelope {
+        fn from(value: OpTxEnvelope<'a>) -> Self {
+            match value {
+                OpTxEnvelope::Legacy { signature, transaction } => {
+                    super::OpTxEnvelope::Legacy(Signed::new_unhashed(transaction.into(), signature))
+                }
+                OpTxEnvelope::Eip2930 { signature, transaction } => super::OpTxEnvelope::Eip2930(
+                    Signed::new_unhashed(transaction.into(), signature),
+                ),
+                OpTxEnvelope::Eip1559 { signature, transaction } => super::OpTxEnvelope::Eip1559(
+                    Signed::new_unhashed(transaction.into(), signature),
+                ),
+                OpTxEnvelope::Eip7702 { signature, transaction } => super::OpTxEnvelope::Eip7702(
+                    Signed::new_unhashed(transaction.into(), signature),
+                ),
+                OpTxEnvelope::Deposit { hash, transaction } => {
+                    super::OpTxEnvelope::Deposit(Sealed::new_unchecked(transaction.into(), hash))
+                }
+            }
+        }
+    }
+
+    impl SerializeAs<super::OpTxEnvelope> for OpTxEnvelope<'_> {
+        fn serialize_as<S>(source: &super::OpTxEnvelope, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let borrowed = OpTxEnvelope::from(source);
+            borrowed.serialize(serializer)
+        }
+    }
+
+    impl<'de> DeserializeAs<'de, super::OpTxEnvelope> for OpTxEnvelope<'de> {
+        fn deserialize_as<D>(deserializer: D) -> Result<super::OpTxEnvelope, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let borrowed = OpTxEnvelope::deserialize(deserializer)?;
+            Ok(borrowed.into())
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use arbitrary::Arbitrary;
+        use rand::Rng;
+        use serde::{Deserialize, Serialize};
+        use serde_with::serde_as;
+
+        /// Tests a bincode round-trip for OpTxEnvelope using an arbitrary instance.
+        #[test]
+        fn test_op_tx_envelope_bincode_roundtrip_arbitrary() {
+            #[serde_as]
+            #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+            struct Data {
+                // Use the bincode-compatible representation defined in this module.
+                #[serde_as(as = "OpTxEnvelope<'_>")]
+                envelope: super::super::OpTxEnvelope,
+            }
+
+            let mut bytes = [0u8; 1024];
+            rand::rng().fill(bytes.as_mut_slice());
+            let data = Data {
+                envelope: super::super::OpTxEnvelope::arbitrary(&mut arbitrary::Unstructured::new(
+                    &bytes,
+                ))
+                .unwrap(),
+            };
+
+            let encoded = bincode::serialize(&data).unwrap();
+            let decoded: Data = bincode::deserialize(&encoded).unwrap();
+            assert_eq!(decoded, data);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use alloc::vec;
     use alloy_consensus::SignableTransaction;
-    use alloy_primitives::{Address, B256, Bytes, PrimitiveSignature, TxKind, U256, hex};
+    use alloy_primitives::{hex, Address, Bytes, PrimitiveSignature, TxKind, B256, U256};
 
     #[test]
     fn test_tx_gas_limit() {

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -4,10 +4,13 @@ mod deposit;
 pub use deposit::{DepositTransaction, TxDeposit};
 
 mod tx_type;
-pub use tx_type::{DEPOSIT_TX_TYPE_ID, OpTxType};
+pub use tx_type::{OpTxType, DEPOSIT_TX_TYPE_ID};
 
 mod envelope;
 pub use envelope::OpTxEnvelope;
+
+#[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
+pub use envelope::serde_bincode_compat as envelope_serde_bincode_compat;
 
 mod typed;
 pub use typed::OpTypedTransaction;
@@ -20,6 +23,6 @@ pub use deposit::serde_deposit_tx_rpc;
 
 /// Bincode-compatible serde implementations for transaction types.
 #[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
-pub(super) mod serde_bincode_compat {
-    pub use super::deposit::serde_bincode_compat::TxDeposit;
+pub mod serde_bincode_compat {
+    pub use super::{deposit::serde_bincode_compat::TxDeposit, envelope::serde_bincode_compat::*};
 }


### PR DESCRIPTION
- This PR also helps close out https://github.com/paradigmxyz/reth/issues/15377
- Related implementation: https://github.com/alloy-rs/alloy/pull/2263
- Running test via `cargo test --features "serde serde-bincode-compat arbitrary k256" test_op_tx_envelope_bincode_roundtrip_arbitrary` shows successful test. Please lmk if it's robust enough or if there's some pointers to make this implementation more extensive 🤙 
- Note that you'll need `alloy-consensus = { workspace = true, features = ["serde", "serde-bincode-compat" ] }` and `[features]
default = ["std", "serde", "serde-bincode-compat", "arbitrary"]` in the `Cargo.toml`
