### PR TITLE
docs: fix broken links in `building` section

### DIFF
--- a/book/src/building/README.md
+++ b/book/src/building/README.md
@@ -15,11 +15,11 @@ Some of the primary crates and their types are listed below.
 <!-- Links -->
 
 [op-block]: https://docs.rs/op-alloy-consensus/latest/op_alloy_consensus/type.OpBlock.html
-[op-tx-envelope]: https://docs.rs/op-alloy-consensus/latest/op_alloy_consensus/enum.OpTxEnvelope.html
+[op-tx-envelope]: https://docs.rs/op-alloy-consensus/latest/op_alloy_consensus/transaction/enum.OpTxEnvelope.html
 [op-rx-envelope]: https://docs.rs/op-alloy-consensus/latest/op_alloy_consensus/enum.OpReceiptEnvelope.html
 
 [op-payload-attributes]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/struct.OpPayloadAttributes.html
-[op-attributes-with-parent]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/struct.OpAttributesWithParent.html
+[op-attributes-with-parent]: https://docs.rs/op-alloy-rpc-types-engine/0.9.5/op_alloy_rpc_types_engine/struct.OpAttributesWithParent.html
 
 [op-alloy-consensus]: https://crates.io/crates/op-alloy-consensus
 [op-alloy-rpc-types-engine]: https://crates.io/crates/op-alloy-rpc-types-engine

--- a/book/src/building/README.md
+++ b/book/src/building/README.md
@@ -8,8 +8,7 @@ Some of the primary crates and their types are listed below.
   [`OpTxEnvelope`][op-tx-envelope], [`OpReceiptEnvelope`][op-rx-envelope],
   and more.
 - [`op-alloy-rpc-types-engine`][op-alloy-rpc-types-engine] provides the
-  [`OpPayloadAttributes`][op-payload-attributes] and
-  [`OpAttributesWithParent`][op-attributes-with-parent].
+  [`OpPayloadAttributes`][op-payload-attributes].
 
 
 <!-- Links -->
@@ -19,7 +18,6 @@ Some of the primary crates and their types are listed below.
 [op-rx-envelope]: https://docs.rs/op-alloy-consensus/latest/op_alloy_consensus/enum.OpReceiptEnvelope.html
 
 [op-payload-attributes]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/struct.OpPayloadAttributes.html
-[op-attributes-with-parent]: https://docs.rs/op-alloy-rpc-types-engine/0.9.5/op_alloy_rpc_types_engine/struct.OpAttributesWithParent.html
 
 [op-alloy-consensus]: https://crates.io/crates/op-alloy-consensus
 [op-alloy-rpc-types-engine]: https://crates.io/crates/op-alloy-rpc-types-engine

--- a/book/src/building/engine.md
+++ b/book/src/building/engine.md
@@ -9,10 +9,6 @@ Optimism defines a custom payload attributes type called [`OpPayloadAttributes`]
 `OpPayloadAttributes` extends alloy's [`PayloadAttributes`][pa] with a few fields: transactions,
 a flag for enabling the tx pool, the gas limit, and EIP 1559 parameters.
 
-Wrapping `OpPayloadAttributes`, the [`OpAttributesWithParent`][parent] type extends payload
-attributes with the parent block (referenced as an [`L2BlockInfo`][lbi]) and a flag
-for whether the associated batch is the last batch in the span.
-
 Optimism also returns a custom type for the `engine_getPayload` request for both V3 and
 V4 payload envelopes. These are the [`OpExecutionPayloadEnvelopeV3`][v3] and
 [`OpExecutionPayloadEnvelopeV4`][v4] types, which both wrap payload envelope types
@@ -24,7 +20,6 @@ from [`alloy-rpc-types-engine`][alloy-engine].
 [alloy-engine]: https://crates.io/crates/alloy-rpc-types-engine
 [v3]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/payload/v3/struct.OpExecutionPayloadEnvelopeV3.html
 [v4]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/payload/v4/struct.OpExecutionPayloadEnvelopeV4.html
-[parent]: https://docs.rs/op-alloy-rpc-types-engine/0.9.5/op_alloy_rpc_types_engine/struct.OpAttributesWithParent.html
 [pa]: https://docs.rs/alloy-rpc-types-engine/latest/alloy_rpc_types_engine/payload/struct.PayloadAttributes.html
 [attributes]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/struct.OpPayloadAttributes.html
 [engine]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/struct.OpAttributesWithParent.html

--- a/book/src/building/engine.md
+++ b/book/src/building/engine.md
@@ -22,9 +22,9 @@ from [`alloy-rpc-types-engine`][alloy-engine].
 <!-- Links -->
 
 [alloy-engine]: https://crates.io/crates/alloy-rpc-types-engine
-[v3]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/struct.OpExecutionPayloadEnvelopeV3.html
-[v4]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/struct.OpExecutionPayloadEnvelopeV4.html
-[parent]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/struct.OpAttributesWithParent.html
+[v3]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/payload/v3/struct.OpExecutionPayloadEnvelopeV3.html
+[v4]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/payload/v4/struct.OpExecutionPayloadEnvelopeV4.html
+[parent]: https://docs.rs/op-alloy-rpc-types-engine/0.9.5/op_alloy_rpc_types_engine/struct.OpAttributesWithParent.html
 [pa]: https://docs.rs/alloy-rpc-types-engine/latest/alloy_rpc_types_engine/payload/struct.PayloadAttributes.html
 [attributes]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/struct.OpPayloadAttributes.html
 [engine]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/struct.OpAttributesWithParent.html

--- a/book/src/building/rpc_types.md
+++ b/book/src/building/rpc_types.md
@@ -14,7 +14,7 @@ Related to receipts, [`op-alloy-rpc-types`][rpc] contains the
 <!-- Links -->
 
 [rpc]: https://crates.io/crates/op-alloy-rpc-types
-[typed]: https://docs.rs/op-alloy-consensus/latest/op_alloy_consensus/enum.OpTypedTransaction.html
+[typed]: https://docs.rs/op-alloy-consensus/latest/op_alloy_consensus/transaction/enum.OpTypedTransaction.html
 [tx]: https://docs.rs/op-alloy-rpc-types/latest/op_alloy_rpc_types/transaction/struct.Transaction.html
 [req]: https://docs.rs/op-alloy-rpc-types/latest/op_alloy_rpc_types/receipt/struct.OpTransactionReceipt.html
 [receipt]: https://docs.rs/op-alloy-rpc-types/latest/op_alloy_rpc_types/receipt/struct.OpTransactionReceipt.html


### PR DESCRIPTION
## Motivation

Hi! I found a bunch of outdated doc links in the `building/` section of the book — most of them were either missing subpaths or pointing to outdated versions.

## Solution

...

## PR Checklist

- [ ] Added Tests  
- [x] Added Documentation  
- [ ] Breaking changes  
