### PR TITLE
chore: `missing-const-for-fn` lint back to warn.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ unnameable-types = "warn"
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
-missing-const-for-fn = "allow" # TODO: https://github.com/rust-lang/rust-clippy/issues/14020
+missing-const-for-fn = "warn"
 use-self = "warn"
 option-if-let-else = "warn"
 redundant-clone = "warn"

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -314,7 +314,7 @@ impl OpTxEnvelope {
     ///
     /// Caution: modifying this will cause side-effects on the hash.
     #[doc(hidden)]
-    pub fn input_mut(&mut self) -> &mut Bytes {
+    pub const fn input_mut(&mut self) -> &mut Bytes {
         match self {
             Self::Eip1559(tx) => &mut tx.tx_mut().input,
             Self::Eip2930(tx) => &mut tx.tx_mut().input,

--- a/crates/consensus/src/transaction/meta.rs
+++ b/crates/consensus/src/transaction/meta.rs
@@ -26,7 +26,7 @@ pub struct OpTransactionInfo {
 impl OpTransactionInfo {
     /// Creates a new [`OpTransactionInfo`] with the given [`TransactionInfo`] and
     /// [`OpDepositInfo`].
-    pub fn new(inner: TransactionInfo, deposit_meta: OpDepositInfo) -> Self {
+    pub const fn new(inner: TransactionInfo, deposit_meta: OpDepositInfo) -> Self {
         Self { inner, deposit_meta }
     }
 }


### PR DESCRIPTION

## Motivation

In the same vein as https://github.com/alloy-rs/evm/pull/167

## Solution

- `missing-const-for-fn` lint set to warn.
-  Updated some funtions to `const` in order to comply with the updated lint level.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
