### PR TITLE
feat(rpc): Add `OpTransactionRequest` and associate it with `TransactionRequest` of `Optimism`

### DIFF
--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -8,10 +8,11 @@
 
 pub use alloy_network::*;
 
-use alloy_consensus::{EthereumTypedTransaction, TxEnvelope, TxType, TypedTransaction};
+use alloy_consensus::{TxEnvelope, TxType, TypedTransaction};
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
-use alloy_rpc_types_eth::{AccessList, TransactionInputKind, TransactionRequest};
-use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, OpTxEnvelope, OpTxType, OpTypedTransaction};
+use alloy_rpc_types_eth::AccessList;
+use op_alloy_consensus::{OpTxEnvelope, OpTxType, OpTypedTransaction};
+use op_alloy_rpc_types::OpTransactionRequest;
 
 /// Types for an Op-stack network.
 #[derive(Clone, Copy, Debug)]
@@ -30,7 +31,7 @@ impl Network for Optimism {
 
     type Header = alloy_consensus::Header;
 
-    type TransactionRequest = alloy_rpc_types_eth::TransactionRequest;
+    type TransactionRequest = op_alloy_rpc_types::OpTransactionRequest;
 
     type TransactionResponse = op_alloy_rpc_types::Transaction;
 
@@ -42,161 +43,120 @@ impl Network for Optimism {
         alloy_rpc_types_eth::Block<Self::TransactionResponse, Self::HeaderResponse>;
 }
 
-impl TransactionBuilder<Optimism> for TransactionRequest {
+impl TransactionBuilder<Optimism> for OpTransactionRequest {
     fn chain_id(&self) -> Option<ChainId> {
-        self.chain_id
+        self.as_ref().chain_id()
     }
 
     fn set_chain_id(&mut self, chain_id: ChainId) {
-        self.chain_id = Some(chain_id);
+        self.as_mut().set_chain_id(chain_id);
     }
 
     fn nonce(&self) -> Option<u64> {
-        self.nonce
+        self.as_ref().nonce()
     }
 
     fn set_nonce(&mut self, nonce: u64) {
-        self.nonce = Some(nonce);
+        self.as_mut().set_nonce(nonce);
     }
 
     fn input(&self) -> Option<&Bytes> {
-        self.input.input()
+        self.as_ref().input()
     }
 
     fn set_input<T: Into<Bytes>>(&mut self, input: T) {
-        self.input.input = Some(input.into());
-    }
-
-    fn set_input_kind<T: Into<Bytes>>(&mut self, input: T, kind: TransactionInputKind) {
-        match kind {
-            TransactionInputKind::Input => self.input.input = Some(input.into()),
-            TransactionInputKind::Data => self.input.data = Some(input.into()),
-            TransactionInputKind::Both => {
-                let bytes = input.into();
-                self.input.input = Some(bytes.clone());
-                self.input.data = Some(bytes);
-            }
-        }
+        self.as_mut().set_input(input);
     }
 
     fn from(&self) -> Option<Address> {
-        self.from
+        self.as_ref().from()
     }
 
     fn set_from(&mut self, from: Address) {
-        self.from = Some(from);
+        self.as_mut().set_from(from);
     }
 
     fn kind(&self) -> Option<TxKind> {
-        self.to
+        self.as_ref().kind()
     }
 
     fn clear_kind(&mut self) {
-        self.to = None;
+        self.as_mut().clear_kind();
     }
 
     fn set_kind(&mut self, kind: TxKind) {
-        self.to = Some(kind);
+        self.as_mut().set_kind(kind);
     }
 
     fn value(&self) -> Option<U256> {
-        self.value
+        self.as_ref().value()
     }
 
     fn set_value(&mut self, value: U256) {
-        self.value = Some(value);
+        self.as_mut().set_value(value);
     }
 
     fn gas_price(&self) -> Option<u128> {
-        self.gas_price
+        self.as_ref().gas_price()
     }
 
     fn set_gas_price(&mut self, gas_price: u128) {
-        self.gas_price = Some(gas_price);
+        self.as_mut().set_gas_price(gas_price);
     }
 
     fn max_fee_per_gas(&self) -> Option<u128> {
-        self.max_fee_per_gas
+        self.as_ref().max_fee_per_gas()
     }
 
     fn set_max_fee_per_gas(&mut self, max_fee_per_gas: u128) {
-        self.max_fee_per_gas = Some(max_fee_per_gas);
+        self.as_mut().set_max_fee_per_gas(max_fee_per_gas);
     }
 
     fn max_priority_fee_per_gas(&self) -> Option<u128> {
-        self.max_priority_fee_per_gas
+        self.as_ref().max_priority_fee_per_gas()
     }
 
     fn set_max_priority_fee_per_gas(&mut self, max_priority_fee_per_gas: u128) {
-        self.max_priority_fee_per_gas = Some(max_priority_fee_per_gas);
+        self.as_mut().set_max_priority_fee_per_gas(max_priority_fee_per_gas);
     }
 
     fn gas_limit(&self) -> Option<u64> {
-        self.gas
+        self.as_ref().gas_limit()
     }
 
     fn set_gas_limit(&mut self, gas_limit: u64) {
-        self.gas = Some(gas_limit);
+        self.as_mut().set_gas_limit(gas_limit);
     }
 
     fn access_list(&self) -> Option<&AccessList> {
-        self.access_list.as_ref()
+        self.as_ref().access_list()
     }
 
     fn set_access_list(&mut self, access_list: AccessList) {
-        self.access_list = Some(access_list);
+        self.as_mut().set_access_list(access_list);
     }
 
     fn complete_type(&self, ty: OpTxType) -> Result<(), Vec<&'static str>> {
         match ty {
             OpTxType::Deposit => Err(vec!["not implemented for deposit tx"]),
-            OpTxType::Legacy => self.complete_legacy(),
-            OpTxType::Eip2930 => self.complete_2930(),
-            OpTxType::Eip1559 => self.complete_1559(),
-            OpTxType::Eip7702 => self.complete_7702(),
+            _ => {
+                let ty = TxType::try_from(ty as u8).unwrap();
+                self.as_ref().complete_type(ty)
+            }
         }
     }
 
     fn can_submit(&self) -> bool {
-        // value and data may be None. If they are, they will be set to default.
-        // gas fields and nonce may be None, if they are, they will be populated
-        // with default values by the RPC server
-        self.from.is_some()
+        self.as_ref().can_submit()
     }
 
     fn can_build(&self) -> bool {
-        // cannot build 4844 txs
-        if self.sidecar.is_some() || self.blob_versioned_hashes.is_some() {
-            return false;
-        }
-
-        // value and data may be none. If they are, they will be set to default
-        // values.
-
-        // chain_id and from may be none.
-        let common = self.gas.is_some() && self.nonce.is_some();
-
-        let legacy = self.gas_price.is_some();
-        let eip2930 = legacy && self.access_list.is_some();
-
-        let eip1559 = self.max_fee_per_gas.is_some() && self.max_priority_fee_per_gas.is_some();
-
-        let eip7702 = eip1559 && self.authorization_list().is_some();
-
-        // required deposit fields
-        let deposit = self.value.is_some()
-            && self.from.is_some()
-            && self.to.is_some()
-            && self.input.input().is_some();
-        common && (legacy || eip2930 || eip1559 || eip7702 || deposit)
+        self.as_ref().can_build()
     }
 
     #[doc(alias = "output_transaction_type")]
     fn output_tx_type(&self) -> OpTxType {
-        if self.transaction_type.is_some_and(|ty| ty == DEPOSIT_TX_TYPE_ID) {
-            return OpTxType::Deposit;
-        }
-        match self.preferred_type() {
+        match self.as_ref().preferred_type() {
             TxType::Eip1559 | TxType::Eip4844 => OpTxType::Eip1559,
             TxType::Eip2930 => OpTxType::Eip2930,
             TxType::Eip7702 => OpTxType::Eip7702,
@@ -206,19 +166,7 @@ impl TransactionBuilder<Optimism> for TransactionRequest {
 
     #[doc(alias = "output_transaction_type_checked")]
     fn output_tx_type_checked(&self) -> Option<OpTxType> {
-        if self.transaction_type.is_some_and(|ty| ty == DEPOSIT_TX_TYPE_ID) {
-            // Check deposit fields
-            if self.value.is_some()
-                && self.from.is_some()
-                && self.to.is_some()
-                && self.input.input().is_some()
-                && (self.complete_legacy().is_ok() || self.complete_1559().is_ok())
-            {
-                return Some(OpTxType::Deposit);
-            }
-            return None;
-        }
-        self.buildable_type().map(|tx_ty| match tx_ty {
+        self.as_ref().buildable_type().map(|tx_ty| match tx_ty {
             TxType::Eip1559 | TxType::Eip4844 => OpTxType::Eip1559,
             TxType::Eip2930 => OpTxType::Eip2930,
             TxType::Eip7702 => OpTxType::Eip7702,
@@ -227,51 +175,16 @@ impl TransactionBuilder<Optimism> for TransactionRequest {
     }
 
     fn prep_for_submission(&mut self) {
-        self.transaction_type = Some(self.preferred_type() as u8);
-        self.trim_conflicting_keys();
+        self.as_mut().prep_for_submission();
     }
 
     fn build_unsigned(self) -> BuildResult<OpTypedTransaction, Optimism> {
-        if self.preferred_type() == TxType::Eip4844 {
-            return Err(TransactionBuilderError::Custom(
-                "EIP-4844 transactions are not supported".to_string().into(),
-            )
-            .into_unbuilt(self));
-        }
-
-        if let Err((tx_type, missing)) = self.missing_keys() {
-            let tx_type = OpTxType::try_from(tx_type as u8).map_err(|e| {
-                TransactionBuilderError::Custom(e.into()).into_unbuilt(self.clone())
-            })?;
-
+        if let Err((tx_type, missing)) = self.as_ref().missing_keys() {
+            let tx_type = OpTxType::try_from(tx_type as u8).unwrap();
             return Err(TransactionBuilderError::InvalidTransactionRequest(tx_type, missing)
                 .into_unbuilt(self));
         }
-
-        let eth_typed = self.build_typed_tx().expect("checked by missing_keys");
-
-        match eth_typed {
-            EthereumTypedTransaction::Legacy(tx) => {
-                let tx = OpTypedTransaction::Legacy(tx);
-                Ok(tx)
-            }
-            EthereumTypedTransaction::Eip2930(tx) => {
-                let tx = OpTypedTransaction::Eip2930(tx);
-                Ok(tx)
-            }
-            EthereumTypedTransaction::Eip1559(tx) => {
-                let tx = OpTypedTransaction::Eip1559(tx);
-                Ok(tx)
-            }
-
-            EthereumTypedTransaction::Eip7702(tx) => {
-                let tx = OpTypedTransaction::Eip7702(tx);
-                Ok(tx)
-            }
-            EthereumTypedTransaction::Eip4844(_) => {
-                unreachable!("EIP-4844 transactions are not supported")
-            }
-        }
+        Ok(self.build_typed_tx().expect("checked by missing_keys"))
     }
 
     async fn build<W: NetworkWallet<Optimism>>(

--- a/crates/rpc-types/src/lib.rs
+++ b/crates/rpc-types/src/lib.rs
@@ -16,7 +16,7 @@ mod receipt;
 pub use receipt::{L1BlockInfo, OpTransactionReceipt, OpTransactionReceiptFields};
 
 mod transaction;
-pub use transaction::{OpTransactionFields, Transaction};
+pub use transaction::{OpTransactionFields, OpTransactionRequest, Transaction};
 
 pub mod error;
 pub use error::SuperchainDAError;

--- a/crates/rpc-types/src/transaction.rs
+++ b/crates/rpc-types/src/transaction.rs
@@ -7,6 +7,9 @@ use alloy_serde::OtherFields;
 use op_alloy_consensus::{OpTransaction, OpTxEnvelope, transaction::OpTransactionInfo};
 use serde::{Deserialize, Serialize};
 
+mod request;
+pub use request::OpTransactionRequest;
+
 /// OP Transaction type
 #[derive(
     Clone, Debug, PartialEq, Eq, Serialize, Deserialize, derive_more::Deref, derive_more::DerefMut,

--- a/crates/rpc-types/src/transaction/request.rs
+++ b/crates/rpc-types/src/transaction/request.rs
@@ -1,0 +1,208 @@
+use alloc::vec::Vec;
+use alloy_consensus::{
+    Sealed, SignableTransaction, Signed, TxEip1559, TxEip4844, TypedTransaction,
+};
+use alloy_eips::eip7702::SignedAuthorization;
+use alloy_network_primitives::TransactionBuilder7702;
+use alloy_primitives::{Address, Signature, TxKind, U256};
+use alloy_rpc_types_eth::{AccessList, TransactionInput, TransactionRequest};
+use op_alloy_consensus::{OpTxEnvelope, OpTypedTransaction, TxDeposit};
+use serde::{Deserialize, Serialize};
+
+/// Builder for [`OpTypedTransaction`].
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    derive_more::From,
+    derive_more::AsRef,
+    derive_more::AsMut,
+    Serialize,
+    Deserialize,
+)]
+#[serde(transparent)]
+pub struct OpTransactionRequest(TransactionRequest);
+
+impl OpTransactionRequest {
+    /// Sets the `from` field in the call to the provided address
+    #[inline]
+    pub const fn from(mut self, from: Address) -> Self {
+        self.0.from = Some(from);
+        self
+    }
+
+    /// Sets the transactions type for the transactions.
+    #[doc(alias = "tx_type")]
+    pub const fn transaction_type(mut self, transaction_type: u8) -> Self {
+        self.0.transaction_type = Some(transaction_type);
+        self
+    }
+
+    /// Sets the gas limit for the transaction.
+    pub const fn gas_limit(mut self, gas_limit: u64) -> Self {
+        self.0.gas = Some(gas_limit);
+        self
+    }
+
+    /// Sets the nonce for the transaction.
+    pub const fn nonce(mut self, nonce: u64) -> Self {
+        self.0.nonce = Some(nonce);
+        self
+    }
+
+    /// Sets the maximum fee per gas for the transaction.
+    pub const fn max_fee_per_gas(mut self, max_fee_per_gas: u128) -> Self {
+        self.0.max_fee_per_gas = Some(max_fee_per_gas);
+        self
+    }
+
+    /// Sets the maximum priority fee per gas for the transaction.
+    pub const fn max_priority_fee_per_gas(mut self, max_priority_fee_per_gas: u128) -> Self {
+        self.0.max_priority_fee_per_gas = Some(max_priority_fee_per_gas);
+        self
+    }
+
+    /// Sets the recipient address for the transaction.
+    #[inline]
+    pub const fn to(mut self, to: Address) -> Self {
+        self.0.to = Some(TxKind::Call(to));
+        self
+    }
+
+    /// Sets the value (amount) for the transaction.
+    pub const fn value(mut self, value: U256) -> Self {
+        self.0.value = Some(value);
+        self
+    }
+
+    /// Sets the access list for the transaction.
+    pub fn access_list(mut self, access_list: AccessList) -> Self {
+        self.0.access_list = Some(access_list);
+        self
+    }
+
+    /// Sets the input data for the transaction.
+    pub fn input(mut self, input: TransactionInput) -> Self {
+        self.0.input = input;
+        self
+    }
+
+    /// Builds [`OpTypedTransaction`] from this builder. See [`TransactionRequest::build_typed_tx`]
+    /// for more info.
+    ///
+    /// Note that EIP-4844 transactions are not supported by Optimism and will be converted into
+    /// EIP-1559 transactions.
+    pub fn build_typed_tx(self) -> Result<OpTypedTransaction, Self> {
+        let tx = self.0.build_typed_tx().map_err(Self)?;
+        match tx {
+            TypedTransaction::Legacy(tx) => Ok(OpTypedTransaction::Legacy(tx)),
+            TypedTransaction::Eip1559(tx) => Ok(OpTypedTransaction::Eip1559(tx)),
+            TypedTransaction::Eip2930(tx) => Ok(OpTypedTransaction::Eip2930(tx)),
+            TypedTransaction::Eip4844(tx) => {
+                let tx: TxEip4844 = tx.into();
+                Ok(OpTypedTransaction::Eip1559(TxEip1559 {
+                    chain_id: tx.chain_id,
+                    nonce: tx.nonce,
+                    gas_limit: tx.gas_limit,
+                    max_priority_fee_per_gas: tx.max_priority_fee_per_gas,
+                    max_fee_per_gas: tx.max_fee_per_gas,
+                    to: TxKind::Call(tx.to),
+                    value: tx.value,
+                    access_list: tx.access_list,
+                    input: tx.input,
+                }))
+            }
+            TypedTransaction::Eip7702(tx) => Ok(OpTypedTransaction::Eip7702(tx)),
+        }
+    }
+}
+
+impl From<OpTransactionRequest> for TransactionRequest {
+    fn from(value: OpTransactionRequest) -> Self {
+        value.0
+    }
+}
+
+impl From<TxDeposit> for OpTransactionRequest {
+    fn from(tx: TxDeposit) -> Self {
+        let TxDeposit {
+            source_hash: _,
+            from,
+            to,
+            mint: _,
+            value,
+            gas_limit,
+            is_system_transaction: _,
+            input,
+        } = tx;
+
+        Self(TransactionRequest {
+            from: Some(from),
+            to: Some(to),
+            value: Some(value),
+            gas: Some(gas_limit),
+            input: input.into(),
+            ..Default::default()
+        })
+    }
+}
+
+impl From<Sealed<TxDeposit>> for OpTransactionRequest {
+    fn from(value: Sealed<TxDeposit>) -> Self {
+        value.into_inner().into()
+    }
+}
+
+impl<T> From<Signed<T, Signature>> for OpTransactionRequest
+where
+    T: SignableTransaction<Signature> + Into<TransactionRequest>,
+{
+    fn from(value: Signed<T, Signature>) -> Self {
+        #[cfg(feature = "k256")]
+        let from = value.recover_signer().ok();
+        #[cfg(not(feature = "k256"))]
+        let from = None;
+
+        let mut inner: TransactionRequest = value.strip_signature().into();
+        inner.from = from;
+
+        Self(inner)
+    }
+}
+
+impl From<OpTypedTransaction> for OpTransactionRequest {
+    fn from(tx: OpTypedTransaction) -> Self {
+        match tx {
+            OpTypedTransaction::Legacy(tx) => Self(tx.into()),
+            OpTypedTransaction::Eip2930(tx) => Self(tx.into()),
+            OpTypedTransaction::Eip1559(tx) => Self(tx.into()),
+            OpTypedTransaction::Eip7702(tx) => Self(tx.into()),
+            OpTypedTransaction::Deposit(tx) => tx.into(),
+        }
+    }
+}
+
+impl From<OpTxEnvelope> for OpTransactionRequest {
+    fn from(value: OpTxEnvelope) -> Self {
+        match value {
+            OpTxEnvelope::Eip2930(tx) => tx.into(),
+            OpTxEnvelope::Eip1559(tx) => tx.into(),
+            OpTxEnvelope::Eip7702(tx) => tx.into(),
+            OpTxEnvelope::Deposit(tx) => tx.into(),
+            _ => Default::default(),
+        }
+    }
+}
+
+impl TransactionBuilder7702 for OpTransactionRequest {
+    fn authorization_list(&self) -> Option<&Vec<SignedAuthorization>> {
+        self.as_ref().authorization_list()
+    }
+
+    fn set_authorization_list(&mut self, authorization_list: Vec<SignedAuthorization>) {
+        self.as_mut().set_authorization_list(authorization_list);
+    }
+}


### PR DESCRIPTION
## Motivation

The change #525 introduced ambiguity of `alloy_network::TransactionBuilder` implementation for `TransactionRequest`, being implemented twice once for `Ethereum` and once for `Optimism`. This then requires fully qualified syntax to differentiate.

## Solution

Bring back `OpTransactionRequest`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
