### PR TITLE
docs: grammar fixes and a cleanup of a broken documentation link

### DIFF
--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -13,9 +13,9 @@ workflows:
         "propagate-feature",
         # These are the features to check:
         "--features=std,serde",
-        # Do not try to add a new section into `[features]` of `A` only because `B` expose that feature. There are edge-cases where this is still needed, but we can add them manually.
+        # Do not try to add a new section into `[features]` of `A` only because `B` exposes that feature. There are edge-cases where this is still needed, but we can add them manually.
         "--left-side-feature-missing=ignore",
-        # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
+        # Ignore the case that `A` is outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
         "--left-side-outside-workspace=ignore",
         # limit to the workspace
         "--workspace",

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -5,7 +5,6 @@
 - [Building](./building/README.md)
   - [Consensus](./building/consensus.md)
   - [Engine RPC Types](./building/engine.md)
-  - [Load a Rollup Config](./examples/load-a-rollup-config.md)
 - [Contributing](./CONTRIBUTING.md)
 - [Licensing](./LICENSE.md)
 - [Glossary](./glossary.md)


### PR DESCRIPTION
In .config/zepter.yaml:

Changed expose → exposes to fix verb form agreement.

Changed A it outside → A is outside to fix grammar and remove incorrect structure.

In book/src/SUMMARY.md:

Removed the line linking to ./examples/load-a-rollup-config.md because the file doesn't exist or is no longer used.

These changes improve documentation clarity and prevent confusion or broken links in the rendered docs.