### PR TITLE
fix(engine): Use OpExecutionPayloadV4

### DIFF
--- a/crates/provider/src/ext/engine.rs
+++ b/crates/provider/src/ext/engine.rs
@@ -7,7 +7,7 @@ use alloy_rpc_types_engine::{
 };
 use alloy_transport::{Transport, TransportResult};
 use op_alloy_rpc_types_engine::{
-    OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpPayloadAttributes,
+    OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpPayloadAttributes, OpExecutionPayloadV4,
 };
 
 /// Extension trait that gives access to Optimism engine API RPC methods.
@@ -52,7 +52,7 @@ pub trait OpEngineApi<N, T> {
     /// OP modifications: TODO
     async fn new_payload_v4(
         &self,
-        payload: ExecutionPayloadV3,
+        payload: OpExecutionPayloadV4,
         parent_beacon_block_root: B256,
     ) -> TransportResult<PayloadStatus>;
 
@@ -208,7 +208,7 @@ where
 
     async fn new_payload_v4(
         &self,
-        payload: ExecutionPayloadV3,
+        payload: OpExecutionPayloadV4,
         parent_beacon_block_root: B256,
     ) -> TransportResult<PayloadStatus> {
         // Note: The `versioned_hashes`, `execution_requests` parameters are always an empty array

--- a/crates/provider/src/ext/engine.rs
+++ b/crates/provider/src/ext/engine.rs
@@ -7,7 +7,8 @@ use alloy_rpc_types_engine::{
 };
 use alloy_transport::{Transport, TransportResult};
 use op_alloy_rpc_types_engine::{
-    OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpPayloadAttributes, OpExecutionPayloadV4,
+    OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpExecutionPayloadV4,
+    OpPayloadAttributes,
 };
 
 /// Extension trait that gives access to Optimism engine API RPC methods.

--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,8 @@ allow = [
     "Unlicense",
     "Unicode-3.0",
     "Zlib",
+    # webpki-root-certs
+    "CDLA-Permissive-2.0",
 ]
 confidence-threshold = 0.8
 exceptions = [


### PR DESCRIPTION
### Description

Fixes the engine api to use the `OpExecutionPayloadV4` type with the withdrawals root. Without this, V4 engine api methods post-isthmus will error since the `withdrawalsRoot` field *must* not be nil.