### PR TITLE
fix link to starting.md

### DIFF
--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -17,7 +17,7 @@ performance types, traits, and middleware from [Alloy][alloy].
 
 ## Sections
 
-### [Getting Started](./starting/starting.md)
+### [Getting Started](./starting.md)
 
 To get started with op-alloy, add its crates as a dependency and take your first steps.
 


### PR DESCRIPTION

## Motivation

link doesn't work here https://alloy-rs.github.io/op-alloy/ 
![Zrzut ekranu 2025-06-04 234747](https://github.com/user-attachments/assets/614d6489-e925-435b-8ad7-f297ee8ae086)


## Solution

just fixed. 

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
