### PR TITLE
docs: fix typo in payload comment

### DIFF
--- a/crates/rpc-types-engine/src/payload/mod.rs
+++ b/crates/rpc-types-engine/src/payload/mod.rs
@@ -500,7 +500,7 @@ impl OpExecutionPayload {
 
     /// Tries to create a new unsealed block from the given payload and payload sidecar.
     ///
-    /// Additional to checks preformed in [`OpExecutionPayload::try_into_block`], which is called
+    /// Additional to checks performed in [`OpExecutionPayload::try_into_block`], which is called
     /// under the hood, also checks that sidecar doesn't contain:
     /// - blob versioned hashes
     /// - execution layer requests


### PR DESCRIPTION
### **Description:**

```markdown
A small typo was corrected in a comment within the `OpExecutionPayload` implementation. This improves the clarity of the documentation.

- **File:** `crates/rpc-types-engine/src/payload/mod.rs`
- **Change:** "preformed" -> "performed"
```







