### PR TITLE
feat(consensus): Add `as_deposit` into `OpTransaction` trait

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -17,8 +17,8 @@ pub use receipt::{OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptEnvelope
 
 pub mod transaction;
 pub use transaction::{
-    DEPOSIT_TX_TYPE_ID, DepositTransaction, OpPooledTransaction, OpTxEnvelope, OpTxType,
-    OpTypedTransaction, TxDeposit,
+    DEPOSIT_TX_TYPE_ID, DepositTransaction, OpPooledTransaction, OpTransaction, OpTxEnvelope,
+    OpTxType, OpTypedTransaction, TxDeposit,
 };
 
 pub mod eip1559;

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -51,13 +51,20 @@ pub enum OpTxEnvelope {
 ///
 /// Compared to Ethereum it can tell whether the transaction is a deposit.
 pub trait OpTransaction {
-    /// Returns true if the transaction is a deposit.
+    /// Returns `true` if the transaction is a deposit.
     fn is_deposit(&self) -> bool;
+
+    /// Returns `Some` if the transaction is a deposit.
+    fn as_deposit(&self) -> Option<&Sealed<TxDeposit>>;
 }
 
 impl OpTransaction for OpTxEnvelope {
     fn is_deposit(&self) -> bool {
-        Self::is_deposit(self)
+        self.is_deposit()
+    }
+
+    fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
+        self.as_deposit()
     }
 }
 
@@ -70,6 +77,13 @@ where
         match self {
             Self::BuiltIn(b) => b.is_deposit(),
             Self::Other(t) => t.is_deposit(),
+        }
+    }
+
+    fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
+        match self {
+            Self::BuiltIn(b) => b.as_deposit(),
+            Self::Other(t) => t.as_deposit(),
         }
     }
 }


### PR DESCRIPTION
Follow-up on #548 

## Motivation

`OpTransaction` trait can tell if its deposit, but that is not very useful if I also need to extract it.

## Solution

Add `as_deposit` function into the trait for the extraction of `TxDeposit`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
