### PR TITLE
docs: add repository migration announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@
 <a href="https://github.com/alloy-rs/op-alloy/blob/main/SNAPPY-LICENSE"><img src="https://img.shields.io/badge/License-SNAPPY-d1d1f6.svg?label=license&labelColor=2a2f35" alt="License"></a>
 <a href="https://alloy-rs.github.io/op-alloy"><img src="https://img.shields.io/badge/Book-854a15?logo=mdBook&labelColor=2a2f35" alt="Book"></a>
 
-Built on [Alloy][alloy], op-alloy aggregates the OP stack's unique primitives from [Maili][maili], 
+> [!IMPORTANT]
+> **This repository is moving to [ethereum-optimism/optimism](https://github.com/ethereum-optimism/optimism).**
+>
+> The `alloy-rs/op-alloy` repository will be archived (deprecated). All future development will continue in the new location. Your GitHub contributions will be preserved.
+
+Built on [Alloy][alloy], op-alloy aggregates the OP stack's unique primitives from [Maili][maili],
 to the subset of L1 types used by Optimistic rollups.
 
 

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,8 @@ feature-depth = 1
 ignore = [
     # paste crate is no longer maintained.
     "RUSTSEC-2024-0436",
+    # bincode is unmaintained, but only used as a dev-dependency for testing.
+    "RUSTSEC-2025-0141",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary
- Add announcement to README that op-alloy is moving to ethereum-optimism/optimism
- Note that alloy-rs/op-alloy will be archived
- Confirm GitHub contributions will be preserved

Migration PR: https://github.com/ethereum-optimism/optimism/pull/18811