### PR TITLE
fix: redirect to op-alloy-provider crate

### DIFF
--- a/book/src/starting.md
+++ b/book/src/starting.md
@@ -62,7 +62,7 @@ so `op-alloy-consensus` types can be used from `op-alloy` through `op_alloy::con
 ## Crates
 
 - [`op-alloy-network`][op-alloy-network]
-- [`op-alloy-provider`][op-alloy-protocol]
+- [`op-alloy-provider`][op-alloy-provider]
 - [`op-alloy-consensus`][op-alloy-consensus] (supports `no_std`)
 - [`op-alloy-rpc-jsonrpsee`][op-alloy-rpc-jsonrpsee]
 - [`op-alloy-rpc-types`][op-alloy-rpc-types] (supports `no_std`)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

on this page is bug - https://alloy-rs.github.io/op-alloy/starting.html 
![image](https://github.com/user-attachments/assets/de4bc17e-1e39-44d1-a050-424a6f43870a)


## Solution

due to this line https://github.com/alloy-rs/op-alloy/blob/main/book/src/links.md?plain=1#L10 we need to do this change. 
## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
