### PR TITLE
fix: resolve `NetworkWallet<Optimism>` conflict with alloy 1.8

### DIFF
--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -25,7 +25,6 @@ alloy-network.workspace = true
 alloy-primitives.workspace = true
 alloy-provider.workspace = true
 alloy-rpc-types-eth.workspace = true
-alloy-signer.workspace = true
 
 [features]
 std = ["op-alloy-consensus/std", "op-alloy-rpc-types/std"]

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -8,10 +8,10 @@
 
 pub use alloy_network::*;
 
-use alloy_consensus::{ReceiptWithBloom, TxEnvelope, TxType, TypedTransaction};
+use alloy_consensus::{ReceiptWithBloom, TxType};
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_rpc_types_eth::AccessList;
-use op_alloy_consensus::{OpReceipt, OpTxEnvelope, OpTxType, OpTypedTransaction};
+use op_alloy_consensus::{OpReceipt, OpTxType, OpTypedTransaction};
 use op_alloy_rpc_types::OpTransactionRequest;
 
 /// Types for an Op-stack network.
@@ -196,45 +196,6 @@ impl TransactionBuilder<Optimism> for OpTransactionRequest {
         wallet: &W,
     ) -> Result<<Optimism as Network>::TxEnvelope, TransactionBuilderError<Optimism>> {
         Ok(wallet.sign_request(self).await?)
-    }
-}
-
-impl NetworkWallet<Optimism> for EthereumWallet {
-    fn default_signer_address(&self) -> Address {
-        NetworkWallet::<Ethereum>::default_signer_address(self)
-    }
-
-    fn has_signer_for(&self, address: &Address) -> bool {
-        NetworkWallet::<Ethereum>::has_signer_for(self, address)
-    }
-
-    fn signer_addresses(&self) -> impl Iterator<Item = Address> {
-        NetworkWallet::<Ethereum>::signer_addresses(self)
-    }
-
-    async fn sign_transaction_from(
-        &self,
-        sender: Address,
-        tx: OpTypedTransaction,
-    ) -> alloy_signer::Result<OpTxEnvelope> {
-        let tx = match tx {
-            OpTypedTransaction::Legacy(tx) => TypedTransaction::Legacy(tx),
-            OpTypedTransaction::Eip2930(tx) => TypedTransaction::Eip2930(tx),
-            OpTypedTransaction::Eip1559(tx) => TypedTransaction::Eip1559(tx),
-            OpTypedTransaction::Eip7702(tx) => TypedTransaction::Eip7702(tx),
-            OpTypedTransaction::Deposit(_) => {
-                return Err(alloy_signer::Error::other("not implemented for deposit tx"));
-            }
-        };
-        let tx = NetworkWallet::<Ethereum>::sign_transaction_from(self, sender, tx).await?;
-
-        Ok(match tx {
-            TxEnvelope::Eip1559(tx) => OpTxEnvelope::Eip1559(tx),
-            TxEnvelope::Eip2930(tx) => OpTxEnvelope::Eip2930(tx),
-            TxEnvelope::Eip7702(tx) => OpTxEnvelope::Eip7702(tx),
-            TxEnvelope::Legacy(tx) => OpTxEnvelope::Legacy(tx),
-            _ => unreachable!(),
-        })
     }
 }
 


### PR DESCRIPTION
## Summary

- Remove the manual `NetworkWallet<Optimism>` impl for `EthereumWallet` that conflicts with alloy 1.8's blanket `impl<N: Network> NetworkWallet<N> for EthereumWallet`
- Remove the now-unused `alloy-signer` dependency from `op-alloy-network`

The blanket impl covers Optimism because `op-alloy-consensus` already provides the required bounds (`OpTypedTransaction: SignableTransaction<Signature>` and `OpTxEnvelope: From<Signed<OpTypedTransaction>>`).

Closes #627