### PR TITLE
deps: Upgrade `alloy` version `1.0.12` => `1.0.14`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,17 +45,17 @@ op-alloy-rpc-types-engine = { version = "0.18.7", path = "crates/rpc-types-engin
 op-alloy-rpc-jsonrpsee = { version = "0.18.7", path = "crates/rpc-jsonrpsee", default-features = false }
 
 # Alloy
-alloy-eips = { version = "1.0.12", default-features = false }
-alloy-serde = { version = "1.0.12", default-features = false }
-alloy-signer = { version = "1.0.12", default-features = false }
-alloy-network = { version = "1.0.12", default-features = false }
-alloy-provider = { version = "1.0.12", default-features = false }
-alloy-transport = { version = "1.0.12", default-features = false }
-alloy-consensus = { version = "1.0.12", default-features = false }
-alloy-rpc-types-eth = { version = "1.0.12", default-features = false }
-alloy-rpc-types-engine = { version = "1.0.12", default-features = false }
-alloy-network-primitives = { version = "1.0.12", default-features = false }
-alloy-json-rpc = { version = "1.0.12", default-features = false }
+alloy-eips = { version = "1.0.14", default-features = false }
+alloy-serde = { version = "1.0.14", default-features = false }
+alloy-signer = { version = "1.0.14", default-features = false }
+alloy-network = { version = "1.0.14", default-features = false }
+alloy-provider = { version = "1.0.14", default-features = false }
+alloy-transport = { version = "1.0.14", default-features = false }
+alloy-consensus = { version = "1.0.14", default-features = false }
+alloy-rpc-types-eth = { version = "1.0.14", default-features = false }
+alloy-rpc-types-engine = { version = "1.0.14", default-features = false }
+alloy-network-primitives = { version = "1.0.14", default-features = false }
+alloy-json-rpc = { version = "1.0.14", default-features = false }
 
 # Alloy RLP
 alloy-rlp = { version = "0.3", default-features = false }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -60,6 +60,10 @@ impl TransactionBuilder<Optimism> for OpTransactionRequest {
         self.as_mut().set_nonce(nonce);
     }
 
+    fn take_nonce(&mut self) -> Option<u64> {
+        self.as_mut().nonce.take()
+    }
+
     fn input(&self) -> Option<&Bytes> {
         self.as_ref().input()
     }


### PR DESCRIPTION
## Motivation

Latest `alloy` release `1.0.14` has breaking changes.

## Solution

Update all implementations to comply with the latest release.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
