### PR TITLE
patch(rpc-types-engine/ssz): fix ssz encoding for blocks of v1 and v2

### DIFF
--- a/crates/rpc-types-engine/src/envelope.rs
+++ b/crates/rpc-types-engine/src/envelope.rs
@@ -45,10 +45,7 @@ impl ssz::Encode for OpExecutionPayloadEnvelope {
         // Write parent beacon block root only if the payload is not a v1 or v2 payload.
         // <https://specs.optimism.io/protocol/rollup-node-p2p.html#block-encoding>
         if !matches!(self.payload, OpExecutionPayload::V1(_) | OpExecutionPayload::V2(_)) {
-            match &self.parent_beacon_block_root {
-                Some(root) => buf.extend_from_slice(root.as_slice()),
-                None => buf.extend_from_slice(&[0u8; 32]),
-            }
+            buf.extend_from_slice(self.parent_beacon_block_root.unwrap_or_default().as_slice());
         }
 
         // Write payload


### PR DESCRIPTION
## Description

Patches the ssz encoding of v1 and v2 payloads to match the spec (https://specs.optimism.io/protocol/rollup-node-p2p.html#block-encoding)