### PR TITLE
Fix: Remove broken Examples links

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -5,7 +5,6 @@
 - [Building](./building/README.md)
   - [Consensus](./building/consensus.md)
   - [Engine RPC Types](./building/engine.md)
-- [Examples](./examples/README.md)
   - [Load a Rollup Config](./examples/load-a-rollup-config.md)
 - [Contributing](./CONTRIBUTING.md)
 - [Licensing](./LICENSE.md)

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -25,10 +25,6 @@ To get started with op-alloy, add its crates as a dependency and take your first
 
 Walk through types and functionality available in different `op-alloy` crates.
 
-### [Examples](./examples/README.md)
-
-Get hands-on experience using `op-alloy` crates for critical OP Stack functionality.
-
 ### [Contributing](./CONTRIBUTING.md)
 
 Contributors are welcome! It is built and maintained by Alloy contributors,


### PR DESCRIPTION
I recommend removing the broken [Examples] section from both SUMMARY.md and intro.md, as the path ./examples/README.md no longer exists in the repository.
If there is a different location or an updated file that should replace this link, feel free to suggest it, and I will update the references accordingly.