### PR TITLE
feat(rpc-types-engine): OpExecutionPayload Wrapper

### DIFF
--- a/crates/rpc-types-engine/src/envelope.rs
+++ b/crates/rpc-types-engine/src/envelope.rs
@@ -15,6 +15,7 @@ use alloy_rpc_types_engine::{
 /// A thin wrapper around [`OpExecutionPayload`] that includes the parent beacon block root.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct OpExecutionPayloadEnvelope {
     /// The execution payload.
     pub payload: OpExecutionPayload,
@@ -442,6 +443,20 @@ impl PayloadHash {
 mod tests {
     use super::*;
     use alloy_primitives::b256;
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_rountrip_op_execution_payload_envelope() {
+        let envelope_str = r#"{
+            "payload": {"parentHash":"0xe927a1448525fb5d32cb50ee1408461a945ba6c39bd5cf5621407d500ecc8de9","feeRecipient":"0x0000000000000000000000000000000000000000","stateRoot":"0x10f8a0830000e8edef6d00cc727ff833f064b1950afd591ae41357f97e543119","receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","prevRandao":"0xe0d8b4521a7da1582a713244ffb6a86aa1726932087386e2dc7973f43fc6cb24","blockNumber":"0x1","gasLimit":"0x2ffbd2","gasUsed":"0x0","timestamp":"0x1235","extraData":"0xd883010d00846765746888676f312e32312e30856c696e7578","baseFeePerGas":"0x342770c0","blockHash":"0x44d0fa5f2f73a938ebb96a2a21679eb8dea3e7b7dd8fd9f35aa756dda8bf0a8a","transactions":[],"withdrawals":[],"blobGasUsed":"0x0","excessBlobGas":"0x0","withdrawalsRoot":"0x10f8a0830000e8edef6d00cc727ff833f064b1950afd591ae41357f97e543119"},
+            "parentBeaconBlockRoot": "0x9999999999999999999999999999999999999999999999999999999999999999"
+        }"#;
+
+        let envelope: OpExecutionPayloadEnvelope = serde_json::from_str(envelope_str).unwrap();
+        let expected = b256!("9999999999999999999999999999999999999999999999999999999999999999");
+        assert_eq!(envelope.parent_beacon_block_root.unwrap(), expected);
+        let _ = serde_json::to_string(&envelope).unwrap();
+    }
 
     #[test]
     fn test_signature_message() {

--- a/crates/rpc-types-engine/src/envelope.rs
+++ b/crates/rpc-types-engine/src/envelope.rs
@@ -12,6 +12,25 @@ use alloy_rpc_types_engine::{
     CancunPayloadFields, ExecutionPayloadInputV2, ExecutionPayloadV3, PraguePayloadFields,
 };
 
+/// A thin wrapper around [`OpExecutionPayload`] that includes the parent beacon block root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct OpExecutionPayloadEnvelope {
+    /// The execution payload.
+    pub payload: OpExecutionPayload,
+    /// The parent beacon block root, if any.
+    pub parent_beacon_block_root: Option<B256>,
+}
+
+impl From<OpNetworkPayloadEnvelope> for OpExecutionPayloadEnvelope {
+    fn from(envelope: OpNetworkPayloadEnvelope) -> Self {
+        Self {
+            payload: envelope.payload,
+            parent_beacon_block_root: envelope.parent_beacon_block_root,
+        }
+    }
+}
+
 /// Struct aggregating [`OpExecutionPayload`] and [`OpExecutionPayloadSidecar`] and encapsulating
 /// complete payload supplied for execution.
 #[derive(Debug, Clone)]

--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -17,7 +17,7 @@ pub use attributes::OpPayloadAttributes;
 mod envelope;
 pub use envelope::{
     OpExecutionData, OpNetworkPayloadEnvelope, PayloadEnvelopeEncodeError, PayloadEnvelopeError,
-    PayloadHash,
+    PayloadHash, OpExecutionPayloadEnvelope,
 };
 
 mod sidecar;

--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -16,8 +16,8 @@ pub use attributes::OpPayloadAttributes;
 
 mod envelope;
 pub use envelope::{
-    OpExecutionData, OpNetworkPayloadEnvelope, PayloadEnvelopeEncodeError, PayloadEnvelopeError,
-    PayloadHash, OpExecutionPayloadEnvelope,
+    OpExecutionData, OpExecutionPayloadEnvelope, OpNetworkPayloadEnvelope,
+    PayloadEnvelopeEncodeError, PayloadEnvelopeError, PayloadHash,
 };
 
 mod sidecar;


### PR DESCRIPTION
### Description

A thin wrapper around `OpExecutionPayload` that includes the parent beacon block root that provides a rust-equivalent to [`ExecutionPayloadEnvelope`](https://github.com/ethereum-optimism/optimism/blob/7c812674f9e2068949a152f44fde13fcb93b2c45/op-service/eth/types.go#L233).

This is required for a serialized rpc type in the op admin api to post unsafe payloads.