### PR TITLE
Update broken OpAttributesWithParent docs.rs link to crate root in engine.md

### DIFF
--- a/book/src/building/engine.md
+++ b/book/src/building/engine.md
@@ -22,4 +22,4 @@ from [`alloy-rpc-types-engine`][alloy-engine].
 [v4]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/payload/v4/struct.OpExecutionPayloadEnvelopeV4.html
 [pa]: https://docs.rs/alloy-rpc-types-engine/latest/alloy_rpc_types_engine/payload/struct.PayloadAttributes.html
 [attributes]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/struct.OpPayloadAttributes.html
-[engine]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/struct.OpAttributesWithParent.html
+[engine]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/


### PR DESCRIPTION
The previous link for [engine] in book/src/building/engine.md pointed to the documentation page for OpAttributesWithParent in the op-alloy-rpc-types-engine crate. However, this struct no longer exists in the latest published documentation, resulting in a 404 error.
To avoid broken links and ensure users are directed to relevant and up-to-date documentation, the link was updated to the root documentation page for the op-alloy-rpc-types-engine crate on docs.rs. This approach ensures that users can always access the latest available types and modules, even if specific items are renamed, moved, or removed in future versions. If a more specific and stable documentation page becomes available in the future, the link can be updated accordingly.