### PR TITLE
fix(rpc-types-engine): Fix `OpExecutionPayloadEnvelope::payload_hash`

### DIFF
--- a/crates/rpc-types-engine/src/envelope.rs
+++ b/crates/rpc-types-engine/src/envelope.rs
@@ -25,11 +25,13 @@ pub struct OpExecutionPayloadEnvelope {
 
 impl OpExecutionPayloadEnvelope {
     /// Returns the payload hash over the ssz encoded payload envelope data.
+    ///
+    /// <https://specs.optimism.io/protocol/rollup-node-p2p.html#block-signatures>
     #[cfg(feature = "std")]
     pub fn payload_hash(&self) -> crate::PayloadHash {
         use ssz::Encode;
         let ssz_bytes = self.as_ssz_bytes();
-        crate::PayloadHash::from(&ssz_bytes.as_slice()[65..])
+        crate::PayloadHash::from(ssz_bytes.as_slice())
     }
 }
 


### PR DESCRIPTION
## Overview

Fixes the `OpExecutionPayloadEnvelope::payload_hash` function to be in-line with the [spec](https://specs.optimism.io/protocol/rollup-node-p2p.html#block-signatures).