### PR TITLE
feat: add Extended conversions for OpPooledTransaction, OpTxEnvelope

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1,7 +1,7 @@
 use crate::{OpPooledTransaction, OpTxType, OpTypedTransaction, TxDeposit};
 use alloy_consensus::{
-    EthereumTxEnvelope, Sealable, Sealed, SignableTransaction, Signed, Transaction, TxEip1559,
-    TxEip2930, TxEip7702, TxEnvelope, TxLegacy, Typed2718, error::ValueError,
+    EthereumTxEnvelope, Extended, Sealable, Sealed, SignableTransaction, Signed, Transaction,
+    TxEip1559, TxEip2930, TxEip7702, TxEnvelope, TxLegacy, Typed2718, error::ValueError,
     transaction::RlpEcdsaDecodableTx,
 };
 use alloy_eips::{
@@ -113,6 +113,12 @@ impl From<(OpTypedTransaction, Signature)> for OpTxEnvelope {
 impl From<Sealed<TxDeposit>> for OpTxEnvelope {
     fn from(v: Sealed<TxDeposit>) -> Self {
         Self::Deposit(v)
+    }
+}
+
+impl<Tx> From<OpTxEnvelope> for Extended<OpTxEnvelope, Tx> {
+    fn from(value: OpTxEnvelope) -> Self {
+        Self::BuiltIn(value)
     }
 }
 

--- a/crates/consensus/src/transaction/pooled.rs
+++ b/crates/consensus/src/transaction/pooled.rs
@@ -3,7 +3,7 @@
 
 use crate::{OpTxEnvelope, OpTxType};
 use alloy_consensus::{
-    SignableTransaction, Signed, Transaction, TxEip7702, TxEnvelope, Typed2718,
+    Extended, SignableTransaction, Signed, Transaction, TxEip7702, TxEnvelope, Typed2718,
     error::ValueError,
     transaction::{RlpEcdsaDecodableTx, TxEip1559, TxEip2930, TxLegacy},
 };
@@ -470,6 +470,30 @@ impl TryFrom<OpTxEnvelope> for OpPooledTransaction {
 
     fn try_from(value: OpTxEnvelope) -> Result<Self, Self::Error> {
         value.try_into_pooled()
+    }
+}
+
+impl<Tx> From<OpPooledTransaction> for Extended<OpTxEnvelope, Tx> {
+    fn from(tx: OpPooledTransaction) -> Self {
+        Self::BuiltIn(tx.into())
+    }
+}
+
+impl<Tx> TryFrom<Extended<OpTxEnvelope, Tx>> for OpPooledTransaction {
+    type Error = ValueError<OpTxEnvelope>;
+
+    fn try_from(_tx: Extended<OpTxEnvelope, Tx>) -> Result<Self, Self::Error> {
+        match _tx {
+            Extended::BuiltIn(inner) => inner.try_into(),
+            Extended::Other(_tx) => Err(ValueError::new(
+                OpTxEnvelope::Legacy(alloy_consensus::Signed::new_unchecked(
+                    alloy_consensus::TxLegacy::default(),
+                    Signature::decode_rlp_vrs(&mut &[0u8; 65][..], |_| Ok(false)).unwrap(),
+                    B256::default(),
+                )),
+                "Cannot convert custom transaction to OpPooledTransaction",
+            )),
+        }
     }
 }
 

--- a/crates/consensus/src/transaction/pooled.rs
+++ b/crates/consensus/src/transaction/pooled.rs
@@ -480,19 +480,12 @@ impl<Tx> From<OpPooledTransaction> for Extended<OpTxEnvelope, Tx> {
 }
 
 impl<Tx> TryFrom<Extended<OpTxEnvelope, Tx>> for OpPooledTransaction {
-    type Error = ValueError<OpTxEnvelope>;
+    type Error = ();
 
     fn try_from(_tx: Extended<OpTxEnvelope, Tx>) -> Result<Self, Self::Error> {
         match _tx {
-            Extended::BuiltIn(inner) => inner.try_into(),
-            Extended::Other(_tx) => Err(ValueError::new(
-                OpTxEnvelope::Legacy(alloy_consensus::Signed::new_unchecked(
-                    alloy_consensus::TxLegacy::default(),
-                    Signature::decode_rlp_vrs(&mut &[0u8; 65][..], |_| Ok(false)).unwrap(),
-                    B256::default(),
-                )),
-                "Cannot convert custom transaction to OpPooledTransaction",
-            )),
+            Extended::BuiltIn(inner) => inner.try_into().map_err(|_| ()),
+            Extended::Other(_tx) => Err(()),
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Ref https://github.com/paradigmxyz/reth/issues/16411
`Extended` type is moved from Reth to Alloy.
So it also needs to move `TryFrom`, `From` trait conversions to op-alloy

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
