### PR TITLE
feat(rpc): Replace wrapped `OpTxEnvelope` with a generic in the `Transaction` RPC response

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -659,27 +659,6 @@ impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
     }
 }
 
-#[cfg(not(feature = "k256"))]
-impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
-    fn recover_signer(&self) -> Result<Address, alloy_consensus::crypto::RecoveryError> {
-        match self {
-            // Optimism's Deposit transaction does not have a signature. Directly return the
-            // `from` address.
-            Self::Deposit(tx) => Ok(tx.from),
-            _ => Err(alloy_consensus::crypto::RecoveryError::new()),
-        }
-    }
-
-    fn recover_signer_unchecked(&self) -> Result<Address, alloy_consensus::crypto::RecoveryError> {
-        match self {
-            // Optimism's Deposit transaction does not have a signature. Directly return the
-            // `from` address.
-            Self::Deposit(tx) => Ok(tx.from),
-            _ => Err(alloy_consensus::crypto::RecoveryError::new()),
-        }
-    }
-}
-
 impl Encodable for OpTxEnvelope {
     fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
         self.network_encode(out)


### PR DESCRIPTION
## Motivation
Extending the transaction RPC response requires to rewrite this entire type.

## Solution
Replace the `OpTxEnvelope` with a generic parameter constrained to `alloy_consensus::Transaction` and `SignerRecoverable`.

Allows reusing `Transaction` RPC response object with custom transactions.

Simplifies the creation of custom nodes.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
