### PR TITLE
feat(interop): Rename `InvalidInboxEntry`->`SuperchainDAError`

### DIFF
--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -30,6 +30,9 @@ alloy-primitives = { workspace = true, features = ["map", "rlp", "serde"] }
 serde_json.workspace = true
 serde = { workspace = true, features = ["derive"] }
 
+# RPC
+jsonrpsee = { workspace = true, optional = true }
+
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 
@@ -63,3 +66,4 @@ arbitrary = [
 ]
 k256 = ["alloy-rpc-types-eth/k256", "op-alloy-consensus/k256"]
 serde = ["op-alloy-consensus/serde"]
+jsonrpsee = ["dep:jsonrpsee"]

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -105,6 +105,8 @@ pub enum SuperchainDAError {
 #[cfg(feature = "jsonrpsee")]
 impl From<SuperchainDAError> for jsonrpsee::types::ErrorObjectOwned {
     fn from(err: SuperchainDAError) -> Self {
+        use crate::alloc::string::ToString;
+        
         jsonrpsee::types::ErrorObjectOwned::owned(err as i32, err.to_string(), None::<()>)
     }
 }

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -111,9 +111,9 @@ impl From<SuperchainDAError> for jsonrpsee::types::ErrorObjectOwned {
 
 #[cfg(feature = "jsonrpsee")]
 impl TryFrom<jsonrpsee::types::ErrorObjectOwned> for SuperchainDAError {
-    type Error = &'static str;
+    type Error = derive_more::TryFromReprError<i32>;
 
-    fn from(err: jsonrpsee::types::ErrorObjectOwned) -> Self {
-        err.code.try_into()
+    fn try_from(err: jsonrpsee::types::ErrorObjectOwned) -> Result<Self, Self::Error> {
+        err.code().try_into()
     }
 }

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -106,7 +106,7 @@ pub enum SuperchainDAError {
 impl From<SuperchainDAError> for jsonrpsee::types::ErrorObjectOwned {
     fn from(err: SuperchainDAError) -> Self {
         use crate::alloc::string::ToString;
-        
+
         jsonrpsee::types::ErrorObjectOwned::owned(err as i32, err.to_string(), None::<()>)
     }
 }

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -108,12 +108,3 @@ impl From<SuperchainDAError> for jsonrpsee::types::ErrorObjectOwned {
         jsonrpsee::types::ErrorObjectOwned::owned(err as i32, err.to_string(), None::<()>)
     }
 }
-
-#[cfg(feature = "jsonrpsee")]
-impl TryFrom<jsonrpsee::types::ErrorObjectOwned> for SuperchainDAError {
-    type Error = derive_more::TryFromReprError<i32>;
-
-    fn try_from(err: jsonrpsee::types::ErrorObjectOwned) -> Result<Self, Self::Error> {
-        err.code().try_into()
-    }
-}

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -29,7 +29,7 @@ use derive_more;
 #[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq, derive_more::TryFrom)]
 #[repr(i32)]
 #[try_from(repr)]
-pub enum SupervisorDAError {
+pub enum SuperchainDAError {
     // -3204XX DEADLINE_EXCEEDED errors
     /// Happens when a chain database is not initialized yet.
     #[error("chain database is not initialized")]
@@ -103,14 +103,14 @@ pub enum SupervisorDAError {
 }
 
 #[cfg(feature = "jsonrpsee")]
-impl From<SupervisorDAError> for jsonrpsee::ErrorObjectOwned {
-    fn from(err: SupervisorDAError) -> Self {
+impl From<SuperchainDAError> for jsonrpsee::ErrorObjectOwned {
+    fn from(err: SuperchainDAError) -> Self {
         jsonrpsee::ErrorObjectOwned::owned(err as i32, err.to_string(), None::<()>)
     }
 }
 
 #[cfg(feature = "jsonrpsee")]
-impl TryFrom<jsonrpsee::ErrorObjectOwned> for SupervisorDAError {
+impl TryFrom<jsonrpsee::ErrorObjectOwned> for SuperchainDAError {
     type Error = &'static str;
 
     fn from(err: jsonrpsee::ErrorObjectOwned) -> Self {

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -103,17 +103,17 @@ pub enum SuperchainDAError {
 }
 
 #[cfg(feature = "jsonrpsee")]
-impl From<SuperchainDAError> for jsonrpsee::ErrorObjectOwned {
+impl From<SuperchainDAError> for jsonrpsee::types::ErrorObjectOwned {
     fn from(err: SuperchainDAError) -> Self {
-        jsonrpsee::ErrorObjectOwned::owned(err as i32, err.to_string(), None::<()>)
+        jsonrpsee::types::ErrorObjectOwned::owned(err as i32, err.to_string(), None::<()>)
     }
 }
 
 #[cfg(feature = "jsonrpsee")]
-impl TryFrom<jsonrpsee::ErrorObjectOwned> for SuperchainDAError {
+impl TryFrom<jsonrpsee::types::ErrorObjectOwned> for SuperchainDAError {
     type Error = &'static str;
 
-    fn from(err: jsonrpsee::ErrorObjectOwned) -> Self {
+    fn from(err: jsonrpsee::types::ErrorObjectOwned) -> Self {
         err.code.try_into()
     }
 }

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -23,13 +23,13 @@
 
 use derive_more;
 
-/// Supervisor protocol error codes.
+/// Supervisor data availability error codes.
 ///
 /// Specs: <https://specs.optimism.io/interop/supervisor.html#protocol-specific-error-codes>
 #[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq, derive_more::TryFrom)]
 #[repr(i32)]
 #[try_from(repr)]
-pub enum InvalidInboxEntry {
+pub enum SupervisorDAError {
     // -3204XX DEADLINE_EXCEEDED errors
     /// Happens when a chain database is not initialized yet.
     #[error("chain database is not initialized")]

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -101,3 +101,19 @@ pub enum SupervisorDAError {
     #[error("underlying database has I/O issues or is corrupted")]
     DataCorruption = -321501,
 }
+
+#[cfg(feature = "jsonrpsee")]
+impl From<SupervisorDAError> for jsonrpsee::ErrorObjectOwned {
+    fn from(err: SupervisorDAError) -> Self {
+        jsonrpsee::ErrorObjectOwned::owned(err as i32, err.to_string(), None::<()>)
+    }
+}
+
+#[cfg(feature = "jsonrpsee")]
+impl TryFrom<jsonrpsee::ErrorObjectOwned> for SupervisorDAError {
+    type Error = &'static str;
+
+    fn from(err: jsonrpsee::ErrorObjectOwned) -> Self {
+        err.code.try_into()
+    }
+}

--- a/crates/rpc-types/src/lib.rs
+++ b/crates/rpc-types/src/lib.rs
@@ -19,4 +19,4 @@ mod transaction;
 pub use transaction::{OpTransactionFields, OpTransactionRequest, Transaction};
 
 pub mod error;
-pub use error::SupervisorDAError;
+pub use error::SuperchainDAError;

--- a/crates/rpc-types/src/lib.rs
+++ b/crates/rpc-types/src/lib.rs
@@ -19,4 +19,4 @@ mod transaction;
 pub use transaction::{OpTransactionFields, OpTransactionRequest, Transaction};
 
 pub mod error;
-pub use error::InvalidInboxEntry;
+pub use error::SupervisorDAError;


### PR DESCRIPTION
Renames `InvalidInboxEntry` to `SuperchainDAError`.

Some of these error variants occur also on updating superchain state. The name `InvalidInboxEntry` is to specialised for `supervisor_checkAccessList`.

Adds feature `jsonrpsee` to `op-alloy-rpc-types` and feature gated conversion to `jsonrpsee::ErrorObjectOwned`.