### PR TITLE
fix: correct `OpReceipt` rlp

### DIFF
--- a/crates/consensus/src/receipts/receipt.rs
+++ b/crates/consensus/src/receipts/receipt.rs
@@ -170,6 +170,7 @@ impl<T> OpReceipt<T> {
     where
         T: Encodable,
     {
+        self.tx_type().encode(out);
         match self {
             Self::Legacy(receipt)
             | Self::Eip2930(receipt)
@@ -344,8 +345,7 @@ impl<T: Decodable> Decodable for OpReceipt<T> {
             return Err(alloy_rlp::Error::UnexpectedString);
         }
 
-        let remaining = buf.len();
-        if remaining < header.payload_length {
+        if buf.len() < header.payload_length {
             return Err(alloy_rlp::Error::InputTooShort);
         }
         let mut fields_buf = &buf[..header.payload_length];


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Removes 2718 impl for `OpReceipt` and changes `Encodable`/`Decodable` to match https://github.com/ethereum-optimism/op-geth/blob/d092a020749f4d788501f05ed1be30320ab102b9/eth/protocols/eth/receipt.go#L206

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
