### PR TITLE
Fix: Correct typos in comments

### DIFF
--- a/crates/rpc-types-engine/src/envelope.rs
+++ b/crates/rpc-types-engine/src/envelope.rs
@@ -440,7 +440,7 @@ pub enum PayloadEnvelopeEncodeError {
     /// Wrong versions of the payload.
     #[error("Wrong version of the payload")]
     WrongVersion,
-    /// An error occured during snap encoding.
+    /// An error occurred during snap encoding.
     #[error(transparent)]
     #[cfg(feature = "std")]
     SnapEncoding(#[from] snap::Error),

--- a/crates/rpc-types-engine/src/superchain.rs
+++ b/crates/rpc-types-engine/src/superchain.rs
@@ -90,7 +90,7 @@ impl ProtocolVersion {
 
         match self {
             Self::V0(value) => {
-                bytes[0] = 0x00; // this is not necessary, but addded for clarity
+                bytes[0] = 0x00; // this is not necessary, but added for clarity
                 bytes[1..].copy_from_slice(&value.encode());
                 B256::from_slice(&bytes)
             }


### PR DESCRIPTION


### **Description:**

This pull request addresses minor typographical errors in the codebase comments.

- Corrected `occured` to `occurred` in `crates/rpc-types-engine/src/envelope.rs`.
- Updated a comment for clarity in `crates/rpc-types-engine/src/superchain.rs`.