### PR TITLE
Change `InvalidInboxEntry` repr `i64`->`i32` for `jsonrpsee` error compat

### DIFF
--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -27,7 +27,7 @@ use derive_more;
 ///
 /// Specs: <https://specs.optimism.io/interop/supervisor.html#protocol-specific-error-codes>
 #[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq, derive_more::TryFrom)]
-#[repr(i64)]
+#[repr(i32)]
 #[try_from(repr)]
 pub enum InvalidInboxEntry {
     // -3204XX DEADLINE_EXCEEDED errors


### PR DESCRIPTION
Changes repr of `InvalidInboxEntry` to `i32` for better conversion to `jsonrpsee::ErrorObjectOwned` error code