### PR TITLE
feat(rpc): Convert into RPC transaction from generic `OpTransaction`

### DIFF
--- a/crates/rpc-types-engine/src/superchain.rs
+++ b/crates/rpc-types-engine/src/superchain.rs
@@ -52,7 +52,7 @@ pub enum ProtocolVersion {
 impl core::fmt::Display for ProtocolVersion {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::V0(value) => write!(f, "{}", value),
+            Self::V0(value) => write!(f, "{value}"),
         }
     }
 }
@@ -166,7 +166,7 @@ impl ProtocolVersion {
     /// Returns a human-readable string representation of the ProtocolVersion
     pub fn display(&self) -> String {
         match self {
-            Self::V0(value) => format!("{}", value),
+            Self::V0(value) => format!("{value}"),
         }
     }
 }

--- a/crates/rpc-types/src/transaction.rs
+++ b/crates/rpc-types/src/transaction.rs
@@ -34,9 +34,11 @@ pub struct Transaction<T = OpTxEnvelope> {
 }
 
 impl Transaction {
-    /// Returns a rpc [`Transaction`] with a [`OpTransactionInfo`] and
-    /// [`Recovered<OpTxEnvelope>`] as input.
-    pub fn from_transaction(tx: Recovered<OpTxEnvelope>, tx_info: OpTransactionInfo) -> Self {
+    /// Converts a consensus `tx` with an additional context `tx_info` into an RPC [`Transaction`].
+    pub fn from_transaction<T: OpTransaction + TransactionTrait>(
+        tx: Recovered<T>,
+        tx_info: OpTransactionInfo,
+    ) -> Transaction<T> {
         let base_fee = tx_info.inner.base_fee;
         let effective_gas_price = if tx.is_deposit() {
             // For deposits, we must always set the `gasPrice` field to 0 in rpc
@@ -51,7 +53,7 @@ impl Transaction {
                 .unwrap_or_else(|| tx.max_fee_per_gas())
         };
 
-        Self {
+        Transaction {
             inner: alloy_rpc_types_eth::Transaction {
                 inner: tx,
                 block_hash: tx_info.inner.block_hash,

--- a/crates/rpc-types/src/transaction.rs
+++ b/crates/rpc-types/src/transaction.rs
@@ -206,7 +206,7 @@ mod tx_serde {
     //! [`alloy_consensus::transaction::Recovered::signer`] which resides in
     //! [`alloy_rpc_types_eth::Transaction::inner`] and [`op_alloy_consensus::TxDeposit::from`].
     //!
-    //! Additionaly, we need similar logic for the `gasPrice` field
+    //! Additionally, we need similar logic for the `gasPrice` field
     use super::*;
     use alloy_consensus::transaction::Recovered;
     use op_alloy_consensus::OpTransaction;


### PR DESCRIPTION
Follow-up on #549 

## Motivation

The RPC transaction object has a dedicated conversion function that accepts `OpTxEnvelope` struct. But it cannot be used with a transaction that is not `OpTxEnvelope` but implements `OpTransaction`.

## Solution

Since `OpTransaction` provides all the needed functionality for the conversion, replace the `OpTxEnvelope` type with a generic type.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
