### PR TITLE
Bump jsonrpsee dependencies to version 0.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,14 +79,14 @@ ethereum_ssz = "0.9"
 ethereum_ssz_derive = "0.9"
 
 # rpc
-jsonrpsee = { version = "0.25", features = [
+jsonrpsee = { version = "0.26", features = [
     "jsonrpsee-core",
     "client-core",
     "server-core",
     "macros",
 ] }
-jsonrpsee-core = "0.25"
-jsonrpsee-types = "0.25"
+jsonrpsee-core = "0.26"
+jsonrpsee-types = "0.26"
 
 # misc
 async-trait = "0.1.87"


### PR DESCRIPTION
## Motivation

Close #588.

Towards https://github.com/paradigmxyz/reth/issues/17900

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
