### PR TITLE
feat(consensus): implement InMemorySize for op types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ alloy-signer = { version = "1.1.2", default-features = false }
 alloy-network = { version = "1.1.2", default-features = false }
 alloy-provider = { version = "1.1.2", default-features = false }
 alloy-transport = { version = "1.1.2", default-features = false }
-alloy-consensus = { version = "1.1.2", default-features = false }
+alloy-consensus = { version = "1.6.2", default-features = false }
 alloy-rpc-types-eth = { version = "1.1.2", default-features = false }
 alloy-rpc-types-engine = { version = "1.1.2", default-features = false }
 alloy-network-primitives = { version = "1.1.2", default-features = false }

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -32,6 +32,8 @@ pub use eip1559::{
 mod source;
 pub use source::*;
 
+mod size;
+
 mod block;
 pub use block::OpBlock;
 

--- a/crates/consensus/src/size.rs
+++ b/crates/consensus/src/size.rs
@@ -15,7 +15,7 @@ impl InMemorySize for OpTxType {
 impl InMemorySize for TxDeposit {
     #[inline]
     fn size(&self) -> usize {
-        TxDeposit::size(self)
+        Self::size(self)
     }
 }
 

--- a/crates/consensus/src/size.rs
+++ b/crates/consensus/src/size.rs
@@ -1,0 +1,75 @@
+use alloy_consensus::InMemorySize;
+
+use crate::{
+    OpDepositReceipt, OpPooledTransaction, OpReceipt, OpTxEnvelope, OpTxType, OpTypedTransaction,
+    TxDeposit,
+};
+
+impl InMemorySize for OpTxType {
+    #[inline]
+    fn size(&self) -> usize {
+        core::mem::size_of::<Self>()
+    }
+}
+
+impl InMemorySize for TxDeposit {
+    #[inline]
+    fn size(&self) -> usize {
+        TxDeposit::size(self)
+    }
+}
+
+impl InMemorySize for OpDepositReceipt {
+    fn size(&self) -> usize {
+        self.inner.size()
+            + core::mem::size_of_val(&self.deposit_nonce)
+            + core::mem::size_of_val(&self.deposit_receipt_version)
+    }
+}
+
+impl InMemorySize for OpReceipt {
+    fn size(&self) -> usize {
+        match self {
+            Self::Legacy(receipt)
+            | Self::Eip2930(receipt)
+            | Self::Eip1559(receipt)
+            | Self::Eip7702(receipt) => receipt.size(),
+            Self::Deposit(receipt) => receipt.size(),
+        }
+    }
+}
+
+impl InMemorySize for OpTypedTransaction {
+    fn size(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.size(),
+            Self::Eip2930(tx) => tx.size(),
+            Self::Eip1559(tx) => tx.size(),
+            Self::Eip7702(tx) => tx.size(),
+            Self::Deposit(tx) => tx.size(),
+        }
+    }
+}
+
+impl InMemorySize for OpPooledTransaction {
+    fn size(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.size(),
+            Self::Eip2930(tx) => tx.size(),
+            Self::Eip1559(tx) => tx.size(),
+            Self::Eip7702(tx) => tx.size(),
+        }
+    }
+}
+
+impl InMemorySize for OpTxEnvelope {
+    fn size(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.size(),
+            Self::Eip2930(tx) => tx.size(),
+            Self::Eip1559(tx) => tx.size(),
+            Self::Eip7702(tx) => tx.size(),
+            Self::Deposit(tx) => tx.size(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implement `alloy_consensus::InMemorySize` trait for op consensus types.

## Motivation
Part of a multi-repo effort to move the `InMemorySize` trait from reth into alloy (done in [alloy#3656](https://github.com/alloy-rs/alloy/pull/3656)). With the trait now in alloy-consensus, reth can re-export it instead of defining it locally. However, due to the orphan rule, the op type impls must live in op-alloy.

## Changes
- Bump `alloy-consensus` minimum to 1.6.2 (which includes `InMemorySize`)
- Add `InMemorySize` impls for: `OpTxType`, `TxDeposit`, `OpDepositReceipt`, `OpReceipt`, `OpTypedTransaction`, `OpPooledTransaction`, `OpTxEnvelope`

## Testing
```
cargo check -p op-alloy-consensus --all-features
cargo test -p op-alloy-consensus
```

Prompted by: mattsse