### PR TITLE
chore(consensus): Rename `SafetyLevel` variants `Unsafe`->`LocalUnsafe` and `Safe`->`CrossSafe`

### DIFF
--- a/crates/consensus/src/interop.rs
+++ b/crates/consensus/src/interop.rs
@@ -15,14 +15,16 @@ pub const CROSS_L2_INBOX_ADDRESS: Address = address!("0x420000000000000000000000
 pub enum SafetyLevel {
     /// The message is finalized.
     Finalized,
-    /// The message is safe.
-    Safe,
+    /// The message is safe across chains.
+    #[cfg_attr(feature = "serde", serde(rename = "safe"))]
+    CrossSafe,
     /// The message is safe locally.
     LocalSafe,
     /// The message is unsafe across chains.
     CrossUnsafe,
-    /// The message is unsafe.
-    Unsafe,
+    /// The message is unsafe locally.
+    #[cfg_attr(feature = "serde", serde(rename = "unsafe"))]
+    LocalUnsafe,
     /// The message is invalid.
     Invalid,
 }
@@ -33,10 +35,10 @@ impl FromStr for SafetyLevel {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "finalized" => Ok(Self::Finalized),
-            "safe" => Ok(Self::Safe),
+            "safe" => Ok(Self::CrossSafe),
             "local-safe" | "localsafe" => Ok(Self::LocalSafe),
             "cross-unsafe" | "crossunsafe" => Ok(Self::CrossUnsafe),
-            "unsafe" => Ok(Self::Unsafe),
+            "unsafe" => Ok(Self::LocalUnsafe),
             "invalid" => Ok(Self::Invalid),
             _ => Err(SafetyLevelParseError(s.to_string())),
         }
@@ -74,12 +76,12 @@ mod tests {
     #[test]
     fn test_safety_level_from_str_valid() {
         assert_eq!(SafetyLevel::from_str("finalized").unwrap(), SafetyLevel::Finalized);
-        assert_eq!(SafetyLevel::from_str("safe").unwrap(), SafetyLevel::Safe);
+        assert_eq!(SafetyLevel::from_str("safe").unwrap(), SafetyLevel::CrossSafe);
         assert_eq!(SafetyLevel::from_str("local-safe").unwrap(), SafetyLevel::LocalSafe);
         assert_eq!(SafetyLevel::from_str("localsafe").unwrap(), SafetyLevel::LocalSafe);
         assert_eq!(SafetyLevel::from_str("cross-unsafe").unwrap(), SafetyLevel::CrossUnsafe);
         assert_eq!(SafetyLevel::from_str("crossunsafe").unwrap(), SafetyLevel::CrossUnsafe);
-        assert_eq!(SafetyLevel::from_str("unsafe").unwrap(), SafetyLevel::Unsafe);
+        assert_eq!(SafetyLevel::from_str("unsafe").unwrap(), SafetyLevel::LocalUnsafe);
         assert_eq!(SafetyLevel::from_str("invalid").unwrap(), SafetyLevel::Invalid);
     }
 

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -30,6 +30,9 @@ alloy-primitives = { workspace = true, features = ["map", "rlp", "serde"] }
 serde_json.workspace = true
 serde = { workspace = true, features = ["derive"] }
 
+# RPC
+jsonrpsee = { workspace = true, optional = true }
+
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 
@@ -63,3 +66,4 @@ arbitrary = [
 ]
 k256 = ["alloy-rpc-types-eth/k256", "op-alloy-consensus/k256"]
 serde = ["op-alloy-consensus/serde"]
+jsonrpsee = ["dep:jsonrpsee"]

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -105,6 +105,8 @@ pub enum SuperchainDAError {
 #[cfg(feature = "jsonrpsee")]
 impl From<SuperchainDAError> for jsonrpsee::types::ErrorObjectOwned {
     fn from(err: SuperchainDAError) -> Self {
+        use crate::alloc::string::ToString;
+        
         jsonrpsee::types::ErrorObjectOwned::owned(err as i32, err.to_string(), None::<()>)
     }
 }

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -111,9 +111,9 @@ impl From<SuperchainDAError> for jsonrpsee::types::ErrorObjectOwned {
 
 #[cfg(feature = "jsonrpsee")]
 impl TryFrom<jsonrpsee::types::ErrorObjectOwned> for SuperchainDAError {
-    type Error = &'static str;
+    type Error = derive_more::TryFromReprError<i32>;
 
-    fn from(err: jsonrpsee::types::ErrorObjectOwned) -> Self {
-        err.code.try_into()
+    fn try_from(err: jsonrpsee::types::ErrorObjectOwned) -> Result<Self, Self::Error> {
+        err.code().try_into()
     }
 }

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -106,7 +106,7 @@ pub enum SuperchainDAError {
 impl From<SuperchainDAError> for jsonrpsee::types::ErrorObjectOwned {
     fn from(err: SuperchainDAError) -> Self {
         use crate::alloc::string::ToString;
-        
+
         jsonrpsee::types::ErrorObjectOwned::owned(err as i32, err.to_string(), None::<()>)
     }
 }

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -108,12 +108,3 @@ impl From<SuperchainDAError> for jsonrpsee::types::ErrorObjectOwned {
         jsonrpsee::types::ErrorObjectOwned::owned(err as i32, err.to_string(), None::<()>)
     }
 }
-
-#[cfg(feature = "jsonrpsee")]
-impl TryFrom<jsonrpsee::types::ErrorObjectOwned> for SuperchainDAError {
-    type Error = derive_more::TryFromReprError<i32>;
-
-    fn try_from(err: jsonrpsee::types::ErrorObjectOwned) -> Result<Self, Self::Error> {
-        err.code().try_into()
-    }
-}

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -29,7 +29,7 @@ use derive_more;
 #[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq, derive_more::TryFrom)]
 #[repr(i32)]
 #[try_from(repr)]
-pub enum SupervisorDAError {
+pub enum SuperchainDAError {
     // -3204XX DEADLINE_EXCEEDED errors
     /// Happens when a chain database is not initialized yet.
     #[error("chain database is not initialized")]
@@ -103,14 +103,14 @@ pub enum SupervisorDAError {
 }
 
 #[cfg(feature = "jsonrpsee")]
-impl From<SupervisorDAError> for jsonrpsee::ErrorObjectOwned {
-    fn from(err: SupervisorDAError) -> Self {
+impl From<SuperchainDAError> for jsonrpsee::ErrorObjectOwned {
+    fn from(err: SuperchainDAError) -> Self {
         jsonrpsee::ErrorObjectOwned::owned(err as i32, err.to_string(), None::<()>)
     }
 }
 
 #[cfg(feature = "jsonrpsee")]
-impl TryFrom<jsonrpsee::ErrorObjectOwned> for SupervisorDAError {
+impl TryFrom<jsonrpsee::ErrorObjectOwned> for SuperchainDAError {
     type Error = &'static str;
 
     fn from(err: jsonrpsee::ErrorObjectOwned) -> Self {

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -103,17 +103,17 @@ pub enum SuperchainDAError {
 }
 
 #[cfg(feature = "jsonrpsee")]
-impl From<SuperchainDAError> for jsonrpsee::ErrorObjectOwned {
+impl From<SuperchainDAError> for jsonrpsee::types::ErrorObjectOwned {
     fn from(err: SuperchainDAError) -> Self {
-        jsonrpsee::ErrorObjectOwned::owned(err as i32, err.to_string(), None::<()>)
+        jsonrpsee::types::ErrorObjectOwned::owned(err as i32, err.to_string(), None::<()>)
     }
 }
 
 #[cfg(feature = "jsonrpsee")]
-impl TryFrom<jsonrpsee::ErrorObjectOwned> for SuperchainDAError {
+impl TryFrom<jsonrpsee::types::ErrorObjectOwned> for SuperchainDAError {
     type Error = &'static str;
 
-    fn from(err: jsonrpsee::ErrorObjectOwned) -> Self {
+    fn from(err: jsonrpsee::types::ErrorObjectOwned) -> Self {
         err.code.try_into()
     }
 }

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -23,13 +23,13 @@
 
 use derive_more;
 
-/// Supervisor protocol error codes.
+/// Supervisor data availability error codes.
 ///
 /// Specs: <https://specs.optimism.io/interop/supervisor.html#protocol-specific-error-codes>
 #[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq, derive_more::TryFrom)]
 #[repr(i32)]
 #[try_from(repr)]
-pub enum InvalidInboxEntry {
+pub enum SupervisorDAError {
     // -3204XX DEADLINE_EXCEEDED errors
     /// Happens when a chain database is not initialized yet.
     #[error("chain database is not initialized")]

--- a/crates/rpc-types/src/error.rs
+++ b/crates/rpc-types/src/error.rs
@@ -101,3 +101,19 @@ pub enum SupervisorDAError {
     #[error("underlying database has I/O issues or is corrupted")]
     DataCorruption = -321501,
 }
+
+#[cfg(feature = "jsonrpsee")]
+impl From<SupervisorDAError> for jsonrpsee::ErrorObjectOwned {
+    fn from(err: SupervisorDAError) -> Self {
+        jsonrpsee::ErrorObjectOwned::owned(err as i32, err.to_string(), None::<()>)
+    }
+}
+
+#[cfg(feature = "jsonrpsee")]
+impl TryFrom<jsonrpsee::ErrorObjectOwned> for SupervisorDAError {
+    type Error = &'static str;
+
+    fn from(err: jsonrpsee::ErrorObjectOwned) -> Self {
+        err.code.try_into()
+    }
+}

--- a/crates/rpc-types/src/lib.rs
+++ b/crates/rpc-types/src/lib.rs
@@ -19,4 +19,4 @@ mod transaction;
 pub use transaction::{OpTransactionFields, OpTransactionRequest, Transaction};
 
 pub mod error;
-pub use error::SupervisorDAError;
+pub use error::SuperchainDAError;

--- a/crates/rpc-types/src/lib.rs
+++ b/crates/rpc-types/src/lib.rs
@@ -19,4 +19,4 @@ mod transaction;
 pub use transaction::{OpTransactionFields, OpTransactionRequest, Transaction};
 
 pub mod error;
-pub use error::InvalidInboxEntry;
+pub use error::SupervisorDAError;


### PR DESCRIPTION
Updates `SafetyLevel` variant names to match Go impl

Ref https://github.com/ethereum-optimism/specs/issues/717